### PR TITLE
Added additional instructions to Mac build section for building python >= 3.7

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -216,12 +216,16 @@ with **Homebrew**::
 
     $ brew install openssl xz
 
-and configure::
+and configure python versions >= 3.7::
+
+    ./configure --with-pydebug --with-openssl=$(brew --prefix openssl)
+
+or configure python versions < 3.7::
 
     $ CPPFLAGS="-I$(brew --prefix openssl)/include" \
       LDFLAGS="-L$(brew --prefix openssl)/lib" \
       ./configure --with-pydebug
-
+      
 and make::
 
     $ make -s -j2

--- a/setup.rst
+++ b/setup.rst
@@ -232,7 +232,7 @@ and make::
 
 or **MacPorts**::
 
-    $ sudo port install openssl xz
+    $ sudo port install pkgconfig openssl xz
 
 and configure::
 


### PR DESCRIPTION
The mac instructions are a little unclear for python versions >= 3.7 and results in openssl not used in build when using homebrew for deps. This adds instructions on what to do.