### PR TITLE
Add simple travis-ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python: 3.5
+
+install: python3 -m pip install sphinx
+
+script:
+    # TODO: add -b linkcheck
+    - sphinx-build -n -W -q -b html -d _build/doctrees . _build/html

--- a/buildslave.rst
+++ b/buildslave.rst
@@ -88,7 +88,7 @@ For Windows:
     * Install the latest version of Python 2.7 from python.org.
     * Open a Command Prompt.
     * Execute ``python -m pip install pypiwin32 buildbot-slave`` (note that
-      ``python.exe`` is not added to :envvar:`PATH` by default, making the
+      ``python.exe`` is not added to ``PATH`` by default, making the
       ``python`` command accessible is left as an exercise for the user).
 
 In a terminal window for the buildbot user, issue the following commands (you

--- a/coverage.rst
+++ b/coverage.rst
@@ -192,7 +192,7 @@ Using test.regrtest
 -------------------
 
 If you prefer to rely solely on the stdlib to generate coverage data, you can
-do so by passing the appropriate flags to :py:mod:`test.regrtest` (along with
+do so by passing the appropriate flags to ``test.regrtest`` (along with
 any other flags you want to)::
 
     ./python -m test --coverage -D `pwd`/coverage_data <test arguments>

--- a/documenting.rst
+++ b/documenting.rst
@@ -218,11 +218,11 @@ grasp a simple example more quickly than they can digest a formal description in
 prose.
 
 People learn faster with concrete, motivating examples that match the context of
-a typical use case.  For instance, the :func:`str.rpartition` method is better
+a typical use case.  For instance, the ``str.rpartition`` method is better
 demonstrated with an example splitting the domain from a URL than it would be
 with an example of removing the last word from a line of Monty Python dialog.
 
-The ellipsis for the :attr:`sys.ps2` secondary interpreter prompt should only be
+The ellipsis for the ``sys.ps2`` secondary interpreter prompt should only be
 used sparingly, where it is necessary to clearly differentiate between input
 lines and output lines.  Besides contributing visual clutter, it makes it
 difficult for readers to cut-and-paste examples so they can experiment with


### PR DESCRIPTION
This adds a simple travis file that builds the docs, failing if warnings occur. There were a few broken references causing errors, so they were also removed. Closes #3.