### PR TITLE
Update xenial to bionic in setup.rst

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -301,9 +301,9 @@ dependencies for the Python you're working on by using the ``apt`` command.
 First, make sure you have enabled the source packages in the sources list.
 You can do this by adding the location of the source packages, including
 URL, distribution name and component name, to ``/etc/apt/sources.list``.
-Take Ubuntu Xenial for example::
+Take Ubuntu Bionic for example::
 
-   deb-src http://archive.ubuntu.com/ubuntu/ xenial main
+   deb-src http://archive.ubuntu.com/ubuntu/ bionic main
 
 For other distributions, like Debian, change the URL and names to correspond
 with the specific distribution.


### PR DESCRIPTION
Since Ubuntu 18.04 (Bionic Beaver) is a LTS release, update from xenial (16.04 LTS) to bionic in the setup steps.