### PR TITLE
Trivial: Fix broken link for Peephole Optimizer Paper

### DIFF
--- a/compiler.rst
+++ b/compiler.rst
@@ -539,7 +539,7 @@ References
    http://www.cs.princeton.edu/research/techreps/TR-554-97
 
 .. [#skip-peephole] Skip Montanaro's Peephole Optimizer Paper
-   (http://legacy.python.org/workshops/1998-11/proceedings/papers/montanaro/montanaro.html)
+   (https://drive.google.com/open?id=0B2InO7qBBGRXQXlDM3FVdWZxQWc)
 
 .. [#Bytecodehacks] Bytecodehacks Project
    (http://bytecodehacks.sourceforge.net/bch-docs/bch/index.html)

--- a/compiler.rst
+++ b/compiler.rst
@@ -539,7 +539,7 @@ References
    http://www.cs.princeton.edu/research/techreps/TR-554-97
 
 .. [#skip-peephole] Skip Montanaro's Peephole Optimizer Paper
-   (http://www.smontanaro.net/python/spam7/optimizer.html)
+   (http://legacy.python.org/workshops/1998-11/proceedings/papers/montanaro/montanaro.html)
 
 .. [#Bytecodehacks] Bytecodehacks Project
    (http://bytecodehacks.sourceforge.net/bch-docs/bch/index.html)


### PR DESCRIPTION
The old link for this paper is broken (or at least doesn't link to the paper in question). A quick google search revealed a few other places where the paper can be found. I opted for the link on legacy.python.org but any of the other links could be used if they better suit the documentation style.

I've run `make html` and it seems to have worked fine 😄 