### PR TITLE
Clarify "Helping with Documentation"

### DIFF
--- a/docquality.rst
+++ b/docquality.rst
@@ -83,7 +83,7 @@ Helping with the Developer's Guide
 The Developer's Guide (what you're reading now) uses the same process as the
 main Python documentation, except for some small differences.  The source
 lives in a `separate repository`_ and bug reports should be submitted to
-the `its GitHub tracker`_.
+`its GitHub tracker`_.
 
 To submit a :doc:`pull request <pullrequest>` you can fork the
 `devguide repo`_ to your GitHub account and clone it using::

--- a/docquality.rst
+++ b/docquality.rst
@@ -117,5 +117,5 @@ that may be different from the main documentation.
 
 .. _separate repository:
 .. _devguide repo: https://github.com/python/devguide
-.. _the GitHub tracker: https://github.com/python/devguide/issues
+.. _its GitHub tracker: https://github.com/python/devguide/issues
 .. _Sphinx: http://www.sphinx-doc.org/

--- a/docquality.rst
+++ b/docquality.rst
@@ -83,7 +83,7 @@ Helping with the Developer's Guide
 The Developer's Guide (what you're reading now) uses the same process as the
 main Python documentation, except for some small differences.  The source
 lives in a `separate repository`_ and bug reports should be submitted to
-the `the GitHub tracker`_.
+the `its GitHub tracker`_.
 
 To submit a :doc:`pull request <pullrequest>` you can fork the
 `devguide repo`_ to your GitHub account and clone it using::

--- a/docquality.rst
+++ b/docquality.rst
@@ -8,6 +8,10 @@ keeping a high level of quality takes a lot of effort. Help is always
 appreciated with the documentation, and it requires little programming
 experience (with or without Python).
 
+
+Python Documentation
+--------------------
+
 :ref:`Documenting Python <documenting>` covers the details of how Python's
 documentation works.
 It includes an explanation of the markup used (although you can figure a lot
@@ -76,9 +80,10 @@ Helping with the Developer's Guide
 
 .. highlight:: console
 
-The Developer's Guide uses the same process as the main Python documentation,
-except for some small differences.  The source lives in a `separate
-repository`_ and bug reports should be submitted to the `the GitHub tracker`_.
+The Developer's Guide (what you're reading now) uses the same process as the
+main Python documentation, except for some small differences.  The source
+lives in a `separate repository`_ and bug reports should be submitted to
+the `the GitHub tracker`_.
 
 To submit a :doc:`pull request <pullrequest>` you can fork the
 `devguide repo`_ to your GitHub account and clone it using::

--- a/documenting.rst
+++ b/documenting.rst
@@ -60,75 +60,6 @@ Please don't let the material in this document stand between the documentation
 and your desire to help out!
 
 
-.. _building-doc:
-
-Building the documentation
-==========================
-
-.. highlight:: bash
-
-
-When you make changes to the Python documentation, you're going to want to
-view those changes locally.  To build the documentation, follow the
-instructions from one of the sections below.  You can view the documentation
-after building the HTML by pointing a browser at the file
-:file:`Doc/build/html/index.html`.
-
-The toolset used to build the docs is written in Python and is called Sphinx_.
-Sphinx is maintained separately and is not included in this tree.  Also needed
-are docutils_, supplying the base markup that Sphinx uses; Jinja_, a templating
-engine; and optionally Pygments_, a code highlighter.
-
-You are expected to have installed the latest stable version of
-Sphinx_ and blurb_ on your system or in a virtualenv_ (which can be
-created using ``make venv``), so that the Makefile can find the
-``sphinx-build`` command.  You can also specify the location of
-``sphinx-build`` with the ``SPHINXBUILD`` :command:`make` variable.
-
-
-Using make / make.bat
----------------------
-
-**On Unix**, run the following from the root of your :ref:`repository clone
-<checkout>` to build the output as HTML::
-
-   cd Doc
-   make venv
-   make html
-
-or alternatively ``make -C Doc/ venv html``.
-
-You can also use ``make help`` to see a list of targets supported by
-:command:`make`.  Note that ``make check`` is automatically run when
-you submit a :doc:`pull request <pullrequest>`, so you should make
-sure that it runs without errors.
-
-**On Windows**, there is a :file:`make.bat` batchfile that tries to
-emulate :command:`make` as closely as possible.
-
-See also :file:`Doc/README.rst` for more information.
-
-
-Without make
-------------
-
-Install the Sphinx and blurb packages from PyPI.
-
-Then, from the ``Doc`` directory, run::
-
-   sphinx-build -b<builder> . build/<builder>
-
-where ``<builder>`` is one of html, text, latex, or htmlhelp (for explanations
-see the make targets above).
-
-.. _docutils: http://docutils.sourceforge.net/
-.. _Jinja: http://jinja.pocoo.org/
-.. _Pygments: http://pygments.org/
-.. _Sphinx: http://sphinx-doc.org/
-.. _virtualenv: https://virtualenv.pypa.io/
-.. _blurb: https://pypi.org/project/blurb/
-
-
 Style guide
 ===========
 
