### PR TITLE
Add entry to developer log.

### DIFF
--- a/developers.rst
+++ b/developers.rst
@@ -105,6 +105,9 @@ Permissions History
 - Eric Snow was given push privileges on Sep 5 2012 by Antoine Pitrou for
   general contributions, on recommendation by Nick Coghlan.
 
+- Jeff Allen was given push privileges on June 13, 2012 by Antoine Pitrou,
+  at the request of Frank Wierzbicki, for Jython development.
+
 - Peter Moody was given push privileges on May 20 2012 by Antoine Pitrou for
   authorship and maintenance of the ipaddress module (accepted in PEP 3144 by
   Nick Coghlan).


### PR DESCRIPTION
Corrects ancient oversight.