### PR TITLE
Update backport instruction

### DIFF
--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -202,8 +202,6 @@ Use the utility script `cherry_picker.py <https://github.com/python/core-workflo
 from the `core-workflow  <https://github.com/python/core-workflow>`_
 repository to backport the commit.
 
-The core developer who merged the pull request is expected to do the backport.
-
 
 .. _git_pr:
 


### PR DESCRIPTION
Remove the part where it says 'core dev is expected to backport'.

No reason a contributor shouldn't be able to do the backport themselves.
If the contributor can do the backport and resolve conflicts on their own, then it's less work for core devs.

The only thing core dev needs to do is remove the label from original PR, and then approve and merge the
backport PR. :)

I think perhaps better for core dev to specify whether they want to do the backport themselves (so they can do
local testing) or ask the contributor to do it.