### PR TITLE
Reorganize the setup.rst page.

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -37,8 +37,8 @@ instructions please see the :ref:`setup guide <setup>`.
       PCbuild\build.bat -e -d
 
    See also :ref:`more detailed instructions <compiling>`,
-   :ref:`how to build dependencies <build-dependencies>`, and the
-   plaform-specific pages for :ref:`UNIX <unix-compiling>`,
+   :ref:`how to install and build dependencies <build-dependencies>`,
+   and the plaform-specific pages for :ref:`UNIX <unix-compiling>`,
    :ref:`Mac OS <MacOS>`, and :ref:`Windows <windows-compiling>`.
 
 4. :doc:`Run the tests <runtests>`::

--- a/setup.rst
+++ b/setup.rst
@@ -161,7 +161,7 @@ stderr and utilize up to 2 CPU cores. If you are using a multi-core machine
 with more than 2 cores (or a single-core machine), you can adjust the number
 passed into the ``-j`` flag to match the number of cores you have.
 
-At the end of the built you should see a success message, possibly followed
+At the end of the build you should see a success message, possibly followed
 by a list of extension modules that haven't been built because their
 dependencies were missing:
 


### PR DESCRIPTION
This PR reorganizes the setup.rst page:
1. There is now a section about compiling Python, followed by a separate section about installing dependencies
2. The commands to compile Python are now just after the section about getting the code
3. The header levels have been fixed
4. Some paragraphs have been rephrased