### PR TITLE
Update the setup and PR lifecycle pages

### DIFF
--- a/committing.rst
+++ b/committing.rst
@@ -57,37 +57,8 @@ passes before merging any code changes.
 Patch checklist
 '''''''''''''''
 
-Along with running the tests, a simple automated patch checklist, ``patchcheck``,
-guides a developer through the common patch generation checks. To run
-``patchcheck``:
-
-   On *UNIX* (including Mac OS X)::
-
-      make patchcheck
-
-   On *Windows* (after any successful build)::
-
-      python.bat Tools/scripts/patchcheck.py
-
-The automated patch checklist runs through:
-
-* Are there any whitespace problems in Python files?
-  (using ``Tools/scripts/reindent.py``)
-* Are there any whitespace problems in C files?
-* Are there any whitespace problems in the documentation?
-  (using ``Tools/scripts/reindent-rst.py``)
-* Has the documentation been updated?
-* Has the test suite been updated?
-* Has an entry under ``Misc/NEWS.d/next`` been added?
-* Has ``Misc/ACKS`` been updated?
-* Has ``configure`` been regenerated, if necessary?
-* Has ``pyconfig.h.in`` been regenerated, if necessary?
-
-The automated patch check doesn't actually *answer* all of these
-questions. Aside from the whitespace checks, the tool is
-a memory aid for the various elements that can go into
-making a complete patch.
-
+You should also :ref:`run patchcheck <patchcheck>` to perform a quick
+sanity check on the changes.
 
 Commit Style
 ------------

--- a/committing.rst
+++ b/committing.rst
@@ -60,23 +60,6 @@ Patch checklist
 You should also :ref:`run patchcheck <patchcheck>` to perform a quick
 sanity check on the changes.
 
-Commit Style
-------------
-
-.. move this to pullrequest
-
-Once a change patch is ready and tested, it can be committed to the repository.
-We usually prefer to put a whole feature or bugfix into a single commit, but no
-more.  In particular:
-
-* Do **not** fix more than one issue in the same commit (except, of course, if
-  one code change fixes all of them).
-* Do **not** do cosmetic changes to unrelated code in the same commit as some
-  feature/bugfix.
-
-It is of course okay to pile up several commits to one branch and merge them
-into another in one commit.
-
 
 Handling Others' Code
 ---------------------
@@ -207,37 +190,6 @@ the issue number as it's part of the file name itself. Example news entry::
 (In other ``.rst`` files the single backticks should not be used.  They are
 allowed here because news entries are meant to be as readable as possible
 unprocessed.)
-
-
-Commit Messages
----------------
-
-.. move to pullrequest
-
-Every commit has a commit message to document why a change was made and to
-communicate that reason to other core developers. Python core developers have
-developed a standard way of formatting commit messages that everyone is
-expected to follow.
-
-Our usual convention mimics that used in news entries (it is actually common to
-start by pasting the news entry into the commit message). The only key
-difference when compared to a news entry is the inclusion of the issue number
-as the beginning of the commit message. Here is an example::
-
-   bpo-42: the spam module is now more spammy.
-
-   The spam module sporadically came up short on spam. This change
-   raises the amount of spam in the module by making it more spammy.
-
-   Thanks to Monty Python for the patch.
-
-The first line or sentence is meant to be a dense, to-the-point explanation
-of what the purpose of the commit is.  If this is not enough detail for a commit,
-a new paragraph(s) can be added to explain in proper depth what has happened
-(detail should be good enough that a core developer reading the commit message
-understands the justification for the change).  Also, if a non-core developer
-contributed to the resolution, it is good practice to credit them.
-
 
 
 Working with Git_

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -18,27 +18,6 @@ sense for you personally when it comes to general Git and GitHub
 details.
 
 
-Tool Setup
-''''''''''
-
-.. _workflow:
-
-If you have not already done so, you will want to fork the
-`CPython repository`_. You can read GitHub's documentation on how to
-`fork a repository <https://help.github.com/articles/fork-a-repo/>`_
-if you are not already familiar with how to do this. This will make
-sure that you have a clone of your fork of CPython on your computer
-and the appropriate remote repositories.
-
-You will then want to create a branch to contain your work. GitHub has
-instructions on how to
-`create a branch <https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/>`_
-within your fork through their website.
-
-
-.. _CPython repository: https://github.com/python/cpython
-
-
 Preparation
 '''''''''''
 

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -16,7 +16,9 @@ the official CPython repository (``upstream``).
 .. _pullrequest-quickguide:
 
 Quick Guide
-'''''''''''
+-----------
+
+.. XXX fix headers
 
 `Clear communication`_ is key to contributing to any project, especially an
 `Open Source`_ project like CPython.
