### PR TITLE
Fix minor typo

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -215,7 +215,7 @@ C++ ecosystems).
 
 There are other Python implementations, each with a different focus.  Like
 CPython, they always have more things they would like to do than they have
-developers to work on them.  Some major example that may be of interest are:
+developers to work on them.  Some major examples that may be of interest are:
 
 * PyPy_: A Python interpreter focused on high speed (JIT-compiled) operation
   on major platforms


### PR DESCRIPTION
Grammar correction in _Other Interpreter Implementations_ section:
    Some major example -> Some major examples