### PR TITLE
Limit line length to 80 & clean-up nearby formatting.

### DIFF
--- a/buildbots.rst
+++ b/buildbots.rst
@@ -4,8 +4,8 @@ Continuous Integration
 ======================
 
 To assert that there are no regressions in the :doc:`development and maintenance
-branches <devcycle>`, Python has a set of dedicated machines (called *buildbots* or
-*build slaves*) used for continuous integration.  They span a number of
+branches <devcycle>`, Python has a set of dedicated machines (called *buildbots*
+or *build slaves*) used for continuous integration.  They span a number of
 hardware/operating system combinations.  Furthermore, each machine hosts
 several *builders*, one per active branch: when a new change is pushed
 to this branch on the public Mercurial repository, all corresponding builders
@@ -186,8 +186,8 @@ offenders:
 When you think a failure might be transient, it is recommended you confirm by
 waiting for the next build.  Still, even if the failure does turn out sporadic
 and unpredictable, the issue should be reported on the bug tracker; even
-better if it can be diagnosed and suppressed by fixing the test's implementation,
-or by making its parameters - such as a timeout - more robust.
+better if it can be diagnosed and suppressed by fixing the test's
+implementation, or by making its parameters - such as a timeout - more robust.
 
 
 Custom builders

--- a/committing.rst
+++ b/committing.rst
@@ -212,12 +212,12 @@ repositories means you have to be more careful with your workflow:
   This exception should not be abused and be left only for very simple changes.
 
 * You should not commit directly into the ``master`` branch, or any of the
-  maintenance branches (currently ``2.7`` or ``3.6``).  You should commit against
-  your own feature branch, and create a pull request.
+  maintenance branches (currently ``2.7`` or ``3.6``).
+  You should commit against your own feature branch, and create a pull request.
 
-It is recommended to keep a fork of the main repository around, as it allows simple
-reversion of all local changes (even "committed" ones) if your local clone gets
-into a state you aren't happy with.
+It is recommended to keep a fork of the main repository around, as it allows
+simple reversion of all local changes (even "committed" ones) if your local
+clone gets into a state you aren't happy with.
 
 
 .. _Git: https://git-scm.com/
@@ -238,15 +238,17 @@ new features.  The other branches only receive bug fixes or security fixes.
 Backporting Changes to an Older Version
 ---------------------------------------
 
-When it is determined that a pull request needs to be backported into one or more of
-the maintenance branches, a core developer can apply the labels ``needs backport to X.Y``
-to the pull request.
+When it is determined that a pull request needs to be backported into one or
+more of the maintenance branches, a core developer can apply the labels
+``needs backport to X.Y`` to the pull request.
 
-After the pull request has been merged, it can be backported using cherry_picker.py_.
+After the pull request has been merged, it can be backported using
+cherry_picker.py_.
 
-The commit hash can be obtained from the original pull request, or by using ``git log``
-on the ``master`` branch.  To display the 10 most recent commit hashes and their first
-line of the commit message::
+The commit hash can be obtained from the original pull request, or by using
+``git log`` on the ``master`` branch.
+To display the 10 most recent commit hashes and their first line of the commit
+message::
 
    git log -10 --oneline
 

--- a/communication.rst
+++ b/communication.rst
@@ -26,10 +26,10 @@ Python-ideas_ is a mailing list open to the public to discuss ideas on changing
 Python. If a new idea does not start here (or python-list_, discussed below),
 it will get redirected here.
 
-Sometimes people post new ideas to python-list_ to gather community opinion before
-heading to python-ideas_. The list is also sometimes known as comp.lang.python,
-the name of the newsgroup it mirrors (it is also known by the abbreviation
-c.l.py).
+Sometimes people post new ideas to python-list_ to gather community opinion
+before heading to python-ideas_. The list is also sometimes known as
+comp.lang.python, the name of the newsgroup it mirrors (it is also known by
+the abbreviation c.l.py).
 
 The python-committers_ mailing list is a private mailing list for core
 developers (the archives are publicly available).

--- a/compiler.rst
+++ b/compiler.rst
@@ -170,11 +170,11 @@ very beginning of the compiler or the end, you need to care about how the arena
 works.  All code relating to the arena is in either :file:`Include/pyarena.h` or
 :file:`Python/pyarena.c`.
 
-``PyArena_New()`` will create a new arena.  The returned ``PyArena`` structure will
-store pointers to all memory given to it.  This does the bookkeeping of what
-memory needs to be freed when the compiler is finished with the memory it used.
-That freeing is done with ``PyArena_Free()``.  This only needs to be called in
-strategic areas where the compiler exits.
+``PyArena_New()`` will create a new arena.  The returned ``PyArena`` structure
+will store pointers to all memory given to it.  This does the bookkeeping of
+what memory needs to be freed when the compiler is finished with the memory it
+used. That freeing is done with ``PyArena_Free()``.  This only needs to be
+called in strategic areas where the compiler exits.
 
 As stated above, in general you should not have to worry about memory
 management when working on the compiler.  The technical details have been
@@ -367,8 +367,8 @@ bytecode step of the compiler.  Several pieces of code throughout Python depend
 on having correct information about what bytecode exists.
 
 First, you must choose a name and a unique identifier number.  The official
-list of bytecode can be found in :file:`Include/opcode.h`.  If the opcode is to take
-an argument, it must be given a unique number greater than that assigned to
+list of bytecode can be found in :file:`Include/opcode.h`.  If the opcode is to
+take an argument, it must be given a unique number greater than that assigned to
 ``HAVE_ARGUMENT`` (as found in :file:`Include/opcode.h`).
 
 Once the name/number pair has been chosen and entered in Include/opcode.h,
@@ -376,14 +376,15 @@ you must also enter it into :file:`Lib/opcode.py` and
 :file:`Doc/library/dis.rst`.
 
 With a new bytecode you must also change what is called the magic number for
-.pyc files.  The variable ``MAGIC`` in :file:`Python/import.c` contains the number.
+.pyc files.  The variable ``MAGIC`` in :file:`Python/import.c` contains the
+number.
 Changing this number will lead to all .pyc files with the old ``MAGIC``
 to be recompiled by the interpreter on import.
 
 Finally, you need to introduce the use of the new bytecode.  Altering
 :file:`Python/compile.c` and :file:`Python/ceval.c` will be the primary places
-to change. But you will also need to change the 'compiler' package.  The key files
-to do that are :file:`Lib/compiler/pyassem.py` and
+to change. But you will also need to change the 'compiler' package.
+The key files to do that are :file:`Lib/compiler/pyassem.py` and
 :file:`Lib/compiler/pycodegen.py`.
 
 If you make a change here that can affect the output of bytecode that
@@ -392,10 +393,10 @@ sure to delete your old .py(c|o) files!  Even though you will end up changing
 the magic number if you change the bytecode, while you are debugging your work
 you will be changing the bytecode output without constantly bumping up the
 magic number.  This means you end up with stale .pyc files that will not be
-recreated.  Running
-``find . -name '*.py[co]' -exec rm -f {} ';'`` should delete all .pyc files you
-have, forcing new ones to be created and thus allow you test out your new
-bytecode properly.
+recreated.
+Running ``find . -name '*.py[co]' -exec rm -f {} ';'`` should delete all .pyc
+files you have, forcing new ones to be created and thus allow you test out your
+new bytecode properly.
 
 
 Code Objects

--- a/devcycle.rst
+++ b/devcycle.rst
@@ -164,11 +164,11 @@ bug fixes can now be committed.  This is when core developers should concentrate
 on the task of fixing regressions and other new issues filed by users who have
 downloaded the alpha and beta releases.
 
-Being in beta can be viewed much like being in RC_ but without the extra overhead
-of needing commit reviews.
+Being in beta can be viewed much like being in RC_ but without the extra
+overhead of needing commit reviews.
 
-Please see the note in the `In-development (main) branch`_ section above
-for new information about the creation of the 3.5 maintenance branch during beta.
+Please see the note in the `In-development (main) branch`_ section above for
+new information about the creation of the 3.5 maintenance branch during beta.
 
 
 .. _rc:
@@ -179,8 +179,8 @@ Release Candidate (RC)
 A branch preparing for an RC release can only have bugfixes applied that have
 been reviewed by other core developers.  Generally, these issues must be
 severe enough (e.g. crashes) that they deserve fixing before the final release.
-All other issues should be deferred to the next development cycle, since stability
-is the strongest concern at this point.
+All other issues should be deferred to the next development cycle, since
+stability is the strongest concern at this point.
 
 You **cannot** skip the peer review during an RC, no matter how small! Even if
 it is a simple copy-and-paste change, **everything** requires peer review from

--- a/developers.rst
+++ b/developers.rst
@@ -14,9 +14,9 @@ change or granted access.  The procedure for adding or removing users is
 described in :ref:`altering-access`.
 
 Note, when giving new commit permissions, be sure to get a contributor agreement
-from the committer.  See https://www.python.org/psf/contrib/ for details.  Commit
-privileges should not be given until the contributor agreement has been signed
-and received.
+from the committer.  See https://www.python.org/psf/contrib/ for details.
+Commit privileges should not be given until the contributor agreement has been
+signed and received.
 
 This file is encoded in UTF-8.  If the usual form for a name is not in
 a Latin or extended Latin alphabet, make sure to include an ASCII

--- a/docquality.rst
+++ b/docquality.rst
@@ -8,7 +8,8 @@ keeping a high level of quality takes a lot of effort. Help is always
 appreciated with the documentation, and it requires little programming
 experience (with or without Python).
 
-:ref:`Documenting Python <documenting>` covers the details of how Python's documentation works.
+:ref:`Documenting Python <documenting>` covers the details of how Python's
+documentation works.
 It includes an explanation of the markup used (although you can figure a lot
 out simply by looking at pre-existing documentation) and :ref:`how to build
 <building-doc>` the documentation (which allows you to see how your changes
@@ -25,8 +26,8 @@ subscribing to the
 Documentation issues reported on the `issue tracker`_ are sent here as well as
 some bug reports being directly emailed to the mailing list. There is also the
 `docs-sig@python.org mailing list
