### PR TITLE
Mention how to add co-author info.

### DIFF
--- a/committing.rst
+++ b/committing.rst
@@ -87,7 +87,9 @@ Third, ensure the patch is attributed correctly with the contributor's
 name in ``Misc/ACKS`` if they aren't already there (and didn't add themselves
 in their patch) and by mentioning "Patch by <x>" in the ``Misc/NEWS.d`` entry
 and the check-in message. If the patch has been heavily modified then "Initial
-patch by <x>" is an appropriate alternate wording.
+patch by <x>" is an appropriate alternate wording.  GitHub now supports `multiple
+authors <https://help.github.com/articles/creating-a-commit-with-multiple-authors/>`_
+in a commit. Add ``Co-authored-by: name <name@example.com>`` at the end of the commit message.
 
 If you omit correct attribution in the initial check-in, then update ``ACKS``
 and ``NEWS.d`` in a subsequent check-in (don't worry about trying to fix the

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -323,8 +323,10 @@ their own pull request. If the author does not respond after a week, it is
 acceptable for another contributor to prepare the pull request based on the
 existing patch. In this case, both parties should sign the :ref:`CLA <cla>`.
 When creating a pull request based on another person's patch, provide
-attribution to the original patch author by adding "Original patch by
-<author name>." to the pull request description and commit message.
+attribution to the original patch author by adding "Co-authored-by: 
+Author Name <email_address> ." to the pull request description and commit message.
+See `the GitHub article <https://help.github.com/articles/creating-a-commit-with-multiple-authors/>`_
+on how to properly add the co-author info.
 
 See also :ref:`Applying a Patch from Mercurial to Git <git_from_mercurial>`.
 


### PR DESCRIPTION
When converting other people's patch, ensure to add the "Co-authored-by:" message.