### PR TITLE
Fixes grammar in pullrequest.rst crediting section

### DIFF
--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -232,5 +232,5 @@ Crediting
 
 Non-trivial contributions are credited in the ``Misc/ACKS`` file (and, most
 often, in a contribution's ``Misc/NEWS`` entry as well).  You may be
-asked to make these edits on the behalf of the core developer you
+asked to make these edits on the behalf of the core developer who
 accepts your pull request.


### PR DESCRIPTION
The sentence in `Crediting` section (https://docs.python.org/devguide/pullrequest.html#crediting) reads:

`You may be asked to make these edits on the behalf of the core developer you accepts your pull request.`

I think it should be 

`You may be asked to make these edits on the behalf of the core developer *who* accepts your pull request.`