### PR TITLE
Building docs without make: Add python-docs-theme to requirements list

### DIFF
--- a/documenting.rst
+++ b/documenting.rst
@@ -1515,7 +1515,7 @@ See also :file:`Doc/README.rst` for more information.
 Without make
 ------------
 
-Install the Sphinx and blurb packages from PyPI.
+Install the Sphinx, blurb, and python-docs-theme packages from PyPI.
 
 Then, from the ``Doc`` directory, run::
 


### PR DESCRIPTION
Note that the `Docs\Makefile` and `Docs\make.bat` files in the cpython repo already include this; it's just missing from the docs here.