### PR TITLE
Refresh tracker page on where to file issues

### DIFF
--- a/tracker.rst
+++ b/tracker.rst
@@ -11,7 +11,7 @@ If you think you have found a bug in Python, you can report it to the
 `issue tracker`_. The `issue tracker`_ is also commonly referred to as 
 `bugs.python.org` and `bpo`.  Documentation bugs can also be reported there.
 
-You can report bugs with how the issue tracker functions to the `meta tracker`_.
+You can report bugs with the issue tracker itself to the `meta tracker`_.
 
 If you would like to file an issue about this devguide, please do so at the
 `devguide repo`_.
@@ -41,7 +41,8 @@ Reporting an issue
 If the problem you're reporting is not already in the `issue tracker`_, you
 need to log in by entering your user and password in the form on the left.
 If you don't already have a tracker account, select the "Register" link or,
-if you use OpenID, one of the OpenID provider logos in the sidebar.
+if you use `OpenID <http://openid.net>`_, one of the OpenID provider logos in
+the sidebar.
 
 It is not possible to submit a bug report anonymously.
 

--- a/tracker.rst
+++ b/tracker.rst
@@ -7,23 +7,32 @@ Issue Tracking
 Using the Issue Tracker
 =======================
 
-If you think you found a bug in Python, you can report it to the
-`issue tracker`_.  Documentation bugs can also be reported there.
-Issues about the tracker should be reported to the `meta tracker`_.
+If you think you have found a bug in Python, you can report it to the
+`issue tracker`_. The `issue tracker`_ is also commonly referred to as 
+`bugs.python.org` and `bpo`.  Documentation bugs can also be reported there.
+
+You can report bugs with how the issue tracker functions to the `meta tracker`_.
+
+If you would like to file an issue about this devguide, please do so at the
+`devguide repo`_.
 
 
 Checking if a bug already exists
 --------------------------------
 
-The first step in filing a report is to determine whether the problem has
-already been reported.  The advantage in doing so, aside from saving the
-developers time, is that you learn what has been done to fix it; it may be that
-the problem has already been fixed for the next release, or additional
-information is needed (in which case you are welcome to provide it if you can!).
+The first step before filing an issue report is to see whether the problem has
+already been reported.  Checking if the problem is an existing issue will:
 
-To do this, search the bug database using the search box on the top of the page.
-An `advanced search`_ is also available by clicking on "Search" in
-the sidebar.
+* help you see if the problem has already been resolved or has been fixed for
+  the next release
+* save time for you and the developers
+* help you learn what needs to be done to fix it
+* determine if additional information, such as how to replicate the issue, 
+  is needed
+
+To do see if the issue already exists, search the bug database using the 
+search box on the top of the issue tracker page. An `advanced search`_ is also
+available by clicking on "Search" in the sidebar.
 
 
 Reporting an issue
@@ -36,7 +45,7 @@ if you use OpenID, one of the OpenID provider logos in the sidebar.
 
 It is not possible to submit a bug report anonymously.
 
-Being now logged in, you can submit a bug by clicking on the "Create New" link
+Once logged in, you can submit a bug by clicking on the "Create New" link
 in the sidebar.
 
 The submission form has a number of fields, and they are described in detail
@@ -46,19 +55,42 @@ in the :ref:`triaging` page.  This is a short summary:
   less than ten words is good;
 * in the **Type** field, select the type of your problem (usually behavior);
 * if you know which **Components** and **Versions** are affected by the issue,
-  you can select these too;
-* if you have JavaScript enabled, you can use the **Nosy List** field to search
-  developers that can help with the issue by entering the name of the affected
-  module, operating system, or interest area.
+  you can select these too; otherwise, leave them blank;
 * last but not least, you have to describe the problem in detail, including
-  what you expected to happen and what did happen, in the **Comment** field.
-  Be sure to include whether any extension modules were involved, and what
-  hardware and software platform you were using (including version information
-  as appropriate).
+  what you expected to happen, what did happen, and how to replicate the
+  problem in the **Comment** field. Be sure to include whether any extension 
+  modules were involved, and what hardware and software platform you were using
+  (including version information as appropriate).
+
+
+Understanding the issue's progress and status
+---------------------------------------------
 
 The triaging team will take care of setting other fields, and possibly assign
 the issue to a specific developer.  You will automatically receive an update
 each time an action is taken on the bug.
+
+
+Disagreement With a Resolution on the Issue Tracker
+===================================================
+
+As humans, we will have differences of opinions from time to time. First and
+foremost, please be respectful that care, thought, and volunteer time went into
+the resolution.
+
+With this in mind, take some time to consider any comments made in association 
+with the resolution of the issue. On reflection, the resolution steps may seem
+more reasonable than you initially thought.
+
+If you still feel the resolution is incorrect, then raise a thoughtful question
+on `python-dev`_. Further argument and disrespectful discourse on `python-dev`_
+after a consensus has been reached amongst the core developers is unlikely to
+win any converts.
+
+As a reminder, issues closed by a core developer have already been carefully
+considered. Please do not reopen a closed issue.
+
+.. _python-dev: https://mail.python.org/mailman/listinfo/python-dev
 
 
 .. _helptriage:
@@ -68,13 +100,13 @@ Helping Triage Issues
 
 Once you know your way around how Python's source files are
 structured and you are comfortable working with patches, a great way to