-<https://mail.python.org/mailman/listinfo/doc-sig>`_ which discusses the
-documentation toolchain, projects, standards, etc.
+<https://mail.python.org/mailman/listinfo/doc-sig>`_
+which discusses the documentation toolchain, projects, standards, etc.
 
 
 Helping with issues filed on the issue tracker
@@ -38,10 +39,10 @@ typos, to unclear documentation, to something completely lacking documentation.
 
 If you decide to tackle a documentation issue, you can simply submit a
 :doc:`pull request <pullrequest>` for the issue. If you are worried that someone
-else might be working simultaneously on the issue, simply leave a comment on the issue
-saying you are going to try and create a pull request and roughly how long you think
-you will take to do it (this allows others to take on the issue if you happen
-to forget or lose interest).
+else might be working simultaneously on the issue, simply leave a comment on the
+issue saying you are going to try and create a pull request and roughly how long
+you think you will take to do it (this allows others to take on the issue if you
+happen to forget or lose interest).
 
 .. _issue tracker: https://bugs.python.org
 .. _documentation issues: https://bugs.python.org/issue?%40search_text=&ignore=file%3Acontent&title=&%40columns=title&id=&%40columns=id&stage=&creation=&creator=&activity=&%40columns=activity&%40sort=activity&actor=&nosy=&type=&components=4&versions=&dependencies=&assignee=&keywords=&priority=&%40group=priority&status=1&%40columns=status&resolution=&nosy_count=&message_count=&%40pagesize=50&%40startwith=0&%40queryname=&%40old-queryname=&%40action=search
