### PR TITLE
stop recommend rebase for new contributors

### DIFF
--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -262,11 +262,10 @@ Solution::
 You may see error messages like "CONFLICT" and "Automatic merge failed;" when
 you run ``git merge upstream/master``.
 
-When it happens, you need to resolve conflict.  See following articles for
-how to resolve conflicts.
+When it happens, you need to resolve conflict.  See these articles about resolving conflicts:
 
-* [About merge conflicts](https://help.github.com/en/articles/about-merge-conflicts)
-* [Resolving a merge conflict using the command line](https://help.github.com/en/articles/resolving-a-merge-conflict-using-the-command-line)
+* `About merge conflicts <https://help.github.com/en/articles/about-merge-conflicts>`_
+* `Resolving a merge conflict using the command line <https://help.github.com/en/articles/resolving-a-merge-conflict-using-the-command-line>`_
 
 
 .. _git_from_mercurial:

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -241,11 +241,8 @@ Scenario:
 Solution::
 
    git checkout master
-   git pull --rebase upstream master
+   git pull upstream master
    git push origin master
-
-The ``--rebase`` option is only needed if you have local changes to the
-branch.
 
 Another scenario:
 
@@ -259,8 +256,17 @@ Solution::
 
    git checkout some-branch
    git fetch upstream
-   git rebase upstream/master
-   git push --force origin some-branch
+   git merge upstream/master
+   git push origin some-branch
+
+You may see error messages like "CONFLICT" and "Automatic merge failed;" when
+you run ``git merge upstream/master``.
+
+When it happens, you need to resolve conflict.  See following articles for
+how to resolve conflicts.
+
+* [About merge conflicts](https://help.github.com/en/articles/about-merge-conflicts)
+* [Resolving a merge conflict using the command line](https://help.github.com/en/articles/resolving-a-merge-conflict-using-the-command-line)
 
 
 .. _git_from_mercurial:


### PR DESCRIPTION
We should not recommend "rebase" and "push -f" to new users.

These command requires high skill when they cause trouble.