### PR TITLE
Update Black URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ The CPython Developer's Guide
    :target: https://python.zulipchat.com
 
 .. |Codestyle| image:: https://img.shields.io/badge/code%20style-black-000000.svg
-   :target: https://github.com/ambv/black
+   :target: https://github.com/psf/black
    :alt: Code style is black
 
 


### PR DESCRIPTION
> Black, your uncompromising #Python code formatter, was a project
> created with the community in mind from Day 1. Today we moved it under
> the PSF umbrella. It's now available on GitHub under
> https://github.com/python/black/ . You install and use it just like
> before.

https://twitter.com/llanga/status/1123980466292445190