### PR TITLE
Don't recommend single backticks in news files

### DIFF
--- a/committing.rst
+++ b/committing.rst
@@ -178,18 +178,13 @@ standard library). The file name itself should be of the format
 So a file name may be
 ``Misc/NEWS.d/next/Library/2017-05-27.bpo-12345.Yl4gI2.rst``.
 
-The contents of a news file should be valid reStructuredText. The "default role"
-(single backticks) in reST can be used to refer to objects in the documentation.
-An 80 character column width should be used. There is no indentation or leading
-marker in the file (e.g. ``-``). There is also no need to start the entry with
-the issue number as it's part of the file name itself. Example news entry::
+The contents of a news file should be valid reStructuredText. An 80 character
+column width should be used. There is no indentation or leading marker in the
+file (e.g. ``-``). There is also no need to start the entry with the issue
+number as it's part of the file name itself. Example news entry::
 
-  Fix warning message when `os.chdir()` fails inside
-  `test.support.temp_cwd()`.  Patch by Chris Jerdonek.
-
-(In other ``.rst`` files the single backticks should not be used.  They are
-allowed here because news entries are meant to be as readable as possible
-unprocessed.)
+  Fix warning message when ``os.chdir()`` fails inside
+  ``test.support.temp_cwd()``.  Patch by Chris Jerdonek.
 
 
 Working with Git_


### PR DESCRIPTION
* It's not a best practice
* It doesn't make news files more readable
* It's easy to confuse its syntax with Markdown
* And it adds unnecessary steps to contributing process.
  Contributors shouldn't have to remember which style should be
  used in news files and the rest of the documentation.
* Sphinx's default_role setting defaults to None
  (http://www.sphinx-doc.org/en/stable/config.html#confval-default_role)
  and neither Doc/conf.py nor blurb set it explicitly so the meaning of
  default_role can change in future releases of Sphinx.