### PR TITLE
Add Sections contents to sidebar

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -113,7 +113,12 @@ templates_path = ['tools/templates']
 html_sidebars = {
     # Defaults taken from http://www.sphinx-doc.org/en/stable/config.html#confval-html_sidebars
     # Removes the quick search block
-    '**': ['localtoc.html', 'relations.html', 'customsourcelink.html']
+    '**': [
+        'localtoc.html',
+        'globaltoc.html',
+        'relations.html',
+        'customsourcelink.html'
+    ]
 }
 
 # Additional static files.

--- a/tools/templates/globaltoc.html
+++ b/tools/templates/globaltoc.html
@@ -1,0 +1,11 @@
+{#
+    basic/globaltoc.html
+    ~~~~~~~~~~~~~~~~~~~~
+
+    Sphinx sidebar template: global table of contents.
+
+    :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+#}
+<h3><a href="{{ pathto(master_doc) }}">{{ _('Sections') }}</a></h3>
+{{ toctree() }}


### PR DESCRIPTION
Adds a Sections contents to the sidebar to improve overall usability and UX so all pages one click from sidebar.

- adds a global toctree template
- adds global toctree to sidebar display

<img width="777" alt="screenshot 2018-03-25 15 58 24" src="https://user-images.githubusercontent.com/2680980/37880976-83e640be-3045-11e8-89b4-38638d5df85f.png">

Related to PR #349. Merge of this PR should allow the table to be placed lower on the index.rst page.