### PR TITLE
README.rst: fix devguide URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,6 @@ nickname of "the devguide" by the Python core developers.
 
 The official home of this guide is https://docs.python.org/devguide/,
 but an up-to-date mirror of this repository is also available at
-http://cpython-devguide.readthedocs.io/en/latest/ (use the mirror if
-you want to verify that a recent change worked well as the copy on
+https://cpython-devguide.readthedocs.io/ (use the mirror if you want 
+to verify that a recent change worked well as the copy on
 docs.python.org is updated only a few times a day).


### PR DESCRIPTION
Replace
  http://cpython-devguide.readthedocs.io/en/latest/ (returns 404)
with
  https://cpython-devguide.readthedocs.io/

:)