### PR TITLE
add navigation table by contributor type to landing page

### DIFF
--- a/documenting.rst
+++ b/documenting.rst
@@ -59,6 +59,7 @@ gladly work with you to integrate your text, dealing with the markup for you.
 Please don't let the material in this document stand between the documentation
 and your desire to help out!
 
+.. _style-guide:
 
 Style guide
 ===========
@@ -276,6 +277,8 @@ the documentation wasn't consulted until after the error was made.  It is
 unfortunate, but typically no documentation edit would have saved the user from
 making false assumptions about the language ("I was surprised by ...").
 
+
+.. _rst-primer:
 
 reStructuredText Primer
 =======================

--- a/index.rst
+++ b/index.rst
@@ -5,9 +5,27 @@ Python Developer's Guide
 .. highlight:: bash
 
 This guide is a comprehensive resource for :ref:`contributing <contributing>`
-to Python_ -- for both new and experienced contributors.  It is
-:ref:`maintained <helping-with-the-developers-guide>` by the same community
-that maintains Python.  We welcome your contributions to Python!
+to Python_ -- for both new and experienced contributors. It is 
+:ref:`maintained <helping-with-the-developers-guide>` by the same
+community that maintains Python.  We welcome your contributions to Python!
+
++------------------------+---------------------+-----------------------+---------------------+
+| New Contributors       | Documentarians      | Triagers              | Core Developers     |
++========================+=====================+=======================+=====================+
+| :doc:`setup`           | :doc:`docquality`   | :doc:`tracker`        | :doc:`coredev`      |
++------------------------+---------------------+-----------------------+---------------------+
+| :doc:`help`            | :doc:`documenting`  | :doc:`triaging`       | :doc:`developers`   |
++------------------------+---------------------+-----------------------+---------------------+
+| :doc:`pullrequest`     | :ref:`style-guide`  | :ref:`helptriage`     | :doc:`committing`   |
++------------------------+---------------------+-----------------------+---------------------+
+| :doc:`runtests`        | :ref:`rst-primer`   |                       | :doc:`devcycle`     |
++------------------------+---------------------+-----------------------+---------------------+
+| :doc:`fixingissues`    |                     |                       | :doc:`experts`      |
++------------------------+---------------------+-----------------------+---------------------+
+| :doc:`communication`   |                     |                       |                     |
++------------------------+---------------------+-----------------------+---------------------+
+| :doc:`gitbootcamp`     |                     |                       |                     |
++------------------------+---------------------+-----------------------+---------------------+
 
 
 Quick Reference
@@ -168,7 +186,7 @@ Contributing
 
 We encourage everyone to contribute to Python and that's why we have put up this
 developer's guide.  If you still have questions after reviewing the material in
-this guide, then the `Python Mentors`_ group is available to help guide new
+this guide, then the `Core Python Mentorship`_ group is available to help guide new
 contributors through the process.
 
 A number of individuals from the Python community have contributed to a series
@@ -352,7 +370,7 @@ Full Table of Contents
 .. _PEPs: https://www.python.org/dev/peps/
 .. _python.org maintenance: https://pythondotorg.readthedocs.io/
 .. _Python: https://www.python.org/
-.. _Python Mentors: https://www.python.org/dev/core-mentorship/
+.. _Core Python Mentorship: https://www.python.org/dev/core-mentorship/
 .. _PyPy: http://www.pypy.org/
 .. _Jython: http://www.jython.org/
 .. _IronPython: http://ironpython.net/

--- a/index.rst
+++ b/index.rst
@@ -18,9 +18,9 @@ community that maintains Python.  We welcome your contributions to Python!
 +------------------------+---------------------+-----------------------+---------------------+
 | :doc:`pullrequest`     | :ref:`style-guide`  | :ref:`helptriage`     | :doc:`committing`   |
 +------------------------+---------------------+-----------------------+---------------------+
-| :doc:`runtests`        | :ref:`rst-primer`   |                       | :doc:`devcycle`     |
+| :doc:`runtests`        | :ref:`rst-primer`   | :doc:`experts`        | :doc:`devcycle`     |
 +------------------------+---------------------+-----------------------+---------------------+
-| :doc:`fixingissues`    |                     |                       | :doc:`experts`      |
+| :doc:`fixingissues`    |                     |                       | :doc:`motivations`  |
 +------------------------+---------------------+-----------------------+---------------------+
 | :doc:`communication`   |                     |                       |                     |
 +------------------------+---------------------+-----------------------+---------------------+

--- a/index.rst
+++ b/index.rst
@@ -9,24 +9,6 @@ to Python_ -- for both new and experienced contributors. It is
 :ref:`maintained <helping-with-the-developers-guide>` by the same
 community that maintains Python.  We welcome your contributions to Python!
 
