### PR TITLE
Improve instructions on commit messages

### DIFF
--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -334,8 +334,7 @@ Pull requests can be accepted and merged by a Python Core Developer.
    button.
 
 2. Replace the reference to GitHub PR #XXX into GH-XXX. If the title
-   too long, add the Pull request to the end of the body as:
-   Pull request: GH-NNN
+   is too long, the pull request number can be added to the body.
 
 3. Adjust and clean up the commit message.
 

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -333,7 +333,7 @@ Pull requests can be accepted and merged by a Python Core Developer.
 1. At the bottom of the pull request page, click the ``Squash and merge``
    button.
 
-2. Replace the reference to GitHub PR #XXX into GH-XXX. If the title
+2. Replace the reference to GitHub PR #NNNN into GH-NNNN. If the title
    is too long, the pull request number can be added to the body.
 
 3. Adjust and clean up the commit message.

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -323,6 +323,8 @@ local copy of a pull request as follows::
    $ git pr <pr_number>
 
 
+.. _accepting-and-merging-a-pr:
+
 Accepting and Merging A Pull Request
 ------------------------------------
 

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -383,6 +383,16 @@ Alternatively, the commit hash can also be obtained by the following git command
 The above commands will print out the hash of the commit containing ``"bpo-12345"``
 as part of the commit message.
 
+When formatting the message for a backport commit: leave it as the the original
+one, pointing to the original pull request number as well (GH-NNN).
+
+Example of good backport commit message::
+
+    bpo-12345: Improve the spam module (GH-777)
+
+    * Add method A to the spam module
+    * Update the documentation of the spam module
+
 
 Editing a Pull Request Prior to Merging
 ---------------------------------------

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -386,7 +386,7 @@ The above commands will print out the hash of the commit containing ``"bpo-12345
 as part of the commit message.
 
 When formatting the message for a backport commit: leave it as the the original
-one, pointing to the original pull request number as well (GH-NNN).
+one, pointing to the original pull request number as well (``GH-NNNN``).
 
 Example of good backport commit message::
 

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -333,7 +333,9 @@ Pull requests can be accepted and merged by a Python Core Developer.
 1. At the bottom of the pull request page, click the ``Squash and merge``
    button.
 
-2. Replace the reference to GitHub PR #XXX into GH-XXX.
+2. Replace the reference to GitHub PR #XXX into GH-XXX. If the title
+   too long, add the Pull request to the end of the body as:
+   Pull request: GH-NNN
 
 3. Adjust and clean up the commit message.
 

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -221,7 +221,7 @@ commit, a new paragraph(s) can be added to explain in proper depth what has
 happened (detail should be good enough that a core developer reading the
 commit message understands the justification for the change).
 
-Check :ref:`the git bootcamp<accepting-and-merging-a-pr>` for further
+Check :ref:`the git bootcamp <accepting-and-merging-a-pr>` for further
 instructions on how the commit should look like when merging a pull request.
 
 

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -210,7 +210,7 @@ and for each pull request there may be several commits.  In particular:
 
 Commit messages should follow the following structure::
 
-   bpo-42: the spam module is now more spammy.
+   bpo-42: the spam module is now more spammy. (GH-NNNN)
 
    The spam module sporadically came up short on spam. This change
    raises the amount of spam in the module by making it more spammy.

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -221,6 +221,9 @@ commit, a new paragraph(s) can be added to explain in proper depth what has
 happened (detail should be good enough that a core developer reading the
 commit message understands the justification for the change).
 
+Check :ref:`the git bootcamp<accepting-and-merging-a-pr>` for further
+instructions on how the commit should look like when merging a pull request.
+
 
 .. _cla:
 


### PR DESCRIPTION
This PR contains the changes as proposed in https://github.com/python/devguide/issues/199.

There are two questions for the backport:

- Should we put the branch? [X.Y]: from the last comment it seems we don't want to but most commits have it at the moment. This PR assumes we don't want to.
- Should we have any reference to the backport PR? This PR assumes the answer is no.

First time contributing to devguide. Happy to change wording/structure/whatever as appropriate 😄 

I've split the change into four commits to follow the structure of the issue but probably makes more sense to squash them together (maybe at merge time?)

Solves #199 