### PR TITLE
Mention that news file should be at least 30 characters

### DIFF
--- a/committing.rst
+++ b/committing.rst
@@ -198,10 +198,11 @@ standard library). The file name itself should be of the format
 So a file name may be
 ``Misc/NEWS.d/next/Library/2017-05-27-16-46-23.bpo-12345.Yl4gI2.rst``.
 
-The contents of a news file should be valid reStructuredText. An 80 character
-column width should be used. There is no indentation or leading marker in the
-file (e.g. ``-``). There is also no need to start the entry with the issue
-number as it's part of the file name itself. Example news entry::
+The contents of a news file should be valid reStructuredText, and at least 30
+characters. An 80 character column width should be used. There is no indentation
+or leading marker in the file (e.g. ``-``). There is also no need to start the
+entry with the issue number as it's part of the file name itself. Example
+news entry::
 
   Fix warning message when ``os.chdir()`` fails inside
   ``test.support.temp_cwd()``.  Patch by Chris Jerdonek.


### PR DESCRIPTION
In the past we've seen behavior where people entered an empty news file just to make the "check" news" status pass.
In https://github.com/python/bedevere/issues/127 we've added a restriction that the news entry should be at least 30 characters long.