### PR TITLE
add appendix with topic pathways

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -1,18 +1,27 @@
 Appendix: Topics 
 ================
 
-Basics
-------
+Basics for contributors
+-----------------------
 
-* :doc:`setup`
+.. note:: **Recommended reading**
+
+   - :doc:`setup`
+   - :doc:`pullrequest`
+
 * :doc:`help`
 * :doc:`communication`
 
 Core developers
 ---------------
 
+.. note:: **Recommended reading**
+
+   * :doc:`setup`
+   * :doc:`pullrequest`
+   * :doc:`committing`
+
 * :doc:`coredev`
-* :doc:`committing`
 * :doc:`developers`
 * :doc:`motivations`
 * :doc:`experts`

--- a/appendix.rst
+++ b/appendix.rst
@@ -1,0 +1,58 @@
+Appendix: Topics 
+================
+
+Basics
+------
+
+* :doc:`setup`
+* :doc:`help`
+* :doc:`communication`
+
+Core developers
+---------------
+
+* :doc:`coredev`
+* :doc:`committing`
+* :doc:`developers`
+* :doc:`motivations`
+* :doc:`experts`
+
+Development workflow for contributors
+-------------------------------------
+
+* :doc:`devcycle`
+* :doc:`pullrequest`
+* :doc:`fixingissues`
+
+Documenting Python and style guide
+----------------------------------
+
+* :doc:`docquality`
+* :doc:`documenting`
+
+Issue tracking and triaging
+---------------------------
+
+* :doc:`tracker`
+* :doc:`triaging`
+
+Language development in depth
+-----------------------------
+
+* :doc:`exploring`
+* :doc:`grammar`
+* :doc:`compiler`
+* :doc:`stdlibchanges`
+* :doc:`langchanges`
+* :doc:`porting`
+
+Testing and continuous integration
+----------------------------------
+
+* :doc:`runtests`
+* :doc:`coverage`
+* :doc:`silencewarnings`
+* :doc:`buildbots`
+* :doc:`buildworker`
+* :doc:`coverity`
+  

--- a/index.rst
+++ b/index.rst
@@ -345,7 +345,7 @@ Full Table of Contents
    buildworker
    motivations
    gitbootcamp
-
+   appendix
 
 .. _Buildbot status: https://www.python.org/dev/buildbot/
 .. _Misc directory: https://github.com/python/cpython/tree/master/Misc


### PR DESCRIPTION
Related to #40, #120, #189 

This PR adds an Appendix that groups the individual document pages into logical subtopics. The goal of this PR is to gather topics together to help:

- consolidation and refactoring of sections that only have one paragraph
- deduplicate redundant content

My hope is that this can be a first pass and that we can iterate on this in future PRs.

<img width="610" alt="screenshot 2018-03-26 07 47 19" src="https://user-images.githubusercontent.com/2680980/37913738-6f667c96-30ca-11e8-9772-a9991a46a7b5.png">