-+------------------------+---------------------+-----------------------+---------------------+
-| New Contributors       | Documentarians      | Triagers              | Core Developers     |
-+========================+=====================+=======================+=====================+
-| :doc:`setup`           | :doc:`docquality`   | :doc:`tracker`        | :doc:`coredev`      |
-+------------------------+---------------------+-----------------------+---------------------+
-| :doc:`help`            | :doc:`documenting`  | :doc:`triaging`       | :doc:`developers`   |
-+------------------------+---------------------+-----------------------+---------------------+
-| :doc:`pullrequest`     | :ref:`style-guide`  | :ref:`helptriage`     | :doc:`committing`   |
-+------------------------+---------------------+-----------------------+---------------------+
-| :doc:`runtests`        | :ref:`rst-primer`   | :doc:`experts`        | :doc:`devcycle`     |
-+------------------------+---------------------+-----------------------+---------------------+
-| :doc:`fixingissues`    |                     |                       | :doc:`motivations`  |
-+------------------------+---------------------+-----------------------+---------------------+
-| :doc:`communication`   |                     |                       |                     |
-+------------------------+---------------------+-----------------------+---------------------+
-| :doc:`gitbootcamp`     |                     |                       |                     |
-+------------------------+---------------------+-----------------------+---------------------+
-
 
 Quick Reference
 ---------------
@@ -199,31 +181,36 @@ Core developers and contributors alike will find the following guides useful:
 
 Guide for contributing to Python:
 
-* :doc:`setup`
-* :doc:`help`
-* :doc:`pullrequest`
-* :doc:`runtests`
-* Beginner tasks to become familiar with the development process
-    * :doc:`docquality`
-    * :doc:`coverage`
-* Advanced tasks for once you are comfortable
-    * :doc:`silencewarnings`
-    * Fixing issues found by the :doc:`buildbots <buildbots>`
-    * Helping out with reviewing `open pull requests`_.
-      See :ref:`how to review a Pull Request <how-to-review-a-pull-request>`.
-    * :doc:`fixingissues`
-* :ref:`tracker` and :ref:`helptriage`
-    * :doc:`triaging`
-    * :doc:`experts`
-* :doc:`communication`
-* :doc:`coredev`
-    * :doc:`committing`
-    * :doc:`devcycle`
-    * :doc:`buildbots`
-    * :doc:`coverity`
-* :doc:`gitbootcamp`
++------------------------+---------------------+-----------------------+---------------------+
+| New Contributors       | Documentarians      | Triagers              | Core Developers     |
++========================+=====================+=======================+=====================+
+| :doc:`setup`           | :doc:`docquality`   | :doc:`tracker`        | :doc:`coredev`      |
++------------------------+---------------------+-----------------------+---------------------+
+| :doc:`help`            | :doc:`documenting`  | :doc:`triaging`       | :doc:`developers`   |
++------------------------+---------------------+-----------------------+---------------------+
+| :doc:`pullrequest`     | :ref:`style-guide`  | :ref:`helptriage`     | :doc:`committing`   |
++------------------------+---------------------+-----------------------+---------------------+
+| :doc:`runtests`        | :ref:`rst-primer`   | :doc:`experts`        | :doc:`devcycle`     |
++------------------------+---------------------+-----------------------+---------------------+
+| :doc:`fixingissues`    |                     |                       | :doc:`motivations`  |
++------------------------+---------------------+-----------------------+---------------------+
+| :doc:`communication`   |                     |                       |                     |
++------------------------+---------------------+-----------------------+---------------------+
+| :doc:`gitbootcamp`     |                     |                       |                     |
++------------------------+---------------------+-----------------------+---------------------+
 
-It is **recommended** that the above documents be read in the order listed.  You
+Advanced tasks and topics for once you are comfortable:
+
+* :doc:`silencewarnings`
+* Fixing issues found by the :doc:`buildbots <buildbots>`
+* :doc:`coverity`
+* Helping out with reviewing `open pull requests`_.
+  See :ref:`how to review a Pull Request <how-to-review-a-pull-request>`.
+* :doc:`fixingissues`
+
+It is **recommended** that the above documents be read as needed. New 
+contributors will build understanding of the CPython workflow by reading the
+sections mentioned in this table. You
 can stop where you feel comfortable and begin contributing immediately without
 reading and understanding these documents all at once.  If you do choose to skip
 around within the documentation, be aware that it is written assuming preceding


### PR DESCRIPTION
Addresses #189 

This PR adds navigation by type of user to the top of the devguide index page. This partially solves 2 issues: 
- guide folks by roles to relevant docs in a space efficient manner
- the sidebar toctree navigation requires multiple clicks to get to a particular page in the devguide. This small table gives one-click access to frequently used pages.

<img width="1145" alt="screenshot 2018-03-24 15 21 16" src="https://user-images.githubusercontent.com/2680980/37869613-c09eb3ac-2f77-11e8-8569-7bc9c39d48b6.png">