-participate is to help triage issues. Do realize, though, that experience
+contribute is to help triage issues. Do realize, though, that experience
 working on Python is needed in order to effectively help triage.
 
 Around the clock, new issues are being opened on the `issue tracker`_ and
-existing issues are being updated. Every
-issue needs to be triaged to make sure various things are in proper order. Even
-without special privileges you can help with this process.
+existing issues are being updated. Every issue needs to be triaged to make
+sure various things are in proper order. Even without special privileges you
+can help with this process.
 
 
 Classifying Reports
@@ -87,12 +119,16 @@ For bugs, an issue needs to:
 * state what version(s) of Python are affected by the bug.
 
 These are things you can help with once you have experience developing for
-Python. For instance, if a bug is not clearly explained enough for you to
-reproduce it then there is a good chance a core developer won't be able to
-either. And it is always helpful to know if a bug not only affects the
-in-development version of Python, but whether it also affects other versions in
-maintenance mode. And if the bug lacks a unit test that should end up in
-Python's test suite, having that written can be very helpful.
+Python:
+
+* try reproducing the bug: For instance, if a bug is not clearly explained 
+  enough for you to reproduce it then there is a good chance a core developer 
+  won't be able to either.
+* see if the issue happens on a different Python version: It is always helpful
+  to know if a bug not only affects the in-development version of Python, but
+  whether it also affects other versions in maintenance mode.
+* write a unit test: If the bug lacks a unit test that should end up in
+  Python's test suite, having that written can be very helpful.
 
 This is all helpful as it allows triagers (i.e.,
 :ref:`people with the Developer role on the issue tracker <devrole>`) to
@@ -121,36 +157,18 @@ working on Python's code base will notice.
 Finding an Issue You Can Help With
 ----------------------------------
 
-If you want to help triaging issues, you might also want to search for issues
-that you are knowledgeable about.  An easy way to do it, is to search for
-the name of a module you are familiar with.  You can also use the
-`advanced search`_ and search for specific components (e.g. "Windows" if you
-are a Windows developer, "Extension Modules" if you are familiar with C, etc.).
-Finally you can use the "Random issue" link in the sidebar to pick random
-issues until you find an issue that you like.  Is not so uncommon to find old
-issues that can be closed, either because they are no longer valid, or
-because they have a patch that is ready to be committed, but no one had
-time to do it yet.
+If you want to help triage issues, you might also want to search for issues
+in modules which you have a working knowledge.  Search for the name of a module
+in the issue tracker or use the `advanced search`_ to search for specific 
+components (e.g. "Windows" if you are a Windows developer, "Extension Modules"
+if you are familiar with C, etc.). Finally you can use the "Random issue" link
+in the sidebar to pick random issues until you find an issue that you like.  
+You may find old issues that can be closed, either because they
+are no longer valid or they have a patch that is ready to be committed, 
+but no one has had the time to do so.
 
 In the sidebar you can also find links to summaries for easy issues and
 issues with a patch.
-
-
-Disagreement With a Resolution on the Issue Tracker
-===================================================
-
-First, take some time to consider any comments made in association with the
-resolution of the tracker issue. On reflection, they may seem more reasonable
-than they first appeared.
-
-If you still feel the resolution is incorrect, then raise the question on
-`python-dev`_. Further argument on `python-dev`_ after a consensus has been
-reached amongst the core developers is unlikely to win any converts.
-
-Issues closed by a core developer have already been carefully considered.
-Please do not reopen a closed issue.
-
-.. _python-dev: https://mail.python.org/mailman/listinfo/python-dev
 
 
 .. _devrole:
@@ -193,6 +211,8 @@ instructions on the `Tracker Development`_ page.
 
 .. seealso::
 
+   | *Issues with Python and documentation*
+
    `The Python issue tracker <https://bugs.python.org/>`_
       Where to report issues about Python.
 
@@ -201,6 +221,8 @@ instructions on the `Tracker Development`_ page.
 
    `The Python-bugs-list mailing list <https://mail.python.org/mailman/listinfo/python-bugs-list>`_
       Where all the changes to issues are reported.
+
+   *The meta tracker and its development*
 
    `The meta tracker <http://psf.upfronthosting.co.za/roundup/meta/>`_
       Where to report issues about the tracker itself.
@@ -216,3 +238,4 @@ instructions on the `Tracker Development`_ page.
 .. _meta tracker: http://psf.upfronthosting.co.za/roundup/meta/
 .. _advanced search: https://bugs.python.org/issue?@template=search
 .. _Tracker Development: https://wiki.python.org/moin/TrackerDevelopment
+.. _devguide repo: https://github.com/python/devguide/issues


### PR DESCRIPTION
Partially addresses #120.

This PR is prompted by recent discussion on "core mentorship" list. It's a refresh of the section.

- expand introduction to clarify *bugs.python.org* and *bpo* refer to the issue tracker and include devguide issue tracker location
- migrate text to bullets in "check if issue exists section" for easier reader scanning
- remove the reference to Javascript and nosy list as it's confusing for those newer to the contributing. It is covered well in the nosy list reference on the triaging page.
- Add a heading for "understanding issue progress and status"
- Move section on "Disagreement" above the triaging sections and edit tone
- reflow text and fix minor grammar issues