@@ -1519,3 +1450,68 @@ default. They are set in the build configuration file :file:`conf.py`.
 .. [1] There is a standard ``include`` directive, but it raises errors if the
        file is not found.  This one only emits a warning.
 
+
+.. _building-doc:
+
+Building the documentation
+==========================
+
+.. highlight:: bash
+
+The toolset used to build the docs is written in Python and is called Sphinx_.
+Sphinx is maintained separately and is not included in this tree.  Also needed
+are docutils_, supplying the base markup that Sphinx uses; Jinja_, a templating
+engine; and optionally Pygments_, a code highlighter.
+
+To build the documentation, follow the instructions from one of the sections
+below.  You can view the documentation after building the HTML by pointing
+a browser at the file :file:`Doc/build/html/index.html`.
+
+You are expected to have installed the latest stable version of
+Sphinx_ and blurb_ on your system or in a virtualenv_ (which can be
+created using ``make venv``), so that the Makefile can find the
+``sphinx-build`` command.  You can also specify the location of
+``sphinx-build`` with the ``SPHINXBUILD`` :command:`make` variable.
+
+
+Using make / make.bat
+---------------------
+
+**On Unix**, run the following from the root of your :ref:`repository clone
+<checkout>` to build the output as HTML::
+
+   cd Doc
+   make venv
+   make html
+
+or alternatively ``make -C Doc/ venv html``.
+
+You can also use ``make help`` to see a list of targets supported by
+:command:`make`.  Note that ``make check`` is automatically run when
+you submit a :doc:`pull request <pullrequest>`, so you should make
+sure that it runs without errors.
+
+**On Windows**, there is a :file:`make.bat` batchfile that tries to
+emulate :command:`make` as closely as possible.
+
+See also :file:`Doc/README.rst` for more information.
+
+
+Without make
+------------
+
+Install the Sphinx and blurb packages from PyPI.
+
+Then, from the ``Doc`` directory, run::
+
+   sphinx-build -b<builder> . build/<builder>
+
+where ``<builder>`` is one of html, text, latex, or htmlhelp (for explanations
+see the make targets above).
+
+.. _docutils: http://docutils.sourceforge.net/
+.. _Jinja: http://jinja.pocoo.org/
+.. _Pygments: http://pygments.org/
+.. _Sphinx: http://sphinx-doc.org/
+.. _virtualenv: https://virtualenv.pypa.io/
+.. _blurb: https://pypi.org/project/blurb/

--- a/documenting.rst
+++ b/documenting.rst
@@ -60,6 +60,75 @@ Please don't let the material in this document stand between the documentation
 and your desire to help out!
 
 