@@ -58,9 +59,10 @@ from Python 2).
 
 If you decide to proofread, then read a section of the documentation from start
 to finish, filing issues in the issue tracker for each problem you find. Simple
-typos don't require an issue of their own, instead submit a pull request directly.
-Don't file a single issue for an entire section containing multiple problems as that
-makes it harder to break the work up for multiple people to help with.
+typos don't require an issue of their own, instead submit a pull request
+directly.
+Don't file a single issue for an entire section containing multiple problems as
+that makes it harder to break the work up for multiple people to help with.
 
 
 .. _helping-with-the-developers-guide:

--- a/documenting.rst
+++ b/documenting.rst
@@ -457,7 +457,9 @@ the extension mechanisms of reST, and Sphinx makes heavy use of it.
 
 Basically, a directive consists of a name, arguments, options and content. (Keep
 this terminology in mind, it is used in the next chapter describing custom
-directives.)  Looking at this example,::
+directives.)  Looking at this example,
+
+::
 
    .. function:: foo(x)
                  foo(y, z)

--- a/documenting.rst
+++ b/documenting.rst
@@ -171,7 +171,8 @@ Bad example (creating worry in the mind of a reader):
     excessive resource consumption.  Never rely on reference counting to
     automatically close a file.
 
-Good example (establishing confident knowledge in the effective use of the language):
+Good example (establishing confident knowledge in the effective use of the
+language):
 
     A best practice for using files is use a try/finally pair to explicitly
     close a file after it is used.  Alternatively, using a with-statement can
