### PR TITLE
Remove outdated mention of a different URL for core-devs.

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -55,8 +55,7 @@ the Python core developers are constantly updating and fixing things in their
 support through the VCS as it will provide a diff tool, etc.
 
 To get a working copy of the :ref:`in-development <indevbranch>` branch of
-CPython (core developers use a different URL as outlined in :ref:`coredev`),
-run::
+CPython, run::
 
     git clone https://github.com/python/cpython
 


### PR DESCRIPTION
https://cpython-devguide.readthedocs.io/setup.html#getting-the-source-code says that core-devs use a different URL to clone, and links to https://cpython-devguide.readthedocs.io/coredev.html#coredev , but the latter doesn't include any URL.
Since the note seems obsolete (the URL is the same for core-devs too), I removed it.