### PR TITLE
Update devguide URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,15 +2,11 @@ The CPython Developer's Guide
 =============================
 
 .. image:: https://readthedocs.org/projects/cpython-devguide/badge/
-   :target: https://cpython-devguide.readthedocs.io/
+   :target: https://devguide.python.org
    :alt: Documentation Status
 
 
 This guide covers how to contribute to CPython. It is known by the
 nickname of "the devguide" by the Python core developers.
 
-The official home of this guide is https://docs.python.org/devguide/,
-but an up-to-date mirror of this repository is also available at
-https://cpython-devguide.readthedocs.io/ (use the mirror if you want 
-to verify that a recent change worked well as the copy on
-docs.python.org is updated only a few times a day).
+The official home of this guide is https://devguide.python.org.


### PR DESCRIPTION
Closes https://github.com/python/devguide/issues/231

Changed the canonical URL for the devguide to point to the new
subdomain and removed mention of the old mirror.