### PR TITLE
Python 3.5 entered security fix only stage

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -12,7 +12,7 @@ Quick Reference
 ---------------
 
 Here are the basic steps needed to get :ref:`set up <setup>` and contribute a
-patch. This is meant as a checklist, once you know the basics. For complete 
+patch. This is meant as a checklist, once you know the basics. For complete
 instructions please see the :ref:`setup guide <setup>`.
 
 1. Install and set up :ref:`Git <vcsetup>` and other dependencies
@@ -93,12 +93,12 @@ Status of Python branches
 | 3.6              | :pep:`494`   | bugfix      | 2016-12-23     | *2021-12-23*   | `Most recent binary release: Python 3.6.1                                  |
 |                  |              |             |                |                | <https://www.python.org/downloads/release/python-361/>`_                   |
 +------------------+--------------+-------------+----------------+----------------+----------------------------------------------------------------------------+
-| 3.5              | :pep:`478`   | bugfix      | 2015-09-13     | *2020-09-13*   | `Most recent binary release: Python 3.5.3                                  |
-|                  |              |             |                |                | <https://www.python.org/downloads/release/python-353/>`_                   |
-+------------------+--------------+-------------+----------------+----------------+----------------------------------------------------------------------------+
 | 2.7              | :pep:`373`   | bugfix      | 2010-07-03     | *2020-01-01*   | The support has been extended to 2020 (1).                                 |
 |                  |              |             |                |                | `Most recent binary release: Python 2.7.13                                 |
 |                  |              |             |                |                | <https://www.python.org/downloads/release/python-2713/>`_                  |
++------------------+--------------+-------------+----------------+----------------+----------------------------------------------------------------------------+
+| 3.5              | :pep:`478`   | security    | 2015-09-13     | *2020-09-13*   | `Most recent binary release: Python 3.5.4                                  |
+|                  |              |             |                |                | <https://www.python.org/downloads/release/python-354/>`_                   |
 +------------------+--------------+-------------+----------------+----------------+----------------------------------------------------------------------------+
 | 3.4              | :pep:`429`   | security    | 2014-03-16     | *2019-03-16*   | `Most recent security release: Python 3.4.6                                |
 |                  |              |             |                |                | <https://www.python.org/downloads/release/python-346/>`_                   |


### PR DESCRIPTION
Python 3.5 just entered security fixes only:
https://mail.python.org/pipermail/python-dev/2017-August/148794.html

Update also the most recent binary release: 3.5.3 => 3.5.4