+.. _building-doc:
+
+Building the documentation
+==========================
+
+.. highlight:: bash
+
+
+When you make changes to the Python documentation, you're going to want to
+view those changes locally.  To build the documentation, follow the
+instructions from one of the sections below.  You can view the documentation
+after building the HTML by pointing a browser at the file
+:file:`Doc/build/html/index.html`.
+
+The toolset used to build the docs is written in Python and is called Sphinx_.
+Sphinx is maintained separately and is not included in this tree.  Also needed
+are docutils_, supplying the base markup that Sphinx uses; Jinja_, a templating
+engine; and optionally Pygments_, a code highlighter.
+
+You are expected to have installed the latest stable version of
+Sphinx_ and blurb_ on your system or in a virtualenv_ (which can be
+created using ``make venv``), so that the Makefile can find the
+``sphinx-build`` command.  You can also specify the location of
+``sphinx-build`` with the ``SPHINXBUILD`` :command:`make` variable.
+
+
+Using make / make.bat
+---------------------
+
+**On Unix**, run the following from the root of your :ref:`repository clone
+<checkout>` to build the output as HTML::
+
+   cd Doc
+   make venv
+   make html
+
+or alternatively ``make -C Doc/ venv html``.
+
+You can also use ``make help`` to see a list of targets supported by
+:command:`make`.  Note that ``make check`` is automatically run when
+you submit a :doc:`pull request <pullrequest>`, so you should make
+sure that it runs without errors.
+
+**On Windows**, there is a :file:`make.bat` batchfile that tries to
+emulate :command:`make` as closely as possible.
+
+See also :file:`Doc/README.rst` for more information.
+
+
+Without make
+------------
+
+Install the Sphinx and blurb packages from PyPI.
+
+Then, from the ``Doc`` directory, run::
+
+   sphinx-build -b<builder> . build/<builder>
+
+where ``<builder>`` is one of html, text, latex, or htmlhelp (for explanations
+see the make targets above).
+
+.. _docutils: http://docutils.sourceforge.net/
+.. _Jinja: http://jinja.pocoo.org/
+.. _Pygments: http://pygments.org/
+.. _Sphinx: http://sphinx-doc.org/
+.. _virtualenv: https://virtualenv.pypa.io/
+.. _blurb: https://pypi.org/project/blurb/
+
+
 Style guide
 ===========
 
@@ -1450,68 +1519,3 @@ default. They are set in the build configuration file :file:`conf.py`.
 .. [1] There is a standard ``include`` directive, but it raises errors if the
        file is not found.  This one only emits a warning.
 
-
-.. _building-doc:
-
-Building the documentation
-==========================
-
-.. highlight:: bash
-
-The toolset used to build the docs is written in Python and is called Sphinx_.
-Sphinx is maintained separately and is not included in this tree.  Also needed
-are docutils_, supplying the base markup that Sphinx uses; Jinja_, a templating
-engine; and optionally Pygments_, a code highlighter.
-
-To build the documentation, follow the instructions from one of the sections
-below.  You can view the documentation after building the HTML by pointing
-a browser at the file :file:`Doc/build/html/index.html`.
-
-You are expected to have installed the latest stable version of
-Sphinx_ and blurb_ on your system or in a virtualenv_ (which can be
-created using ``make venv``), so that the Makefile can find the
-``sphinx-build`` command.  You can also specify the location of
-``sphinx-build`` with the ``SPHINXBUILD`` :command:`make` variable.
-
-
-Using make / make.bat
----------------------
-
-**On Unix**, run the following from the root of your :ref:`repository clone
-<checkout>` to build the output as HTML::
-
-   cd Doc
-   make venv
-   make html
-
-or alternatively ``make -C Doc/ venv html``.
-
-You can also use ``make help`` to see a list of targets supported by
-:command:`make`.  Note that ``make check`` is automatically run when
-you submit a :doc:`pull request <pullrequest>`, so you should make
-sure that it runs without errors.
-
-**On Windows**, there is a :file:`make.bat` batchfile that tries to
-emulate :command:`make` as closely as possible.
-
-See also :file:`Doc/README.rst` for more information.
-
-
-Without make
-------------
-
-Install the Sphinx and blurb packages from PyPI.
-
-Then, from the ``Doc`` directory, run::
-
-   sphinx-build -b<builder> . build/<builder>
-
-where ``<builder>`` is one of html, text, latex, or htmlhelp (for explanations
-see the make targets above).
-
-.. _docutils: http://docutils.sourceforge.net/
-.. _Jinja: http://jinja.pocoo.org/
-.. _Pygments: http://pygments.org/
-.. _Sphinx: http://sphinx-doc.org/
-.. _virtualenv: https://virtualenv.pypa.io/
-.. _blurb: https://pypi.org/project/blurb/


### PR DESCRIPTION
For issue #334 .

I've made a few changes in this PR to maybe make building the Python docs clearer.  
- Added a section heading on "Helping with Documentation"
- Added parenthetical text to "Helping with the Dev Guide" section so the reader realizes that it's talking about a different set of docs.
- Moved the 'Building the documentation" section of the "Documenting Python" page from the end to right after the introduction.  I think it's more 'findable' this way.
- Add a short introduction to the 'Building the Documentation' section.

I hope these changes don't step on decisions made in the past, but I think they might help a newcomer navigate more easily.  

