### PR TITLE
Use rtd config file with htmldir builder

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,16 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+sphinx:
+  builder: htmldir
+  configuration: conf.py
+
+formats: all
+
+python:
+  version: 3.7
+  install:
+    - requirements: requirements.txt


### PR DESCRIPTION
This PR is a follow-up to #481 and the redirect issue in #483.

This adds the ReadTheDocs configuration file which is the preferred build method for RTD.

Unlike #481, this PR specifies that the sphinx builder should user `dirhtml` instead of the default `html`. [Reference in Sphinx docs](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.dirhtml.DirectoryHTMLBuilder)

@JulienPalard, would you mind doing the review on this? Happy to answer any specific questions about it. Thanks.