### PR TITLE
Remove Mercurial #52

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -24,13 +24,18 @@ Getting Set Up
 Version Control Setup
 ---------------------
 
-CPython is developed using `Mercurial <http://hg-scm.org/>`_. The Mercurial
-command line program is named ``hg``; this is also used to refer to Mercurial
-itself. Mercurial is easily available for common Unix systems by way of the
-standard package manager; under Windows, you might want to use the
-`TortoiseHg <http://tortoisehg.org/>`_ graphical client, but the build system
-still prefers :file:`hg.exe` to be on your PATH.
+CPython is developed using `git <https://git-scm.com>`_. The git
+command line program is named ``git``; this is also used to refer to git
+itself. git is easily available for all common operating systems. As the
+CPython repo is hosted on GitHub, please refer to either the
+`GitHub setup instructions <https://help.github.com/articles/set-up-git/>`_
+or the `git project instructions <https://git-scm.com>`_ for step-by-step
+installation directions.
 
+You may also wish to set up an SSH key as
+described in the GitHub instructions as this will allow you to interact with
+GitHub without typing a username and password each time you execute a
+command, such as `git pull`, `git push`, or `git fetch`.
 
 .. _checkout:
 
@@ -49,13 +54,13 @@ To get a working copy of the :ref:`in-development <indevbranch>` branch of
 CPython (core developers use a different URL as outlined in :ref:`coredev`),
 run::
 
-    hg clone https://hg.python.org/cpython
+    git clone https://github.com/python/cpython
 
 If you want a working copy of an already-released version of Python,
-i.e., a version in :ref:`maintenance mode <maintbranch>`, you can update your
-working copy. For instance, to update your working copy to Python 3.5, do::
+i.e., a version in :ref:`maintenance mode <maintbranch>`, you can checkout
+a release branch. For instance, to checkout a working copy of Python 3.5, do::
 
-   hg update 3.5
+   git checkout 3.5
 
 You will need to re-compile CPython when you do such an update.
 
@@ -346,9 +351,8 @@ when trying to build an old (2.x) Python with a new (3.x) Python installed, or
 vice versa.
 
 To overcome this problem, auto-generated files are also checked into the
-Mercurial repository. So if you don't touch the auto-generation scripts, there's
-no real need to auto-generate anything. However, as Mercurial doesn't preserve
-timestamps well, a special build target ``touch`` was added (the ``touch``
+git repository. So if you don't touch the auto-generation scripts, there's
+no real need to auto-generate anything. A special build target ``touch`` was added (the ``touch``
 build target is not designed for git clones and does not support them). Run::
 
     make touch


### PR DESCRIPTION
Closes #52 

- Removed Mercurial references in text and commands
- Used the expected github.com url for cloning the CPython repo

- Please review info on `touch`target since I'm not sure what it does.

We may wish to add forking the GitHub repo before the clone but for simplicity I have left that for another issue/PR