@@ -57,7 +59,7 @@ Here is a quick overview of how you can contribute to CPython:
 .. _pullrequest-steps:
 
 Step-by-step Guide
-''''''''''''''''''
+------------------
 
 You should have already :ref:`set up your system <setup>`,
 :ref:`got the source code <checkout>`, and :ref:`built Python <compiling>`.
@@ -119,7 +121,7 @@ After your PR has been accepted and merged, you can :ref:`delete the branch <del
 .. _good-prs:
 
 Making good PRs
-'''''''''''''''
+---------------
 
 When creating a pull request for submission, there are several things that you
 should do to help ensure that your pull request is accepted.
@@ -158,7 +160,7 @@ additions/changes should be included.
 .. _patchcheck:
 
 ``patchcheck``
-''''''''''''''
+--------------
 
 ``patchcheck`` is a simple automated patch checklist that guides a developer
 through the common patch generation checks. To run ``patchcheck``:

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -38,7 +38,8 @@ Here is a quick overview of how you can contribute to CPython:
 
 #. Review and address `comments on your Pull Request`_
 
-#. When your changes are merged, you can :ref:`delete the PR branch <deleting_branches>`
+#. When your changes are merged, you can :ref:`delete the PR branch
+   <deleting_branches>`
 
 #. Celebrate contributing to CPython! :)
 
@@ -68,7 +69,7 @@ Create a new branch in your local clone::
 
 Make changes to the code, and use ``git status`` and ``git diff`` to see them.
 
-(Learn more about :ref:`making good PRs <good-prs>`)
+(Learn more about :ref:`good-prs`)
 
 Make sure the changes are fine and don't cause any test failure::
 
@@ -108,7 +109,8 @@ automatically update your PR::
    git commit -m '<message>'
    git push origin <branch-name>
 
-After your PR has been accepted and merged, you can :ref:`delete the branch <deleting_branches>`::
+After your PR has been accepted and merged, you can :ref:`delete the branch
+<deleting_branches>`::
 
    git branch -D <branch-name>  # delete local branch
    git push origin -d <branch-name>  # delete remote branch
@@ -120,7 +122,7 @@ After your PR has been accepted and merged, you can :ref:`delete the branch <del
 
 .. _good-prs:
 
-Making good PRs
+Making Good PRs
 ---------------
 
 When creating a pull request for submission, there are several things that you

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -18,8 +18,6 @@ the official CPython repository (``upstream``).
 Quick Guide
 -----------
 
-.. XXX fix headers
-
 `Clear communication`_ is key to contributing to any project, especially an
 `Open Source`_ project like CPython.
 

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -63,45 +63,45 @@ Step-by-step Guide
 You should have already :ref:`set up your system <setup>`,
 :ref:`got the source code <checkout>`, and :ref:`built Python <compiling>`.
 
-Create a new branch in your local clone::
+* Create a new branch in your local clone::
 
-   git checkout -b <branch-name> upstream/master
+     git checkout -b <branch-name> upstream/master
 
-Make changes to the code, and use ``git status`` and ``git diff`` to see them.
+* Make changes to the code, and use ``git status`` and ``git diff`` to see them.
 
-(Learn more about :ref:`good-prs`)
+  (Learn more about :ref:`good-prs`)
 
