### PR TITLE
Issue #129: Guide to editing PR branches

### DIFF
--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -274,18 +274,18 @@ To edit an open pull request that targets ``master``:
    git checkout -b <contributor>-<branch_name>
    git pull https://github.com/<contributor>/cpython.git <branch_name>
 
-3. Set up a new SSH git remote for the contributor's fork::
+3. Using those details, set up a new SSH git remote for the contributor's fork::
 
    git remote add <contributor> git@github.com:<contributor>/cpython.git
    git fetch <contributor>
 
-4. Check out the contributor's PR branch::
+4. And check out the contributor's PR branch::
 
    git checkout -b <branch_name> --track <contributor>/<branch_name>
 
 5. Make your changes on the branch. For example, merge in changes made to
    ``master`` since the PR was submitted (any merge commits will be
-   removed by the ``Squash and Merge`` when accepting the change::
+   removed by the later ``Squash and Merge`` when accepting the change)::
 
    git merge origin/master
 

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -202,6 +202,8 @@ repository to backport the commit .
 The core developer who merged the pull request is expected to do the backport.
 
 
+.. _git_pr:
+
 Downloading Other's Patches
 ---------------------------
 
@@ -263,36 +265,28 @@ items like updating ``Misc/ACKS`` and ``Misc/NEWS``.
 
 To edit an open pull request that targets ``master``:
 
-1. At the bottom of the pull request page, click the "command line instructions"
-   link (next to the more prominent ``Squash and merge`` button).
+1. In the pull request page, under the description, there is some information
+   about the contributor's fork and branch name that will be useful::
 
