### PR TITLE
Update Python 2.7 EOL date

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -98,7 +98,7 @@ Status of Python branches
 | 3.6              | :pep:`494`   | bugfix      | 2016-12-23     | *2021-12-23*   | `Most recent binary release: Python 3.6.4                                  |
 |                  |              |             |                |                | <https://www.python.org/downloads/release/python-364/>`_                   |
 +------------------+--------------+-------------+----------------+----------------+----------------------------------------------------------------------------+
-| 2.7              | :pep:`373`   | bugfix      | 2010-07-03     | *2020-01-01*   | The support has been extended to 2020 (1).                                 |
+| 2.7              | :pep:`373`   | bugfix      | 2010-07-03     | *2020-01-01*   | The support has been extended to 2020-01-01.                               |
 |                  |              |             |                |                | `Most recent binary release: Python 2.7.14                                 |
 |                  |              |             |                |                | <https://www.python.org/downloads/release/python-2714/>`_                  |
 +------------------+--------------+-------------+----------------+----------------+----------------------------------------------------------------------------+
@@ -108,12 +108,6 @@ Status of Python branches
 | 3.4              | :pep:`429`   | security    | 2014-03-16     | *2019-03-16*   | `Most recent security release: Python 3.4.7                                |
 |                  |              |             |                |                | <https://www.python.org/downloads/release/python-347/>`_                   |
 +------------------+--------------+-------------+----------------+----------------+----------------------------------------------------------------------------+
-
-(1) The exact date of Python 2.7 end-of-life has not been decided yet. It will
-be decided by Python 2.7 release manager, Benjamin Peterson, who will update
-the :pep:`373`. Read also the `[Python-Dev] Exact date of Python 2 EOL?
-<https://mail.python.org/pipermail/python-dev/2017-March/147655.html>`_ thread
-on python-dev (March 2017).
 
 Status:
 


### PR DESCRIPTION
> Let's not play games with semantics. The way I see the situation for 2.7 is
that EOL is January 1st, 2020, and there will be no updates, not even
source-only security patches, after that date. Support (from the core devs,
the PSF, and python.org) stops completely on that date. If you want support
for 2.7 beyond that day you will have to pay a commercial vendor. Of course
it's open source so people are also welcome to fork it. But the core devs
have toiled long enough, and the 2020 EOL date (an extension from the
originally annouced 2015 EOL!) was announced with sufficient lead time and
fanfare that I don't feel bad about stopping to support it at all.

Guido van Rossum, https://mail.python.org/pipermail/python-dev/2018-March/152348.html

>Sounds good to me. I've updated the PEP to say 2.7 is completely dead on Jan 1 2020. The final release may not literally be on January 1st, but we certainly don't want to support 2.7 through all of 2020.

Benjamin Peterson, https://mail.python.org/pipermail/python-dev/2018-March/152355.html

> Being the last of the 2.x series, 2.7 will have an extended period of maintenance. Specifically, 2.7 will receive bugfix support until January 1, 2020. All 2.7 development work will cease in 2020.

Benjamin Peterson, https://www.python.org/dev/peps/pep-0373/