-Make sure the changes are fine and don't cause any test failure::
+* Make sure the changes are fine and don't cause any test failure::
 
-   make patchcheck
-   ./python -m test
+     make patchcheck
+     ./python -m test
 
-(Learn more about :ref:`patchcheck` and about :doc:`runtests`)
+  (Learn more about :ref:`patchcheck` and about :doc:`runtests`)
 
-Once you are satisfied with the changes, add the files and commit them::
+* Once you are satisfied with the changes, add the files and commit them::
 
-   git add <filenames>
-   git commit -m '<message>'
+     git add <filenames>
+     git commit -m '<message>'
 
-(Learn more about :ref:`good-commits`)
+  (Learn more about :ref:`good-commits`)
 
-Then push your work to your GitHub fork::
+* Then push your work to your GitHub fork::
 
-   git push origin <branch-name>
+     git push origin <branch-name>
 
-If someone else added new changesets and you get an error::
+* If someone else added new changesets and you get an error::
 
-   git fetch upstream
-   git rebase upstream/master
-   git push --force origin <branch-name>
+     git fetch upstream
+     git rebase upstream/master
+     git push --force origin <branch-name>
 
-Finally go on :samp:`https://github.com/{<your-username>}/cpython`: you will
-see a box with the branch you just pushed and a green button that allows
-you to create a pull request against the official CPython repository.
+* Finally go on :samp:`https://github.com/{<your-username>}/cpython`: you will
+  see a box with the branch you just pushed and a green button that allows
+  you to create a pull request against the official CPython repository.
 
-When people start adding review comments, you can address them by switching
-to your branch, making more changes, committing them, and pushing them to
-automatically update your PR::
+* When people start adding review comments, you can address them by switching
+  to your branch, making more changes, committing them, and pushing them to
+  automatically update your PR::
 
    git checkout <branch-name>
    # make changes and run tests
@@ -109,11 +109,11 @@ automatically update your PR::
    git commit -m '<message>'
    git push origin <branch-name>
 
-After your PR has been accepted and merged, you can :ref:`delete the branch
-<deleting_branches>`::
+* After your PR has been accepted and merged, you can :ref:`delete the branch
+  <deleting_branches>`::
 
-   git branch -D <branch-name>  # delete local branch
-   git push origin -d <branch-name>  # delete remote branch
+     git branch -D <branch-name>  # delete local branch
+     git push origin -d <branch-name>  # delete remote branch
 
 .. note::
    You can still upload a patch to bugs.python.org_, but the GitHub pull request

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -4,18 +4,13 @@ Lifecycle of a Pull Request
 ===========================
 
 
-Creating
---------
+Introduction
+------------
 
 CPython uses a workflow based on pull requests. What this means is
 that you create a branch in Git, make your changes, push those changes
-to GitHub, and then create a pull request.
-`GitHub's help pages <https://help.github.com/>`_ are good and there
-are tons of pages out there for help with Git.  As such, this
-document does not go into any great detail as the assumption is there
-is a resource out there which will explain things in a way that makes
-sense for you personally when it comes to general Git and GitHub
-details.
+to your fork on GitHub (``origin``), and then create a pull request against
+the official CPython repository (``upstream``).
 
 
 Preparation

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -82,6 +82,8 @@ Once you are satisfied with the changes, add the files and commit them::
    git add <filenames>
    git commit -m '<message>'
 
+(Learn more about :ref:`good-commits`)
+
 Then push your work to your GitHub fork::
 
    git push origin <branch-name>
@@ -189,6 +191,33 @@ The automated patch check doesn't actually *answer* all of these
 questions. Aside from the whitespace checks, the tool is
 a memory aid for the various elements that can go into
 making a complete patch.
