### PR TITLE
#97: remove retired "devguide" component from triaging.rst

### DIFF
--- a/triaging.rst
+++ b/triaging.rst
@@ -80,8 +80,6 @@ ctypes
     The ctypes package in `Lib/ctypes`_.
 Demos and Tools
     The files in Tools_ and `Tools/demo`_.
-Devguide
-    The `Developer's guide`_.
 Distutils
     The distutils package in `Lib/distutils`_.
 Documentation


### PR DESCRIPTION
This removes the retired devguide component as noticed in #97.

(I tried editing this directly from GitHub but since it doesn't show me a preview I created a PR to see the diff.)