### PR TITLE
Update compiler.rst for more precision about new opcode

### DIFF
--- a/compiler.rst
+++ b/compiler.rst
@@ -394,7 +394,10 @@ Changing this number will lead to all .pyc files with the old ``MAGIC_NUMBER``
 to be recompiled by the interpreter on import.  Whenever ``MAGIC_NUMBER`` is
 changed, the ranges in the ``magic_values`` array in :file:`PC/launcher.c`
 must also be updated.  Changes to :file:`Lib/importlib/_bootstrap_external.py`
-will take effect only after running ``make regen-importlib``.
+will take effect only after running ``make regen-importlib``. Running this 
+command before adding the new bytecode to :file:`Python/ceval.c` will result 
+in an error. You should proceed to the next step before importlib is 
+regenerated. 
 
 Finally, you need to introduce the use of the new bytecode.  Altering
 :file:`Python/compile.c` and :file:`Python/ceval.c` will be the primary places


### PR DESCRIPTION
When adding a new opcode, if the guide is followed as is, the following error will be emitted as regen-importlib expects the new opcode target to be present in ceval.c before the command is added. I simply added a quick precision in the guide. Will create an issue with this in a few seconds. 

`
gcc -pthread -c -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall    -std=c99 -Wextra -Wno-unused-result -Wno-unused-parameter -Wno-missing-field-initializers -Werror=implicit-function-declaration   -I. -I./Include    -DPy_BUILD_CORE -o Python/ceval.o Python/ceval.c
In file included from Python/ceval.c:629:0:
Python/ceval.c: In function ‘_PyEval_EvalFrameDefault’:
Python/opcode_targets.h:119:5: error: label ‘TARGET_LOAD_BUILTIN’ used but not defined
     &&TARGET_LOAD_BUILTIN,
     ^
Makefile:1613: recipe for target 'Python/ceval.o' failed
make: *** [Python/ceval.o] Error 1
`