+
+
+.. _good-commits:
+
+Making Good Commits
+-------------------
+
+Each feature or bugfix should be addressed by a single pull request,
+and for each pull request there may be several commits.  In particular:
+
+* Do **not** fix more than one issue in the same commit (except,
+  of course, if one code change fixes all of them).
+* Do **not** do cosmetic changes to unrelated code in the same
+  commit as some feature/bugfix.
+
+Commit messages should follow the following structure::
+
+   bpo-42: the spam module is now more spammy.
+
+   The spam module sporadically came up short on spam. This change
+   raises the amount of spam in the module by making it more spammy.
+
+The first line or sentence is meant to be a dense, to-the-point explanation
+of what the purpose of the commit is.  If this is not enough detail for a
+commit, a new paragraph(s) can be added to explain in proper depth what has
+happened (detail should be good enough that a core developer reading the
+commit message understands the justification for the change).
 
 
 .. _cla:

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -50,21 +50,6 @@ Fifth, proper :ref:`documentation <documenting>`
 additions/changes should be included.
 
 
-.. _patch-generation:
-
-Generation
-''''''''''
-
-To perform a quick sanity check on your changes, you can run::
-
-   make patchcheck
-
-This will check and/or fix various common things people forget to do for
-pull requests, such as adding any new files needed for the pull request to work
-(note that not all checks apply to non-core developers).  On Windows, use this
-command (after any successful build of Python)::
-
-   python.bat Tools/scripts/patchcheck.py
 
 .. _pullrequest-quickguide:
 
@@ -82,7 +67,7 @@ Here is a quick overview of how you can contribute to CPython:
 
 #. Work on changes (e.g. fix a bug or add a new feature)
 
-#. :ref:`Run tests <runtests>` again
+#. :ref:`Run tests <runtests>` and ``make patchcheck``
 
 #. :ref:`Commit <commit-changes>` and :ref:`push <push-changes>`
    changes to your GitHub fork
@@ -121,9 +106,12 @@ Create a new branch in your local clone::
 
 Make changes to the code, and use ``git status`` and ``git diff`` to see them.
 
-Make sure the changes you made don't cause any test failure::
+Make sure the changes are fine and don't cause any test failure::
 
+   make patchcheck
    ./python -m test
+
+(Learn more about :ref:`patchcheck` and about :doc:`runtests`)
 
 Once you are satisfied with the changes, add the files and commit them::
 
@@ -162,6 +150,42 @@ After your PR has been accepted and merged, you can :ref:`delete the branch <del
 .. note::
    You can still upload a patch to bugs.python.org_, but the GitHub pull request
    workflow is **strongly** preferred.
+
+
+.. _patchcheck:
+
+``patchcheck``
+''''''''''''''
+
+``patchcheck`` is a simple automated patch checklist that guides a developer
+through the common patch generation checks. To run ``patchcheck``:
+
+   On *UNIX* (including Mac OS X)::
+
+      make patchcheck
+
+   On *Windows* (after any successful build)::
+
+      python.bat Tools/scripts/patchcheck.py
+
+The automated patch checklist runs through:
+
+* Are there any whitespace problems in Python files?
+  (using ``Tools/scripts/reindent.py``)
+* Are there any whitespace problems in C files?
+* Are there any whitespace problems in the documentation?
+  (using ``Tools/scripts/reindent-rst.py``)
+* Has the documentation been updated?
+* Has the test suite been updated?
+* Has an entry under ``Misc/NEWS.d/next`` been added?
+* Has ``Misc/ACKS`` been updated?
+* Has ``configure`` been regenerated, if necessary?
+* Has ``pyconfig.h.in`` been regenerated, if necessary?
+
+The automated patch check doesn't actually *answer* all of these
+questions. Aside from the whitespace checks, the tool is
+a memory aid for the various elements that can go into
+making a complete patch.
 
 
 .. _cla:

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -100,24 +100,13 @@ Quick Guide
 `Clear communication`_ is key to contributing to any project, especially an
 `Open Source`_ project like CPython.
 
-Here is a quick overview of how you can contribute to CPython on GitHub:
+Here is a quick overview of how you can contribute to CPython:
 
-#. If an issue doesn't exist, `create an Issue`_ that describes your change.
-   Trivial issues (e.g. typo fixes) do not require any issue to be created.
+#. `Create an issue`_ that describes your change [*]_
 
-#. :ref:`Get started <setup>` and set up your system
+#. :ref:`Create a new branch in Git <pullrequest-steps>`
 
-#. :ref:`Fork CPython <fork-cpython>` (using the Fork button in the
-   upper-right on GitHub)
-
-#. :ref:`Clone your GitHub fork and add an "upstream" remote <clone-your-fork>`
-
-#. :ref:`Build Python <compiling>` on your system
-
-#. :ref:`Run tests <runtests>` after you have built Python
-
-#. :ref:`Create a Branch in Git <pullrequest-steps>` where you can work on
-   changes
+#. Work on changes (e.g. fix a bug or add a new feature)
 
 #. :ref:`Run tests <runtests>` again
 
@@ -132,9 +121,12 @@ Here is a quick overview of how you can contribute to CPython on GitHub:
 
 #. Celebrate contributing to CPython! :)
 
+.. [*] If an issue is trivial (e.g. typo fixes), or if an issue already exists,
+       you can skip this step.
+
 .. _Clear communication: https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
 .. _Open Source: https://opensource.guide/
-.. _create an Issue: https://bugs.python.org/
+.. _create an issue: https://bugs.python.org/
 .. _CPython: https://github.com/python/cpython
 .. _use HTTPS: https://help.github.com/articles/which-remote-url-should-i-use/
 .. _Create Pull Request: https://help.github.com/articles/creating-a-pull-request/
@@ -143,40 +135,55 @@ Here is a quick overview of how you can contribute to CPython on GitHub:
 
 .. _pullrequest-steps:
 
-Quick Guide Step-by-step
-''''''''''''''''''''''''
+Step-by-step Guide
+''''''''''''''''''
 
-Set up your system (using SSH, or you can `use HTTPS`_)::
+You should have already :ref:`set up your system <setup>`,
+:ref:`got the source code <checkout>`, and :ref:`built Python <compiling>`.
 
-    git clone git@github.com:YOUR_GITHUB_ID/cpython.git
+Create a new branch in your local clone::
 
-Replace ``YOUR_GITHUB_ID`` with your GitHub account name above, then add
-main CPython repository as upstream::
+   git checkout -b <branch-name> upstream/master
 
-    git remote add upstream git://github.com/python/cpython.git
+Make changes to the code, and use ``git status`` and ``git diff`` to see them.
 
-Work on new features or fixes::
+Make sure the changes you made don't cause any test failure::
 
-    git checkout -b MY_BRANCH_NAME upstream/master
+   ./python -m test
 
-As you work, commit changes::
+Once you are satisfied with the changes, add the files and commit them::
 
-    git commit
+   git add <filenames>
+   git commit -m '<message>'
 
-Then fetch upstream to see if anything conflicts with your changes::
+Then push your work to your GitHub fork::
 
-    git fetch upstream
+   git push origin <branch-name>
 
-Then push your work to your clone on GitHub::
+If someone else added new changesets and you get an error::
 
-    git push origin MY_BRANCH_NAME
+   git fetch upstream
+   git rebase upstream/master
+   git push --force origin <branch-name>
 
-Make a pull request on GitHub from your changes in ``MY_BRANCH_NAME``.
+Finally go on :samp:`https://github.com/{<your-username>}/cpython`: you will
+see a box with the branch you just pushed and a green button that allows
+you to create a pull request against the official CPython repository.
+
+When people start adding review comments, you can address them by switching
+to your branch, making more changes, committing them, and pushing them to
+automatically update your PR::
+
+   git checkout <branch-name>
+   # make changes and run tests
+   git add <filenames>
+   git commit -m '<message>'
+   git push origin <branch-name>
 
 After your PR has been accepted and merged, you can :ref:`delete the branch <deleting_branches>`::
 
-   git branch -D MY_BRANCH_NAME  # delete local branch
-   git push origin -d MY_BRANCH_NAME  # delete remote branch
+   git branch -D <branch-name>  # delete local branch
+   git push origin -d <branch-name>  # delete remote branch
 
 .. note::
    You can still upload a patch to bugs.python.org_, but the GitHub pull request

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -13,44 +13,6 @@ to your fork on GitHub (``origin``), and then create a pull request against
 the official CPython repository (``upstream``).
 
 
-Preparation
-'''''''''''
-
-When creating a pull request for submission, there are several things that you
-should do to help ensure that your pull request is accepted.
-
-First, make sure to follow Python's style guidelines. For Python code you
-should follow :PEP:`8`, and for C code you should follow :PEP:`7`. If you have
-one or two discrepancies those can be fixed by the core developer who merges
-your pull request. But if you have systematic deviations from the style guides
-your pull request will be put on hold until you fix the formatting issues.
-
-Second, be aware of backwards-compatibility considerations. While the core
-developer who eventually handles your pull request will make the final call on
-whether something is acceptable, thinking about backwards-compatibility early
-will help prevent having your pull request rejected on these grounds. Put
-yourself in the shoes of someone whose code will be broken by the change(s)
-introduced by the pull request. It is quite likely that any change made will
-break someone's code, so you need to have a good reason to make a change as
-you will be forcing someone to update their code. (This obviously does not
-apply to new classes or functions; new arguments should be optional and have
-default values which maintain the existing behavior.) If in doubt, have a look
-at :PEP:`387` or :ref:`discuss <communication>` the issue with experienced
-developers.
-
-Third, make sure you have proper tests to verify your pull request works as
-expected. Pull requests will not be accepted without the proper tests!
-
-Fourth, make sure the entire test suite :ref:`runs <runtests>` **without
-failure** because of your changes.  It is not sufficient to only run whichever
-test seems impacted by your changes, because there might be interferences
-unknown to you between your changes and some other part of the interpreter.
-
-Fifth, proper :ref:`documentation <documenting>`
-additions/changes should be included.
-
-
-
 .. _pullrequest-quickguide:
 
 Quick Guide
