### PR TITLE
Update multiprocessing experts

### DIFF
--- a/experts.rst
+++ b/experts.rst
@@ -156,7 +156,8 @@ mmap                  twouters
 modulefinder          theller (inactive), jvr
 msilib
 msvcrt
-multiprocessing       davin*, pitrou, jnoller (inactive), sbt (inactive)
+multiprocessing       pitrou, davin (inactive), jnoller (inactive),
+                      sbt (inactive)
 netrc
 nis
 nntplib


### PR DESCRIPTION
Davin get sometimes/often assigned multiprocessing issues, but he doesn't contribute anymore, so remove his asterisk and mark him inactive.
