### PR TITLE
remove references to spark.py

### DIFF
--- a/compiler.rst
+++ b/compiler.rst
@@ -538,8 +538,6 @@ References
 .. _The Zephyr Abstract Syntax Description Language.:
    http://www.cs.princeton.edu/research/techreps/TR-554-97
 
-.. _SPARK: http://pages.cpsc.ucalgary.ca/~aycock/spark/
-
 .. [#skip-peephole] Skip Montanaro's Peephole Optimizer Paper
    (http://www.smontanaro.net/python/spam7/optimizer.html)
 

--- a/compiler.rst
+++ b/compiler.rst
@@ -421,15 +421,13 @@ Important Files
         ASDL syntax file
 
     asdl.py
-        "An implementation of the Zephyr Abstract Syntax Definition
-        Language."  Uses SPARK_ to parse the ASDL files.
+        Parser for ASDL definition files. Reads in an ASDL 
+	description and parses it into an AST that describes it.
 
     asdl_c.py
         "Generate C code from an ASDL description."  Generates
         Python/Python-ast.c and Include/Python-ast.h .
 
-    spark.py
-        SPARK_ parser generator
 
 + Python/
 


### PR DESCRIPTION
In `compiler.rst` a reference to `spark.py`, used until Python `3.4`, is still present. [issue19655](https://bugs.python.org/issue19655) changed that for `Python >= 3.5` so, this PR simply removes the references to `spark.py` and changes the text under `asdl.py`.