@@ -106,6 +68,8 @@ Create a new branch in your local clone::
 
 Make changes to the code, and use ``git status`` and ``git diff`` to see them.
 
+(Learn more about :ref:`making good PRs <good-prs>`)
+
 Make sure the changes are fine and don't cause any test failure::
 
    make patchcheck
@@ -150,6 +114,45 @@ After your PR has been accepted and merged, you can :ref:`delete the branch <del
 .. note::
    You can still upload a patch to bugs.python.org_, but the GitHub pull request
    workflow is **strongly** preferred.
+
+
+.. _good-prs:
+
+Making good PRs
+'''''''''''''''
+
+When creating a pull request for submission, there are several things that you
+should do to help ensure that your pull request is accepted.
+
+First, make sure to follow Python's style guidelines. For Python code you
+should follow :PEP:`8`, and for C code you should follow :PEP:`7`. If you have
+one or two discrepancies those can be fixed by the core developer who merges
+your pull request. But if you have systematic deviations from the style guides
+your pull request will be put on hold until you fix the formatting issues.
+
+Second, be aware of backwards-compatibility considerations. While the core
+developer who eventually handles your pull request will make the final call on
+whether something is acceptable, thinking about backwards-compatibility early
+will help prevent having your pull request rejected on these grounds. Put
+yourself in the shoes of someone whose code will be broken by the change(s)
+introduced by the pull request. It is quite likely that any change made will
+break someone's code, so you need to have a good reason to make a change as
+you will be forcing someone to update their code. (This obviously does not
+apply to new classes or functions; new arguments should be optional and have
+default values which maintain the existing behavior.) If in doubt, have a look
+at :PEP:`387` or :ref:`discuss <communication>` the issue with experienced
+developers.
+
+Third, make sure you have proper tests to verify your pull request works as
+expected. Pull requests will not be accepted without the proper tests!
+
+Fourth, make sure the entire test suite :ref:`runs <runtests>` **without
+failure** because of your changes.  It is not sufficient to only run whichever
+test seems impacted by your changes, because there might be interferences
+unknown to you between your changes and some other part of the interpreter.
+
+Fifth, proper :ref:`documentation <documenting>`
+additions/changes should be included.
 
 
 .. _patchcheck:

--- a/setup.rst
+++ b/setup.rst
@@ -50,13 +50,13 @@ Getting the Source Code
 
 In order to get a copy of the source code you should :ref:`fork the
 Python repository on GitHub <fork-cpython>`, :ref:`create a local