@@ -222,8 +223,8 @@ a typical use case.  For instance, the :meth:`str.rpartition` method is better
 demonstrated with an example splitting the domain from a URL than it would be
 with an example of removing the last word from a line of Monty Python dialog.
 
-The ellipsis for the :py:data:`sys.ps2` secondary interpreter prompt should only be
-used sparingly, where it is necessary to clearly differentiate between input
+The ellipsis for the :py:data:`sys.ps2` secondary interpreter prompt should only
+be used sparingly, where it is necessary to clearly differentiate between input
 lines and output lines.  Besides contributing visual clutter, it makes it
 difficult for readers to cut-and-paste examples so they can experiment with
 variations.
@@ -456,7 +457,7 @@ the extension mechanisms of reST, and Sphinx makes heavy use of it.
 
 Basically, a directive consists of a name, arguments, options and content. (Keep
 this terminology in mind, it is used in the next chapter describing custom
-directives.)  Looking at this example, ::
+directives.)  Looking at this example,::
 
    .. function:: foo(x)
                  foo(y, z)
@@ -853,8 +854,8 @@ Syntax highlighting is handled in a smart way:
 
 Longer displays of verbatim text may be included by storing the example text in
 an external file containing only plain text.  The file may be included using the
-``literalinclude`` directive. [1]_ For example, to include the Python source file
-:file:`example.py`, use::
+``literalinclude`` directive. [1]_ For example, to include the Python source
+file :file:`example.py`, use::
 
    .. literalinclude:: example.py
 
@@ -895,8 +896,8 @@ a matching identifier is found:
 
 .. describe:: mod
 
-   The name of a module; a dotted name may be used.  This should also be used for
-   package names.
+   The name of a module; a dotted name may be used.  This should also be used
+   for package names.
 
 .. describe:: func
 
@@ -1358,8 +1359,8 @@ pair
    namely ``loop; statement`` and ``statement; loop``.
 triple
    Likewise, ``triple: module; search; path`` is a shortcut that creates three
-   index entries, which are ``module; search path``, ``search; path, module`` and
-   ``path; module search``.
+   index entries, which are ``module; search path``, ``search; path, module``
+   and ``path; module search``.
 module, keyword, operator, object, exception, statement, builtin
    These all create two index entries.  For example, ``module: hashlib``
    creates the entries ``module; hashlib`` and ``hashlib; module``.  The
@@ -1418,8 +1419,8 @@ The following is an example taken from the Python Reference Manual::
 Substitutions
 -------------
 
-The documentation system provides three substitutions that are defined by default.
-They are set in the build configuration file :file:`conf.py`.
+The documentation system provides three substitutions that are defined by
+default. They are set in the build configuration file :file:`conf.py`.
 
 .. describe:: |release|
 
@@ -1491,7 +1492,7 @@ Without make
 
 Install the Sphinx package and its dependencies from PyPI.
 
-Then, from the ``Docs`` directory, run ::
+Then, from the ``Docs`` directory, run::
 
    sphinx-build -b<builder> . build/<builder>
 

