### PR TITLE
Add links to promote reviews by non core-developers

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -189,7 +189,7 @@ Guide for contributing to Python:
 * Advanced tasks for once you are comfortable
     * :doc:`silencewarnings`
     * Fixing issues found by the :doc:`buildbots <buildbots>`
-    * Helping out with `Open Reviews`_.
+    * Helping out with reviewing `open pull requests`_.
       See :ref:`how to review a Pull Request <how-to-review-a-pull-request>`.
     * :doc:`fixingissues`
 * :ref:`tracker` and :ref:`helptriage`

--- a/index.rst
+++ b/index.rst
@@ -189,6 +189,8 @@ Guide for contributing to Python:
 * Advanced tasks for once you are comfortable
     * :doc:`silencewarnings`
     * Fixing issues found by the :doc:`buildbots <buildbots>`
+    * Helping out with `Open Reviews`_.
+      See :ref:`how to review a Pull Request <how-to-review-a-pull-request>`.
     * :doc:`fixingissues`
 * :ref:`tracker` and :ref:`helptriage`
     * :doc:`triaging`
@@ -354,3 +356,4 @@ Full Table of Contents
 .. _IronPython: http://ironpython.net/
 .. _Stackless: http://www.stackless.com/
 .. _Issue tracker: https://bugs.python.org/
+.. _Open Reviews: https://github.com/python/cpython/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Aopen%20label%3A%22awaiting%20review%22

--- a/index.rst
+++ b/index.rst
@@ -356,4 +356,4 @@ Full Table of Contents
 .. _IronPython: http://ironpython.net/
 .. _Stackless: http://www.stackless.com/
 .. _Issue tracker: https://bugs.python.org/
-.. _Open Reviews: https://github.com/python/cpython/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Aopen%20label%3A%22awaiting%20review%22
+.. _open pull requests: https://github.com/python/cpython/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Aopen%20label%3A%22awaiting%20review%22

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -342,6 +342,9 @@ back to them for changes).  It is then expected that you update your
 pull request to address these comments, and the review process will
 thus iterate until a satisfactory solution has emerged.
 
+.. _how-to-review-a-pull-request:
+
+
 How to Review a Pull Request
 ''''''''''''''''''''''''''''
 


### PR DESCRIPTION
Add a link to the open PR with tag [`awaiting-review`](https://github.com/python/cpython/pulls?q=is%3Apr+is%3Aopen+label%3A%22awaiting+review%22) and another one pointing to [how to review pull requests](https://docs.python.org/devguide/pullrequest.html#how-to-review-a-pull-request).

The objective is to try to promote non-core developers to help out with the reviews as stated in #194

Closes #194