-clone of your private fork, and configure the remotes <clone-your-fork>`.
+clone of your personal fork, and configure the remotes <clone-your-fork>`.
 
 You will only need to execute these steps once:
 
 1. Go to https://github.com/python/cpython.
 
-2. Press ``Fork`` on the top right.
+2. Press :guilabel:`Fork` on the top right.
 
 3. When asked where to fork the repository, choose to fork it to your username.
 

--- a/setup.rst
+++ b/setup.rst
@@ -34,22 +34,58 @@ installation directions. You may also want to consider a graphical client
 such as `TortoiseGit <https://tortoisegit.org/>`_ or
 `GitHub Desktop <https://desktop.github.com/>`_.
 
-You may also wish to set up :ref:`your name and email <set-up-name-email>`
-and `an SSH key
+Once you installed Git, you should set up
+:ref:`your name and email <set-up-name-email>` and `an SSH key
 <https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/>`_
 as this will allow you to interact with GitHub without typing a username
 and password each time you execute a command, such as ``git pull``,
 ``git push``, or ``git fetch``.  On Windows, you should also
 :ref:`enable autocrlf <autocrlf>`.
 
+
 .. _checkout:
 
 Getting the Source Code
 -----------------------
 
-In order to get a copy of the source code you should first :ref:`fork the
-Python repository on GitHub <fork-cpython>` and then :ref:`create a local
-clone of your private fork and configure the remotes <clone-your-fork>`.
+In order to get a copy of the source code you should :ref:`fork the
+Python repository on GitHub <fork-cpython>`, :ref:`create a local
+clone of your private fork, and configure the remotes <clone-your-fork>`.
+
+You will only need to execute these steps once:
+
+1. Go to https://github.com/python/cpython.
+
+2. Press ``Fork`` on the top right.
+
+3. When asked where to fork the repository, choose to fork it to your username.
+
+4. Your fork will be created at :samp:`https://github.com/{<username>}/cpython`.
+
+5. Clone your GitHub fork (replace ``<username>`` with your username)::
+
+      $ git clone git@github.com:<username>/cpython.git
+
+   (You can use both SSH-based or HTTPS-based URLs.)
+
+6. Configure an ``upstream`` remote::
+
+      $ cd cpython
+      $ git remote add upstream git@github.com:python/cpython.git
+
+7. Verify that your setup is correct::
+
+      $ git remote -v
+      origin  git@github.com:<your-username>/devguide.git (fetch)
+      origin  git@github.com:<your-username>/devguide.git (push)
+      upstream        git@github.com:python/devguide.git (fetch)
+      upstream        git@github.com:python/devguide.git (push)
+
+If you did everything correctly, you should now have a copy of the code
+in the ``cpython`` dir and two remotes that refer to your own GitHub fork
+(``origin``) and the official CPython repository (``upstream``).
+
+.. XXX move the text below in pullrequest
 
 If you want a working copy of an already-released version of Python,
 i.e., a version in :ref:`maintenance mode <maintbranch>`, you can checkout


### PR DESCRIPTION
This is part of #120, and it builds on #263. The goal of this PR is to reorganize the setup and pullrequest pages.

The end result will be:

* The setup page will include all the necessary information for the initial setup.  This will need to be done once.
*  The pullrequest page will include all the steps from creating a branch to getting it merged in CPython.