### PR TITLE
Update information about token types and add more mark up.

### DIFF
--- a/compiler.rst
+++ b/compiler.rst
@@ -31,8 +31,9 @@ implementation laid out in the Dragon Book [Aho86]_.
 
 The grammar file for Python can be found in :file:`Grammar/Grammar` with the
 numeric value of grammar rules stored in :file:`Include/graminit.h`.  The
-numeric values for types of tokens (literal tokens, such as ``:``,
-numbers, etc.) are kept in :file:`Include/token.h`.  The parse tree is made up
+list of types of tokens (literal tokens, such as ``:``, numbers, etc.) can
+be found in :file:`Grammar/Tokens` with the numeric value stored in
+:file:`Include/token.h`.  The parse tree is made up
 of ``node *`` structs (as defined in :file:`Include/node.h`).
 
 Querying data from the node structs can be done with the following

--- a/grammar.rst
+++ b/grammar.rst
@@ -7,7 +7,7 @@ Abstract
 --------
 
 There's more to changing Python's grammar than editing
-Grammar/Grammar and Python/compile.c.  This document aims to be a
+:file:`Grammar/Grammar` and :file:`Python/compile.c`.  This document aims to be a
 checklist of places that must also be fixed.
 
 It is probably incomplete.  If you see omissions,  submit a bug or patch.
@@ -22,48 +22,53 @@ Rationale
 People are getting this wrong all the time; it took well over a
 year before someone `noticed <https://bugs.python.org/issue676521>`_
 that adding the floor division
-operator (//) broke the parser module.
+operator (``//``) broke the :mod:`parser` module.
 
 
 Checklist
 ---------
 
-* Grammar/Grammar: OK, you'd probably worked this one out :)
+* :file:`Grammar/Grammar`: OK, you'd probably worked this one out :)
 
-* Parser/Python.asdl may need changes to match the Grammar.  Then run 'make
-  regen-ast' to regenerate Include/Python-ast.h and Python/Python-ast.c.
+* :file:`Grammar/Tokens` is a place for adding new token types.  After
+  changing it, run '``make regen-token``' to regenerate :file:`Include/token.h`,
+  :file:`Parser/token.c`, :file:`Lib/token.py` and
+  :file:`Doc/library/token-list.inc`.
 
-* Python/ast.c will need changes to create the AST objects involved with the
+* :file:`Parser/Python.asdl` may need changes to match the Grammar.  Then run '``make
+  regen-ast``' to regenerate :file:`Include/Python-ast.h` and :file:`Python/Python-ast.c`.
+
+* :file:`Python/ast.c` will need changes to create the AST objects involved with the
   Grammar change.
 
-* Parser/pgen needs to be rerun to regenerate Include/graminit.h and
-  Python/graminit.c. ('make regen-grammar' should handle this for you.)
+* :file:`Parser/pgen` needs to be rerun to regenerate :file:`Include/graminit.h` and
+  :file:`Python/graminit.c`. ('``make regen-grammar``' should handle this for you.)
 
-* Python/symtable.c: This handles the symbol collection pass
+* :file:`Python/symtable.c`: This handles the symbol collection pass
   that happens immediately before the compilation pass.
 
-* Python/compile.c: You will need to create or modify the
-  compiler_* functions to generate opcodes for your productions.
+* :file:`Python/compile.c`: You will need to create or modify the
+  ``compiler_*`` functions to generate opcodes for your productions.
 
-* You may need to regenerate Lib/symbol.py and/or Lib/token.py
-  and/or Lib/keyword.py.
+* You may need to regenerate :file:`Lib/symbol.py`
+  and/or :file:`Lib/keyword.py`.
 
-* The parser module.  Add some of your new syntax to test_parser,
-  bang on Modules/parsermodule.c until it passes.
+* The :mod:`parser` module.  Add some of your new syntax to ``test_parser``,
+  bang on :file:`Modules/parsermodule.c` until it passes.
 
-* Add some usage of your new syntax to test_grammar.py
+* Add some usage of your new syntax to ``test_grammar.py``.
 
 * If you've gone so far as to change the token structure of
-  Python, then the Lib/tokenizer.py library module will need to be changed.
+  Python, then the :file:`Lib/tokenizer.py` library module will need to be changed.
 
-* Certain changes may require tweaks to the library module pyclbr.
+* Certain changes may require tweaks to the library module :mod:`pyclbr`.
 
-* Lib/lib2to3/Grammar.txt may need changes to match the Grammar.
+* :file:`Lib/lib2to3/Grammar.txt` may need changes to match the Grammar.
 
 * Documentation must be written!
 
 * After everything has been checked in, you're likely to see a new
-  change to Python/Python-ast.c.  This is because this
+  change to :file:`Python/Python-ast.c`.  This is because this
   (generated) file contains the git version of the source from
   which it was generated.  There's no way to avoid this; you just
   have to submit this file separately.


### PR DESCRIPTION
Include/token.h is now generated from Grammar/Tokens (see [bpo-30455](https://bugs.python.org/issue30455)).