### PR TITLE
Remove "languishing" status from triaging doc.

### DIFF
--- a/triaging.rst
+++ b/triaging.rst
@@ -269,9 +269,6 @@ Status
 +===============+============================================================+
 | open          | Issue is not resolved.                                     |
 +---------------+------------------------------------------------------------+
-| languishing   | The issue has no clear solution , e.g., no agreement on a  |
-|               | technical solution or if it is even a problem worth fixing.|
-+---------------+------------------------------------------------------------+
 | pending       | The issue is blocked until someone (often the              |
 |               | :abbr:`OP (original poster)`) provides some critical       |
 |               | information; the issue will be closed after a set amount   |


### PR DESCRIPTION
There was no languishing status in b.p.o

<img width="196" alt="screen shot 2018-06-13 at 8 43 10 pm" src="https://user-images.githubusercontent.com/5844587/41390462-94d59ebc-6f4a-11e8-9110-ca6a3bdfed98.png">
