### PR TITLE
Explain why commits in a PR shouldn't be squashed.

### DIFF
--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -169,9 +169,9 @@ added to it.
 Your pull request may involve several commits as a result of addressing code
 review comments.  Please keep the commit history in the pull request intact by
 not squashing, amending, or anything that would require a force push to GitHub.
-This allows reviewers to view the diff of one commit to another so they can
-easily verify whether their comments have been addressed.  The commits will be
-squashed when the pull request is merged.
+A detailed commit history allows reviewers to view the diff of one commit to
+another so they can easily verify whether their comments have been addressed.
+The commits will be squashed when the pull request is merged.
 
 
 .. _issue tracker: https://bugs.python.org

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -166,11 +166,13 @@ any discussion of what the pull request is trying to solve (e.g. fixing a
 spelling mistake), then the pull request needs to have the "trivial" label
 added to it.
 
-If your pull request involves several commits as a result of addressing code
-review comments, please do not squash them.  When you squash your commits,
-reviewers lose the ability to view the diff of one commit to the next
-and are therefore unable to easily verify whether their comments have been
-addressed.
+Your pull request may involve several commits as a result of addressing code
+review comments.  Please keep the commit history in the pull request intact by
+not squashing, amending, or anything that would require a force push to GitHub.
+This allows reviewers to view the diff of one commit to another so they can
+easily verify whether their comments have been addressed.  The commits will be
+squashed when the pull request is merged.
+
 
 .. _issue tracker: https://bugs.python.org
 

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -166,10 +166,11 @@ any discussion of what the pull request is trying to solve (e.g. fixing a
 spelling mistake), then the pull request needs to have the "trivial" label
 added to it.
 
-If your pull request involves several commits, as a result of addressing code
+If your pull request involves several commits as a result of addressing code
 review comments, please do not squash them.  When you squash your commits,
-reviewers lose the ability to view the diff of one commit to the next,
-and therefore unable to easily verify whether their comments have been addressed.
+reviewers lose the ability to view the diff of one commit to the next
+and are therefore unable to easily verify whether their comments have been
+addressed.
 
 .. _issue tracker: https://bugs.python.org
 

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -166,6 +166,10 @@ any discussion of what the pull request is trying to solve (e.g. fixing a
 spelling mistake), then the pull request needs to have the "trivial" label
 added to it.
 
+If your pull request involves several commits, as a result of addressing code
+review comments, please do not squash them.  When you squash your commits,
+reviewers lose the ability to view the diff of one commit to the next,
+and therefore unable to easily verify whether their comments have been addressed.
 
 .. _issue tracker: https://bugs.python.org
 


### PR DESCRIPTION
Closes https://github.com/python/devguide/issues/159