### PR TITLE
Adjust Editing Contributor's PR section of the bootcamp

### DIFF
--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -285,7 +285,8 @@ To edit an open pull request that targets ``master``:
    made to ``master`` since the PR was submitted (any merge commits will be
    removed by the later ``Squash and Merge`` when accepting the change)::
 
-      $ git merge origin/master
+      $ git fetch upstream
+      $ git merge upstream/master
       $ git add <filename>
       $ git commit -m "<commit message>"
 


### PR DESCRIPTION
The original instruction is to merge with `origin/master`.
I think it's more accurate to merge with `upstream/master`, where `upstream` has been referenced throughout the document as cpython's repo, and `origin` refers to our own fork.

If our `origin/master` is not up to date, we might not see the right result.
So I think it's better to merge with `upstream/master`.