### PR TITLE
PR lifecycle: Fix the target to cla

### DIFF
--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -92,8 +92,6 @@ command (after any successful build of Python)::
 
    python.bat Tools/scripts/patchcheck.py
 
-.. _cla:
-
 .. _pullrequest-quickguide:
 
 Quick Guide
@@ -176,6 +174,8 @@ Make a pull request on GitHub from your changes in ``MY_BRANCH_NAME``.
    You can still upload a patch to bugs.python.org_, but the GitHub pull request
    workflow is **strongly** preferred.
 
+
+.. _cla:
 
 Licensing
 ---------


### PR DESCRIPTION
It was placed above Pull request Guide Step-by-step section.
Moving it `Licensing` section.