--- a/fixingissues.rst
+++ b/fixingissues.rst
@@ -5,9 +5,9 @@ Fixing "easy" Issues (and Beyond)
 
 When you feel comfortable enough to want to help tackle issues by trying to
 create a patch to fix an issue, you can start by looking at the `"easy"
-issues`_. These issues *should* be ones where it should take no longer than a day
-or weekend to fix. But because the "easy" classification is typically done at
-triage time it can turn out to be inaccurate, so do feel free to leave a
+issues`_. These issues *should* be ones where it should take no longer than a
+day or weekend to fix. But because the "easy" classification is typically done
+at triage time it can turn out to be inaccurate, so do feel free to leave a
 comment if you think the classification no longer applies.
 
 For the truly adventurous looking for a challenge, you can look for issues that

--- a/gdb.rst
+++ b/gdb.rst
@@ -49,8 +49,8 @@ enabled::
        {'Yuck': <type at remote 0xad4730>, '__builtins__': <module at remote 0x7ffff7fd5ee8>, '__file__': 'Lib/test/crashers/nasty_eq_vs_dict.py', '__package__': None, 'y': <Yuck(i=0) at remote 0xaacd80>, 'dict': {0: 0, 1: 1, 2: 2, 3: 3}, '__cached__': None, '__name__': '__main__', 'z': <Yuck(i=0) at remote 0xaace60>, '__doc__': None}, key=
        0x5c2b8d "__lltrace__") at Objects/dictobject.c:2171
 
-(notice how the dictionary argument to ``PyDict_GetItemString`` is displayed
-as its ``repr()``, rather than an opaque ``PyObject *`` pointer)
+(Notice how the dictionary argument to ``PyDict_GetItemString`` is displayed
+as its ``repr()``, rather than an opaque ``PyObject *`` pointer.)
 
 The extension works by supplying a custom printing routine for values of type
 ``PyObject *``.  If you need to access lower-level details of an object, then
@@ -114,11 +114,12 @@ Here's how to see the implementation details of a ``str`` instance (for Python
     $8 = {ob_base = {ob_refcnt = 33, ob_type = 0x3dad3a95a0}, length = 12,
     str = 0x7ffff2128500, hash = 7065186196740147912, state = 1, defenc = 0x0}
 
-As well as adding pretty-printing support for ``PyObject *``, the extension adds a number of commands to gdb
+As well as adding pretty-printing support for ``PyObject *``,
+the extension adds a number of commands to gdb:
 
 ``py-list``
-    List the Python source code (if any) for the current frame in the selected
-    thread.  The current line is marked with a ">"::
+   List the Python source code (if any) for the current frame in the selected
+   thread.  The current line is marked with a ">"::
 
         (gdb) py-list
          901        if options.profile:
@@ -133,24 +134,24 @@ As well as adding pretty-printing support for ``PyObject *``, the extension adds
          910            except KeyboardInterrupt:
          911                # properly quit on a keyboard interrupt...
 
-    Use ``py-list START`` to list at a different line number within the python
-    source, and ``py-list START,END`` to list a specific range of lines within
-    the python source.
+   Use ``py-list START`` to list at a different line number within the python
+   source, and ``py-list START,END`` to list a specific range of lines within
+   the python source.
 
 ``py-up`` and ``py-down``
-  The ``py-up`` and ``py-down`` commands are analogous to gdb's regular ``up``
-  and ``down`` commands, but try to move at the level of CPython frames, rather
-  than C frames.
+   The ``py-up`` and ``py-down`` commands are analogous to gdb's regular ``up``
+   and ``down`` commands, but try to move at the level of CPython frames, rather
+   than C frames.
 
-  gdb is not always able to read the relevant frame information, depending on
-  the optimization level with which CPython was compiled. Internally, the
-  commands look for C frames that are executing ``PyEval_EvalFrameEx`` (which
-  implements the core bytecode interpreter loop within CPython) and look up
-  the value of the related ``PyFrameObject *``.
+   gdb is not always able to read the relevant frame information, depending on
+   the optimization level with which CPython was compiled. Internally, the
+   commands look for C frames that are executing ``PyEval_EvalFrameEx`` (which
+   implements the core bytecode interpreter loop within CPython) and look up
+   the value of the related ``PyFrameObject *``.
 
-  They emit the frame number (at the C level) within the thread.
+   They emit the frame number (at the C level) within the thread.
 
-  For example::
+   For example::
 
         (gdb) py-up
         #37 Frame 0x9420b04, for file /usr/lib/python2.6/site-packages/
@@ -163,7 +164,7 @@ As well as adding pretty-printing support for ``PyObject *``, the extension adds
         (gdb) py-up
         Unable to find an older python frame
 
-  so we're at the top of the python stack.  Going back down::
+   so we're at the top of the python stack.  Going back down::
 
         (gdb) py-down
         #37 Frame 0x9420b04, for file /usr/lib/python2.6/site-packages/gnome_sudoku/main.py, line 906, in start_game ()
@@ -185,13 +186,13 @@ As well as adding pretty-printing support for ``PyObject *``, the extension adds
         (gdb) py-down
         Unable to find a newer python frame
 
-  and we're at the bottom of the python stack.
+   and we're at the bottom of the python stack.
 
 ``py-bt``
-  The ``py-bt`` command attempts to display a Python-level backtrace of the
-  current thread.
+   The ``py-bt`` command attempts to display a Python-level backtrace of the
+   current thread.
 
-  For example::
+   For example::
 
         (gdb) py-bt
         #8 (unable to read python frame information)
@@ -207,10 +208,13 @@ As well as adding pretty-printing support for ``PyObject *``, the extension adds
         #40 Frame 0x948e82c, for file /usr/lib/python2.6/site-packages/gnome_sudoku/gnome_sudoku.py, line 22, in start_game (main=<module at remote 0xb771b7f4>)
             main.start_game()
 
-  The frame numbers correspond to those displayed by gdb's standard ``backtrace`` command.
+   The frame numbers correspond to those displayed by gdb's standard
+   ``backtrace`` command.
 
 ``py-print``
-  The ``py-print`` command looks up a Python name and tries to print it.  It looks in locals within the current thread, then globals, then finally builtins::
+   The ``py-print`` command looks up a Python name and tries to print it.
+   It looks in locals within the current thread, then globals, then finally
+   builtins::
 
         (gdb) py-print self
         local 'self' = <SwappableArea(running=<gtk.Dialog at remote 0x98faaa4>,
@@ -223,14 +227,17 @@ As well as adding pretty-printing support for ``PyObject *``, the extension adds
         'scarlet_pimpernel' not found
 
 ``py-locals``
-  The ``py-locals`` command looks up all Python locals within the current Python frame in the selected thread, and prints their representations::
+   The ``py-locals`` command looks up all Python locals within the current
+   Python frame in the selected thread, and prints their representations::
 
         (gdb) py-locals
         self = <SwappableArea(running=<gtk.Dialog at remote 0x98faaa4>,
         main_page=0) at remote 0x98fa6e4>
         d = <gtk.Dialog at remote 0x98faaa4>
 
-You can of course use other gdb commands.  For example, the ``frame`` command takes you directly to a particular frame within the selected thread.  We can use it to go a specific frame shown by ``py-bt`` like this::
+You can of course use other gdb commands.  For example, the ``frame`` command
+takes you directly to a particular frame within the selected thread.
+We can use it to go a specific frame shown by ``py-bt`` like this::
 
         (gdb) py-bt
         (output snipped)
@@ -247,14 +254,17 @@ You can of course use other gdb commands.  For example, the ``frame`` command ta
         1547        with test_support.temp_cwd(TESTCWD, quiet=True):
         >1548            main()
 
-The ``info threads`` command will give you a list of the threads within the process, and you can use the ``thread`` command to select a different one::
+The ``info threads`` command will give you a list of the threads within the
+process, and you can use the ``thread`` command to select a different one::
 
         (gdb) info threads
           105 Thread 0x7fffefa18710 (LWP 10260)  sem_wait () at ../nptl/sysdeps/unix/sysv/linux/x86_64/sem_wait.S:86
           104 Thread 0x7fffdf5fe710 (LWP 10259)  sem_wait () at ../nptl/sysdeps/unix/sysv/linux/x86_64/sem_wait.S:86
         * 1 Thread 0x7ffff7fe2700 (LWP 10145)  0x00000038e46d73e3 in select () at ../sysdeps/unix/syscall-template.S:82
 
-You can use ``thread apply all COMMAND`` or (``t a a COMMAND`` for short) to run a command on all threads.  You can use this with ``py-bt`` to see what every thread is doing at the Python level::
+You can use ``thread apply all COMMAND`` or (``t a a COMMAND`` for short) to run
+a command on all threads.  You can use this with ``py-bt`` to see what every
+thread is doing at the Python level::
 
         (gdb) t a a py-bt
 

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -76,8 +76,7 @@ Enabling ``autocrlf`` on Windows
 
 The *autocrlf* option will fix automatically any Windows-specific line endings.
 This should be enabled on Windows, since the public repository has a hook which
-will reject all changesets having the wrong line endings.
-::
+will reject all changesets having the wrong line endings::
 
     $ git config --global core.autocrlf input
 
@@ -364,7 +363,8 @@ A pull request may need to be backported into one of the maintenance branches
 after it has been accepted and merged into ``master``.  It is usually indicated
 by the label ``needs backport to X.Y`` on the pull request itself.
 
-Use the utility script `cherry_picker.py <https://github.com/python/core-workflow/tree/master/cherry_picker>`_
+Use the utility script
+`cherry_picker.py <https://github.com/python/core-workflow/tree/master/cherry_picker>`_
 from the `core-workflow  <https://github.com/python/core-workflow>`_
 repository to backport the commit.
 