-2. The given instructions are *not* the right instructions for CPython (as they
-   assume you will be pushing directly to the CPython repository, rather than
-   pushing back to the contributor's PR branch), but they include the relevant
-   repository and branch names::
+      <contributor> wants to merge 1 commit into ``python:master`` from ``<contributor>:<branch_name>``
 
-      $ git checkout -b <contributor>-<branch_name>
-      $ git pull https://github.com/<contributor>/cpython.git <branch_name>
+2. Fetch the said pr, using the :ref:`git pr <git_pr>` alias::
 
-3. Using those details, set up a new SSH git remote for the contributor's fork::
+      $ git pr <pr_number>
 
-      $ git remote add <contributor> git@github.com:<contributor>/cpython.git
-      $ git fetch <contributor>
+   This will checkout the contributor's branch at ``pr_XXX``
 
-4. And check out the contributor's PR branch::
-
-      $ git checkout -b <branch_name> --track <contributor>/<branch_name>
-
-5. Make your changes on the branch. For example, merge in changes made to
-   ``master`` since the PR was submitted (any merge commits will be
+3. Make and commit your changes on the branch.  For example, merge in changes
+   made to ``master`` since the PR was submitted (any merge commits will be
    removed by the later ``Squash and Merge`` when accepting the change)::
 
       $ git merge origin/master
 
 6. Push the changes back to the contributor's PR branch::
 
-      $ git push <contributor>
+      $ git push git@github.com:<contributor>/cpython <pr_XXX>:<branch_name>
 
-7. (Optional) Delete the remote definition for the contributor's fork::
 
-      $ git remote remove <contributor>
+7. Optional, delete the contributor's branch::
+
+      $ git branch -D <pr_XXX>

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -253,7 +253,7 @@ Pull requests can be accepted and merged by a Python Core Developer.
 Editing a Pull Request Prior to Merging
 ---------------------------------------
 
-When a pull request submitter has enabled the `"Allow edits from maintainers"``
+When a pull request submitter has enabled the ``"Allow edits from maintainers"``
 option, Python Core Developers may decide to make any remaining edits needed
 prior to merging themselves, rather than asking the submitter to do them. This
 can be particularly appropriate when the remaining changes are bookkeeping

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -281,6 +281,8 @@ To edit an open pull request that targets ``master``:
    removed by the later ``Squash and Merge`` when accepting the change)::
 
       $ git merge origin/master
+      $ git add <filename>
+      $ git commit -m "<commit message>"
 
 4. Push the changes back to the contributor's PR branch::
 

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -253,13 +253,13 @@ Pull requests can be accepted and merged by a Python Core Developer.
 Editing a Pull Request Prior to Merging
 ---------------------------------------
 
-When a pull request submitter has enabled the ``Allow edits from maintainers``
+When a pull request submitter has enabled the `Allow edits from maintainers`_
 option, Python Core Developers may decide to make any remaining edits needed
 prior to merging themselves, rather than asking the submitter to do them. This
 can be particularly appropriate when the remaining changes are bookkeeping
 items like updating ``Misc/ACKS`` and ``Misc/NEWS``.
 
-.. _"Allow edits from maintainers": https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/
+.. _Allow edits from maintainers: https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/
 
 To edit an open pull request that targets ``master``:
 

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -266,15 +266,15 @@ items like updating ``Misc/ACKS`` and ``Misc/NEWS``.
 To edit an open pull request that targets ``master``:
 
 1. In the pull request page, under the description, there is some information
-   about the contributor's fork and branch name that will be useful::
+   about the contributor's fork and branch name that will be useful later::
 
-      <contributor> wants to merge 1 commit into ``python:master`` from ``<contributor>:<branch_name>``
+      <contributor> wants to merge 1 commit into python:master from <contributor>:<branch_name>
 
 2. Fetch the said pr, using the :ref:`git pr <git_pr>` alias::
 
       $ git pr <pr_number>
 
-   This will checkout the contributor's branch at ``pr_XXX``
+   This will checkout the contributor's branch at ``pr_XXX``.
 
 3. Make and commit your changes on the branch.  For example, merge in changes
    made to ``master`` since the PR was submitted (any merge commits will be
@@ -282,11 +282,11 @@ To edit an open pull request that targets ``master``:
 
       $ git merge origin/master
 
-6. Push the changes back to the contributor's PR branch::
+4. Push the changes back to the contributor's PR branch::
 
       $ git push git@github.com:<contributor>/cpython <pr_XXX>:<branch_name>
 
+5. Optional, delete the contributor's branch::
 
-7. Optional, delete the contributor's branch::
-
+      $ git checkout master
       $ git branch -D <pr_XXX>

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -253,7 +253,7 @@ Pull requests can be accepted and merged by a Python Core Developer.
 Editing a Pull Request Prior to Merging
 ---------------------------------------
 
-When a pull request submitter has enabled the ``"Allow edits from maintainers"``
+When a pull request submitter has enabled the ``Allow edits from maintainers``
 option, Python Core Developers may decide to make any remaining edits needed
 prior to merging themselves, rather than asking the submitter to do them. This
 can be particularly appropriate when the remaining changes are bookkeeping

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -248,3 +248,51 @@ Pull requests can be accepted and merged by a Python Core Developer.
       * rebased
 
 3. Press the ``Confirm squash and merge`` button.
+
+
+Editing a Pull Request Prior to Merging
+---------------------------------------
+
+When a pull request submitter has enabled the `"Allow edits from maintainers"``
+option, Python Core Developers may decide to make any remaining edits needed
+prior to merging themselves, rather than asking the submitter to do them. This
+can be particularly appropriate when the remaining changes are bookkeeping
+items like updating ``Misc/ACKS`` and ``Misc/NEWS``.
+
+.. _"Allow edits from maintainers": https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/
+
+To edit an open pull request that targets ``master``:
+
+1. At the bottom of the pull request page, click the "command line instructions"
+   link (next to the more prominent ``Squash and merge`` button).
+
+2. The given instructions are *not* the right instructions for CPython (as they
+   assume you will be pushing directly to the CPython repository, rather than
+   pushing back to the contributor's PR branch), but they include the relevant
+   repository and branch names::
+
+   git checkout -b <contributor>-<branch_name>
+   git pull https://github.com/<contributor>/cpython.git <branch_name>
+
+3. Set up a new SSH git remote for the contributor's fork::
+
+   git remote add <contributor> git@github.com:<contributor>/cpython.git
+   git fetch <contributor>
+
+4. Check out the contributor's PR branch::
+
+   git checkout -b <branch_name> --track <contributor>/<branch_name>
+
+5. Make your changes on the branch. For example, merge in changes made to
+   ``master`` since the PR was submitted (any merge commits will be
+   removed by the ``Squash and Merge`` when accepting the change::
+
+   git merge origin/master
+
+6. Push the changes back to the contributor's PR branch::
+
+   git push <contributor>
+
+7. (Optional) Delete the remote definition for the contributor's fork::
+
+   git remote remove <contributor>

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -271,28 +271,28 @@ To edit an open pull request that targets ``master``:
    pushing back to the contributor's PR branch), but they include the relevant
    repository and branch names::
 
-   git checkout -b <contributor>-<branch_name>
-   git pull https://github.com/<contributor>/cpython.git <branch_name>
+      git checkout -b <contributor>-<branch_name>
+      git pull https://github.com/<contributor>/cpython.git <branch_name>
 
 3. Using those details, set up a new SSH git remote for the contributor's fork::
 
-   git remote add <contributor> git@github.com:<contributor>/cpython.git
-   git fetch <contributor>
+      git remote add <contributor> git@github.com:<contributor>/cpython.git
+      git fetch <contributor>
 
 4. And check out the contributor's PR branch::
 
-   git checkout -b <branch_name> --track <contributor>/<branch_name>
+      git checkout -b <branch_name> --track <contributor>/<branch_name>
 
 5. Make your changes on the branch. For example, merge in changes made to
    ``master`` since the PR was submitted (any merge commits will be
    removed by the later ``Squash and Merge`` when accepting the change)::
 
-   git merge origin/master
+      git merge origin/master
 
 6. Push the changes back to the contributor's PR branch::
 
-   git push <contributor>
+      git push <contributor>
 
 7. (Optional) Delete the remote definition for the contributor's fork::
 
-   git remote remove <contributor>
+      git remote remove <contributor>

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -271,28 +271,28 @@ To edit an open pull request that targets ``master``:
    pushing back to the contributor's PR branch), but they include the relevant
    repository and branch names::
 
-      git checkout -b <contributor>-<branch_name>
-      git pull https://github.com/<contributor>/cpython.git <branch_name>
+      $ git checkout -b <contributor>-<branch_name>
+      $ git pull https://github.com/<contributor>/cpython.git <branch_name>
 
 3. Using those details, set up a new SSH git remote for the contributor's fork::
 
-      git remote add <contributor> git@github.com:<contributor>/cpython.git
-      git fetch <contributor>
+      $ git remote add <contributor> git@github.com:<contributor>/cpython.git
+      $ git fetch <contributor>
 
 4. And check out the contributor's PR branch::
 
-      git checkout -b <branch_name> --track <contributor>/<branch_name>
+      $ git checkout -b <branch_name> --track <contributor>/<branch_name>
 
 5. Make your changes on the branch. For example, merge in changes made to
    ``master`` since the PR was submitted (any merge commits will be
    removed by the later ``Squash and Merge`` when accepting the change)::
 
-      git merge origin/master
+      $ git merge origin/master
 
 6. Push the changes back to the contributor's PR branch::
 
-      git push <contributor>
+      $ git push <contributor>
 
 7. (Optional) Delete the remote definition for the contributor's fork::
 
-      git remote remove <contributor>
+      $ git remote remove <contributor>

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -270,7 +270,7 @@ To edit an open pull request that targets ``master``:
 
       <contributor> wants to merge 1 commit into python:master from <contributor>:<branch_name>
 
-2. Fetch the said pr, using the :ref:`git pr <git_pr>` alias::
+2. Fetch the pull request, using the :ref:`git pr <git_pr>` alias::
 
       $ git pr <pr_number>
 

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -288,7 +288,7 @@ To edit an open pull request that targets ``master``:
 
       $ git push git@github.com:<contributor>/cpython <pr_XXX>:<branch_name>
 
-5. Optional, delete the contributor's branch::
+5. Optionally, delete the local PR branch::
 
       $ git checkout master
       $ git branch -D <pr_XXX>


### PR DESCRIPTION
- set up an SSH remote for the contributor's CPython fork
- check out a local branch based on their PR branch
- make changes and push them back to their fork