### PR TITLE
Update git pr instruction

### DIFF
--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -213,7 +213,7 @@ Scenario:
 - A contributor made a pull request to CPython.
 - Before merging it, you want to be able to test their changes locally.
 
-Set up the following git alias::
+On Unix and MacOS, set up the following git alias::
 
    $ git config --global alias.pr '!sh -c "git fetch upstream pull/${1}/head:pr_${1} && git checkout pr_${1}" -'
    

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -216,6 +216,10 @@ Scenario:
 Set up the following git alias::
 
    $ git config --global alias.pr '!sh -c "git fetch upstream pull/${1}/head:pr_${1} && git checkout pr_${1}" -'
+   
+On Windows, reverse the single (`'`) and double (`"`) quotes::
+
+   git config --global alias.pr "!sh -c 'git fetch upstream pull/${1}/head:pr_${1} && git checkout pr_${1}' -"
 
 The alias only needs to be done once.  After the alias is set up, you can get a
 local copy of a pull request as follows::


### PR DESCRIPTION
On Windows, the single and double quotes should be reversed
Closes https://github.com/python/devguide/issues/217