@@ -376,13 +376,14 @@ page.  Find the event that says something like::
 
 By following the link to ``<commit_sha1>``, you will get the full commit hash.
 
-Alternatively, the commit hash can also be obtained by the following git commands::
+Alternatively, the commit hash can also be obtained by the following git
+commands::
 
    $ git fetch upstream
    $ git rev-parse ":/bpo-12345"
 
-The above commands will print out the hash of the commit containing ``"bpo-12345"``
-as part of the commit message.
+The above commands will print out the hash of the commit containing
+``"bpo-12345"`` as part of the commit message.
 
 When formatting the message for a backport commit: leave it as the the original
 one, pointing to the original pull request number as well (``GH-NNNN``).

--- a/index.rst
+++ b/index.rst
@@ -297,12 +297,14 @@ Additional Resources
 Code of Conduct
 ---------------
 Please note that all interactions on
-`Python Software Foundation <https://www.python.org/psf-landing/>`__-supported infrastructure is
-`covered <https://www.python.org/psf/records/board/minutes/2014-01-06/#management-of-the-psfs-web-properties>`__
-by the `PSF Code of Conduct <https://www.python.org/psf/codeofconduct/>`__, which includes all
-infrastructure used in the development of Python itself (e.g. mailing lists, issue trackers, GitHub, etc.).
-In general this means everyone is expected to be open, considerate, and respectful of others no matter what
-their position is within the project.
+`Python Software Foundation <https://www.python.org/psf-landing/>`__-supported
+infrastructure is `covered
+<https://www.python.org/psf/records/board/minutes/2014-01-06/#management-of-the-psfs-web-properties>`__
+by the `PSF Code of Conduct <https://www.python.org/psf/codeofconduct/>`__,
+which includes all infrastructure used in the development of Python itself
+(e.g. mailing lists, issue trackers, GitHub, etc.).
+In general this means everyone is expected to be open, considerate, and
+respectful of others no matter what their position is within the project.
 
 .. _contents:
 

