### PR TITLE
We don't need to apply `cherry-pick for *` label anymore.

### DIFF
--- a/committing.rst
+++ b/committing.rst
@@ -429,8 +429,8 @@ Prefix the backport pull request with the branch, for example::
 Note that cherry_picker.py_ adds the branch prefix automatically.
    
 Once the backport pull request has been created, remove the
-``needs backport to X.Y`` label from the original pull request on ``master``.
-Only Core Developers can apply labels to GitHub pull requests.
+``needs backport to X.Y`` label from the original pull request.  (Only Core
+Developers can apply labels to GitHub pull requests).
 
 .. _cherry_picker.py: https://github.com/python/core-workflow/tree/master/cherry_picker
 

--- a/committing.rst
+++ b/committing.rst
@@ -428,10 +428,9 @@ Prefix the backport pull request with the branch, for example::
    
 Note that cherry_picker.py_ adds the branch prefix automatically.
    
-Apply the label ``cherry-pick or X.Y`` to the backport pull request.  Once the backport
-pull request has been created, remove the ``needs backport to X.Y`` label from the
-original pull request on ``master``.  Only Core Developers can apply labels to GitHub
-pull requests.  
+Once the backport pull request has been created, remove the
+``needs backport to X.Y`` label from the original pull request on ``master``.
+Only Core Developers can apply labels to GitHub pull requests.
 
 .. _cherry_picker.py: https://github.com/python/core-workflow/tree/master/cherry_picker
 


### PR DESCRIPTION
lol also just now noticed the typo 😛 

Background: https://mail.python.org/pipermail/core-workflow/2017-May/000991.html 