### PR TITLE
Add RTD configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,15 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+sphinx:
+  configuration: conf.py
+
+formats: all
+
+python:
+  version: 3.7
+  install:
+    - requirements: requirements.txt


### PR DESCRIPTION
Create a config file to enable more people to edit settings without access to the RTD GUI.

[Reference: RTD documentation of configuration file](https://docs.readthedocs.io/en/stable/config-file/index.html#configuration-file)

[Rendered docs on my test account](https://test-devguide.readthedocs.io/en/rtd-build/)