### PR TITLE
Adding Shengjing Zhu as the coordinator of the zh-cn translation.

### DIFF
--- a/experts.rst
+++ b/experts.rst
@@ -368,4 +368,5 @@ Bengali India  kushal.das
 Hungarian      gbtami
 Portuguese     rougeth
 Chinese (TW)   adrianliaw
+Chinese (CN)   zhsj
 =============  ============


### PR DESCRIPTION
c.f. https://mail.python.org/pipermail/doc-sig/2018-October/thread.html (thread unarchived yet, message of Xiang Zhang saying "I agree to promote Shengjing Zhu as the repo coordinator.".