### PR TITLE
Removed ambiguity under topic Mercurial for git developers

### DIFF
--- a/gitdevs.rst
+++ b/gitdevs.rst
@@ -263,8 +263,7 @@ Now, the history graph should look like this::
     | |  date:        Fri Nov 28 14:52:14 2014 -0800
     | |  summary:     Minor code cleanup.
 
-Notice that the only difference between this and the previous one is that
-changeset 91935 now also has the bookmark "issueA". Bookmarks are advanced
+Notice that the only difference between this and the previous history graph is that changeset 93654 now also has the bookmark "issueA". Bookmarks are advanced
 automatically with each subsequent commit.
 
 Once work has been completed on issueA, commit and prepare a patch for

--- a/gitdevs.rst
+++ b/gitdevs.rst
@@ -263,7 +263,8 @@ Now, the history graph should look like this::
     | |  date:        Fri Nov 28 14:52:14 2014 -0800
     | |  summary:     Minor code cleanup.
 
-Notice that the only difference between this and the previous history graph is that changeset 93654 now also has the bookmark "issueA". Bookmarks are advanced
+Notice that the only difference between this and the previous history graph is
+that changeset 93654 now also has the bookmark "issueA". Bookmarks are advanced
 automatically with each subsequent commit.
 
 Once work has been completed on issueA, commit and prepare a patch for


### PR DESCRIPTION
There was a little bit of ambiguity in the language about what we are talking about _commit_ or _history graph_ and the changeset number mentioned in the text supporting it was not matching the changeset number in the history graph.