--- a/motivations.rst
+++ b/motivations.rst
@@ -244,7 +244,7 @@ Limitations on scope
   developers are NOT required to publish their motivations and affiliations if
   they do not choose to do so. This helps to ensure that core contribution
   processes remain open to anyone that is in a position to sign the `Contributor
-  Licensing Agreement`_, the details of which are filed privately with the Python
-  Software Foundation, rather than publicly.
+  Licensing Agreement`_, the details of which are filed privately with the
+  Python Software Foundation, rather than publicly.
 
 .. _Contributor Licensing Agreement: https://www.python.org/psf/contrib/contrib-form/

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -242,23 +242,23 @@ license your code for use with Python (you retain the copyright).
 Here are the steps needed in order to sign the CLA:
 
 1. If you don't have an account on `bugs.python.org <https://bugs.python.org>`_
-   (aka b.p.o), please `register <https://bugs.python.org/user?@template=register>`_
-   to create one.
+   (aka b.p.o), please
+   `register <https://bugs.python.org/user?@template=register>`_ to create one.
 
-2. Make sure your GitHub username is listed in the
-   `"Your Details" <https://cloud.githubusercontent.com/assets/2680980/23276970/d14a380c-f9d1-11e6-883d-e13b6b211239.png>`_
+2. Make sure your GitHub username is listed in the `"Your Details"
+   <https://cloud.githubusercontent.com/assets/2680980/23276970/d14a380c-f9d1-11e6-883d-e13b6b211239.png>`_
    section at b.p.o.
 
 3. Fill out and sign the PSF `contributor form`_. The "bugs.python.org username"
    requested by the form is the "Login name" field under "Your Details".
 
 After signing the CLA, please **wait at least one US business day** and
