### PR TITLE
Replace  --force with --force-with-lease

### DIFF
--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -94,7 +94,7 @@ You should have already :ref:`set up your system <setup>`,
 
      git fetch upstream
      git rebase upstream/master
-     git push --force origin <branch-name>
+     git push --force-with-lease origin <branch-name>
 
 * Finally go on :samp:`https://github.com/{<your-username>}/cpython`: you will
   see a box with the branch you just pushed and a green button that allows


### PR DESCRIPTION
`--force-with-lease` is generally less harmful than `--force`  and is usually what people want when they use `--force`.