### PR TITLE
CircleCI PoC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,45 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: dependency-cache-{{ checksum "requirements.txt" }}
+
+      - run:
+          name: install python dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements.txt
+
+      - save_cache:
+          key: dependency-cache-{{ checksum "requirements.txt" }}
+          paths:
+            - "venv"
+
+      - run:
+          name: build sphinx
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements.txt
+            sphinx-build -n -W -q -b html -d _build/doctrees . _build/html
+
+      - run:
+          name: run linkcheck
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements.txt
+            # don't fail the build if linkcheck fails
+            make linkcheck || true
+
+            # make "broken" report
+            cat _build/linkcheck/output.txt | grep broken > _build/linkcheck/broken.txt
+
+      - store_artifacts:
+          path: _build


### PR DESCRIPTION
This is what running the build on CircleCI might look like. If you look at my fork there are a couple cool things. 

https://circleci.com/gh/levlaz/devguide/5

1. The entire build (including linkcheck) ran in under 1 minute. 
2. We are able to store the build output as artifacts. 

<img width="1278" alt="screen shot 2017-11-01 at 7 23 02 pm" src="https://user-images.githubusercontent.com/7981032/32306687-370725a0-bf3a-11e7-9c1d-06c62c1a40bf.png">

This allows us to make a nice report for "broken" things in linkcheck here: https://3-108794746-gh.circle-artifacts.com/0/home/circleci/project/_build/linkcheck/broken.txt

And we can see the entire build HTML which could be useful for previewing the state of the project at a specific commit: https://3-108794746-gh.circle-artifacts.com/0/home/circleci/project/_build/html/index.html

*note: linkcheck does not fail the build even though it has failures because the command that is run is `make linkcheck || true` which forces an exit code of 0. 

fix https://github.com/python/devguide/issues/292