### PR TITLE
Build in a virtual environment on Windows (#267)

### DIFF
--- a/docquality.rst
+++ b/docquality.rst
@@ -86,12 +86,31 @@ To build the devguide, some additional dependencies are required (most
 importantly, `Sphinx`_), and the standard way to install dependencies in
 Python projects is to create a virtualenv, and then install dependencies from
 a ``requirements.txt`` file. For your convenience, this is all *automated for
-you* and all you have to do to build the devguide is run::
+you*.
+
+On a Unix-like system all you have to do to build the devguide is run::
 
     $ make html
 
 in the checkout directory, which will write the files to the ``_build/html``
-directory.  Note that ``make check`` is automatically run when
+directory.
+
+On Windows the command is:
+
+..  code-block:: doscon
+
+    > .\make html
+
+in the checkout directory, and again this will write the files to the
+``_build\html`` directory.
+If you are running PowerShell, you may have to enable unsigned local scripts to
+run, with the command (used once only):
+
+..  code-block:: ps1con
+
+    PS> Set-ExecutionPolicy -Scope CurrentUser RemoteSigned
+
+Note that ``make check`` is automatically run when
 you submit a :doc:`pull request <pullrequest>`, so you should make
 sure that it runs without errors.
 

--- a/docquality.rst
+++ b/docquality.rst
@@ -86,30 +86,17 @@ To build the devguide, some additional dependencies are required (most
 importantly, `Sphinx`_), and the standard way to install dependencies in
 Python projects is to create a virtualenv, and then install dependencies from
 a ``requirements.txt`` file. For your convenience, this is all *automated for
-you*.
-
-On a Unix-like system all you have to do to build the devguide is run::
+you*. To build the devguide on a Unix-like system use::
 
     $ make html
 
-in the checkout directory, which will write the files to the ``_build/html``
-directory.
-
-On Windows the command is:
+in the checkout directory. On Windows use:
 
 ..  code-block:: doscon
 
     > .\make html
 
-in the checkout directory, and again this will write the files to the
-``_build\html`` directory.
-If you are running PowerShell, you may have to enable unsigned local scripts to
-run, with the command (used once only):
-
-..  code-block:: ps1con
-
-    PS> Set-ExecutionPolicy -Scope CurrentUser RemoteSigned
-
+You will find the generated files in ``_build/html``.
 Note that ``make check`` is automatically run when
 you submit a :doc:`pull request <pullrequest>`, so you should make
 sure that it runs without errors.

--- a/make.bat
+++ b/make.bat
@@ -47,7 +47,9 @@ if "%1" == "clean" (
 	goto end
 )
 
-rem If we get this far, we're going to use the SPHINXBUILD command
+rem Targets other than "clean", "check", "serve", "help", or "" need the
+rem Sphinx build command, which the user may define via SPHINXBUILD.
+
 if not defined SPHINXBUILD (
 	rem If it is not defined, we build in a virtual environment
 	if not exist venv (

--- a/make.bat
+++ b/make.bat
@@ -4,6 +4,8 @@ REM Command file for Sphinx documentation
 
 setlocal
 
+pushd %~dp0
+
 if "%PYTHON%" == "" (
 	set PYTHON=py -3
 )
@@ -198,4 +200,5 @@ cmd /C %PYTHON% tools\serve.py %BUILDDIR%\html
 goto end
 
 :end
+popd
 endlocal

--- a/make.bat
+++ b/make.bat
@@ -2,12 +2,12 @@
 
 REM Command file for Sphinx documentation
 
+setlocal
+
 if "%PYTHON%" == "" (
 	set PYTHON=py -3
 )
-if "%SPHINXBUILD%" == "" (
-	set SPHINXBUILD=sphinx-build
-)
+
 set BUILDDIR=_build
 set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% .
 if NOT "%PAPER%" == "" (
@@ -18,7 +18,7 @@ if "%1" == "" goto help
 if "%1" == "check" goto check
 if "%1" == "serve" goto serve
 
-if "%1" == "help" (
+if NOT "%1" == "help" goto help0
 	:help
 	echo.Please use `make ^<target^>` where ^<target^> is one of
 	echo.  html       to make standalone HTML files
@@ -39,12 +39,25 @@ if "%1" == "help" (
 	echo.  check
 	echo.  serve      to serve devguide on the localhost (8000)
 	goto end
-)
+:help0
 
 if "%1" == "clean" (
 	for /d %%i in (%BUILDDIR%\*) do rmdir /q /s %%i
 	del /q /s %BUILDDIR%\*
 	goto end
+)
+
+rem If we get this far, we're going to use the SPHINXBUILD command
+if not defined SPHINXBUILD (
+	rem If it is not defined, we build in a virtual environment
+	if not exist venv (
+		echo.    Setting up the virtual environment
+		%PYTHON% -m venv venv
+		echo.    Installing requirements
+		venv\Scripts\python -m pip install -r requirements.txt
+	)
+	set PYTHON=venv\Scripts\python
+	set SPHINXBUILD=venv\Scripts\sphinx-build
 )
 
 if "%1" == "html" (
@@ -183,3 +196,4 @@ cmd /C %PYTHON% tools\serve.py %BUILDDIR%\html
 goto end
 
 :end
+endlocal

--- a/make.bat
+++ b/make.bat
@@ -16,11 +16,11 @@ if NOT "%PAPER%" == "" (
 	set ALLSPHINXOPTS=-D latex_paper_size=%PAPER% %ALLSPHINXOPTS%
 )
 
-if "%1" == "" goto help
 if "%1" == "check" goto check
 if "%1" == "serve" goto serve
 
-if NOT "%1" == "help" goto help0
+if "%1" == "" goto help
+if "%1" == "help" (
 	:help
 	echo.Please use `make ^<target^>` where ^<target^> is one of
 	echo.  html       to make standalone HTML files
@@ -38,10 +38,10 @@ if NOT "%1" == "help" goto help0
 	echo.  changes    to make an overview over all changed/added/deprecated items
 	echo.  linkcheck  to check all external links for integrity
 	echo.  doctest    to run all doctests embedded in the documentation if enabled
-	echo.  check
-	echo.  serve      to serve devguide on the localhost (8000)
+	echo.  check      to check for stylistic and formal issues using rstlint
+	echo.  serve      to serve devguide on the localhost ^(8000^)
 	goto end
-:help0
+)
 
 if "%1" == "clean" (
 	for /d %%i in (%BUILDDIR%\*) do rmdir /q /s %%i


### PR DESCRIPTION
Add to the Windows build script a clause to create and use a virtual
environment and install Sphinx there, comparable with the Unix Makefile.
The user may suppress this behaviour by defining a her preferred command
in the environment variable SPHINXBUILD, as before.