### PR TITLE
Revert "Update multiprocessing experts"

### DIFF
--- a/experts.rst
+++ b/experts.rst
@@ -156,8 +156,7 @@ mmap                  twouters
 modulefinder          theller (inactive), jvr
 msilib
 msvcrt
-multiprocessing       pitrou, davin (inactive), jnoller (inactive),
-                      sbt (inactive)
+multiprocessing       davin*, pitrou, jnoller (inactive), sbt (inactive)
 netrc
 nis
 nntplib


### PR DESCRIPTION
Reverts python/devguide#435

Despite Antoine contacting me directly about my current activity, I find it very difficult to believe that he chose to proceed with this.  Please revert while I update Antoine on my current development effort to bring a new feature to multiprocessing.