-then check "Your Details" on `b.p.o <https://bugs.python.org>`_ to see if your account has
-been marked as having signed the CLA (the delay is due to a person having
-to manually check your signed CLA). Once you have verified that your b.p.o
-account reflects your signing of the CLA, you can either ask for the CLA check
-to be run again or wait for it to be run automatically the next time you push
-changes to your PR.
+then check "Your Details" on `b.p.o <https://bugs.python.org>`_ to see if your
+account has been marked as having signed the CLA (the delay is due to a person
+having to manually check your signed CLA). Once you have verified that your
+b.p.o account reflects your signing of the CLA, you can either ask for the CLA
+check to be run again or wait for it to be run automatically the next time you
+push changes to your PR.
 
 
 .. _PSF license: https://docs.python.org/dev/license.html#terms-and-conditions-for-accessing-or-otherwise-using-python
@@ -283,10 +283,11 @@ list anything), you will want to push your branch to your fork::
 This will get your changes up to GitHub.
 
 Now you want to
-`create a pull request from your fork <https://help.github.com/articles/creating-a-pull-request-from-a-fork/>`_.
+`create a pull request from your fork
+<https://help.github.com/articles/creating-a-pull-request-from-a-fork/>`_.
 If this is a pull request in response to a pre-existing issue on the
-`issue tracker`_, please make sure to reference the issue number using bpo-NNNN in
-the pull request title or message.
+`issue tracker`_, please make sure to reference the issue number using
+``bpo-NNNN`` in the pull request title or message.
 
 If this is a pull request for an unreported issue (assuming you already
 performed a search on the issue tracker for a pre-existing issue), create a
@@ -372,7 +373,8 @@ code and leave comments in the pull request or issue tracker.
    of the Python REPL (the interactive shell prompt), which you can launch
    by executing ./python inside the repository.
 
-3. Checkout and apply the pull request (Please refer to the instruction :ref:`git_pr`)
+3. Checkout and apply the pull request (Please refer to the instruction
+   :ref:`git_pr`)
 
 4. If the changes affect any C file, run the build again.
 

--- a/setup.rst
+++ b/setup.rst
@@ -188,7 +188,8 @@ If necessary, run the following::
 
     $ xcode-select --install
 
-This will also ensure that the system header files are installed into ``/usr/include``.
+This will also ensure that the system header files are installed into
+``/usr/include``.
 
 For **older releases of OS X**, you will need to download either the correct
 version of the Command Line Tools, if available, or install them from the

--- a/stdlibchanges.rst
+++ b/stdlibchanges.rst
@@ -83,7 +83,7 @@ it.
 
 
 Requirements
-''''''''''''''
+''''''''''''
 In order for a module to even be considered for inclusion into the stdlib, a
 couple of requirements must be met.
 
@@ -144,8 +144,7 @@ will once again receive a large amount of feedback and discussion. A PEP
 dictator will be assigned who makes the final call on whether the PEP will be
 accepted or not. If the PEP dictator agrees to accept your PEP (which typically
 means that the core developers end up agreeing in general to accepting
-your PEP) then the module
-will be added to the stdlib once the creators of the module sign
-:ref:`contributor agreements <contributor_agreement>`.
+your PEP) then the module will be added to the stdlib once the creators of the
+module sign :ref:`contributor agreements <contributor_agreement>`.
 
 .. _PEP index: https://www.python.org/dev/peps/

--- a/triaging.rst
+++ b/triaging.rst
@@ -83,7 +83,8 @@ Demos and Tools
 Distutils
     The distutils package in `Lib/distutils`_.
 Documentation
-    The documentation in Doc_ (used to build the HTML doc at https://docs.python.org/).
+    The documentation in Doc_ (used to build the HTML doc at
+    https://docs.python.org/).
 email
     The email package and related modules.
 Extension Modules


### PR DESCRIPTION
Primary aim is to conform to the 80 character rule (where possible). At the same time I've cleaned up other formatting faults in the same area as the long lines.

I don't personally like to re-flow paragraphs further than end of the affected sentence when I'm writing, so I mostly haven't. It makes it easier to see what changed.