### PR TITLE
Add make serve to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ help:
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 	@echo "  check      to run a check for frequent markup errors"
+	@echo "  serve      to serve devguide on the localhost (8000)"
 
 clean:
 	-rm -rf $(BUILDDIR)/*
@@ -138,3 +139,6 @@ doctest: venv
 
 check:
 	$(PYTHON) tools/rstlint.py -i tools -i venv
+
+serve: html
+	tools/serve.py _build/html

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
 .PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp \
-        devhelp epub latex latexpdf text man changes linkcheck doctest check
+        devhelp epub latex latexpdf text man changes linkcheck doctest check \
+        serve
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"

--- a/make.bat
+++ b/make.bat
@@ -16,6 +16,7 @@ if NOT "%PAPER%" == "" (
 
 if "%1" == "" goto help
 if "%1" == "check" goto check
+if "%1" == "serve" goto serve
 
 if "%1" == "help" (
 	:help
@@ -35,7 +36,8 @@ if "%1" == "help" (
 	echo.  changes    to make an overview over all changed/added/deprecated items
 	echo.  linkcheck  to check all external links for integrity
 	echo.  doctest    to run all doctests embedded in the documentation if enabled
-	echo.  check      
+	echo.  check
+	echo.  serve      to serve devguide on the localhost (8000)
 	goto end
 )
 
@@ -174,6 +176,10 @@ results in %BUILDDIR%/doctest/output.txt.
 
 :check
 cmd /C %PYTHON% tools\rstlint.py -i tools -i venv
+goto end
+
+:serve
+cmd /C %PYTHON% tools\serve.py %BUILDDIR%\html
 goto end
 
 :end

--- a/tools/serve.py
+++ b/tools/serve.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+'''
+Small wsgiref based web server. Takes a path to serve from and an
+optional port number (defaults to 8000), then tries to serve files.
+Mime types are guessed from the file names, 404 errors are raised
+if the file is not found. Used for the make serve target in Doc.
+'''
+import sys
+import os
+import mimetypes
+from wsgiref import simple_server, util
+
+
+def app(environ, respond):
+
+    fn = os.path.join(path, environ['PATH_INFO'][1:])
+    if '.' not in fn.split(os.path.sep)[-1]:
+        fn = os.path.join(fn, 'index.html')
+    type = mimetypes.guess_type(fn)[0]
+
+    if os.path.exists(fn):
+        respond('200 OK', [('Content-Type', type)])
+        return util.FileWrapper(open(fn, "rb"))
+    else:
+        respond('404 Not Found', [('Content-Type', 'text/plain')])
+        return [b'not found']
+
+
+if __name__ == '__main__':
+    path = sys.argv[1]
+    port = int(sys.argv[2]) if len(sys.argv) > 2 else 8000
+    httpd = simple_server.make_server('', port, app)
+    print("Serving {} on port {}, control-C to stop".format(path, port))
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\b\bShutting down.")
+

--- a/tools/serve.py
+++ b/tools/serve.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
     path = sys.argv[1]
     port = int(sys.argv[2]) if len(sys.argv) > 2 else 8000
     httpd = simple_server.make_server('', port, app)
-    print("Serving {} on port {}, control-C to stop".format(path, port))
+    print("Serving {} on http://localhost:{}, control-C to stop".format(path, port))
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:


### PR DESCRIPTION
Borrow from python/cpython documentation, add `make serve` to serve devgudie at localhost (port 8000).

If the doc didn't build up, it will first build up then serve the devguide.