### PR TITLE
Explain the requirements for converting bpo patch to GitHub

### DIFF
--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -259,6 +259,19 @@ The commits will be squashed when the pull request is merged.
 
 .. _issue tracker: https://bugs.python.org
 
+Converting an Existing Patch from the b.p.o to GitHub
+-----------------------------------------------------
+
+When a patch exists in the `issue tracker`_ that should be converted into a
+GitHub pull request, please first ask the original patch author to prepare
+their own pull request. If the author does not respond after a week, it is
+acceptable for another contributor to prepare the pull request based on the
+existing patch. In this case, both parties should sign the :ref:`CLA <cla>`.
+When creating a pull request based on another person's patch, provide
+attribution to the original patch author by adding "Original patch by
+<author name>." to the pull request description and commit message.
+
+See also :ref:`Applying a Patch from Mercurial to Git <git_from_mercurial>`.
 
 Reviewing
 ---------


### PR DESCRIPTION
- first ask the original author to do it
- wait a week before converting a patch by another author
- ensure both parties sign CLA
- provide attribution to the original author

Closes https://github.com/python/devguide/issues/195