### PR TITLE
Update "Helping with the Developer’s Guide" to current state

### DIFF
--- a/docquality.rst
+++ b/docquality.rst
@@ -69,15 +69,12 @@ Helping with the Developer's Guide
 
 .. highlight:: bash
 
-The Developer's Guide uses the same process as the main Python documentation,
-except for some small differences.  The source lives in a `separate
-repository`_.  Bug reports and patches should be submitted to the `Python
-bug tracker`_ using the ``devguide`` component.  Changes to the devguide
+The Developer's Guide has already migrated to GitHub, where the source lives in a `separate
+repository`_.  Bug reports and patches should be submitted there as well.  Changes to the devguide
 are normally published within a day, on a schedule that may be different from
 the main documentation.
 
 .. _separate repository: https://github.com/python/devguide
-.. _Python bug tracker: http://bugs.python.org
 
 To clone the Developer's Guide::
 
@@ -92,3 +89,7 @@ in the checkout directory, which will write the files to the ``_build/html``
 directory.
 
 .. _Sphinx: http://sphinx.pocoo.org/
+
+You still need an account in the `Python bug tracker`_ to :ref:`sign the CLA <cla>`, fill in the field ``GitHub Name`` in your user details to connect the two accounts.
+
+.. _Python bug tracker: http://bugs.python.org

--- a/patch.rst
+++ b/patch.rst
@@ -105,6 +105,8 @@ help revisions``. Just please make sure that you generate a
 **single, condensed** patch rather than a series of several changesets.
 
 
+.. _cla:
+
 Licensing
 ---------
 

--- a/triaging.rst
+++ b/triaging.rst
@@ -82,8 +82,6 @@ ctypes
     The ctypes package in `Lib/ctypes`_.
 Demos and Tools
     The files in Tools_ and `Tools/demo`_.
-Devguide
-    The `Developer's guide`_.
 Distutils
     The distutils package in `Lib/distutils`_.
 Documentation


### PR DESCRIPTION
If I read various issues and documents right this now describes the current process to contribute to the Developers Guide. Once the Github migration is complete this should be updated to reference the more general sections of the Guide.

Also, random piece of feedback: that here the github branch is the primary branch is a bit confusing and not clearly called out – looking at the commit history, a bunch of the previous PRs probably should have been merged into `master` and not `github`?