### PR TITLE
python/core-workflow#339: Add "Python triage team" section to "triaging.rst"

### DIFF
--- a/triaging.rst
+++ b/triaging.rst
@@ -12,7 +12,7 @@ directly without any assistance.
 Additionally, this section provides an overview of the bug triager role.
 
 Python triage team
-------------
+-----------------------------
 
 The Python triage team is a role dedicated towards improving workflow efficiency and
 lessening the workload of the core developers. The expectations of this role

--- a/triaging.rst
+++ b/triaging.rst
@@ -9,7 +9,38 @@ and developers.
 Contributors with the Developer role on the `issue tracker`_ can triage issues
 directly without any assistance.
 
-Additionally, this section provides an overview of the `bug triager`_ role.
+Additionally, this section provides an overview of the bug triager role.
+
+Bug Triager
+------------
+
+The bug triager is a role dedicated towards improving workflow efficiency and
+lessening the workload of the core developers. The expectations of this role
+expand upon the "python triager" role on the `issue tracker`_. The responsibilities
+listed below are primarily centered around the Python GitHub repositories. This
+extends beyond cpython, to the other repos such as devguide, core-workflow, and
+python.org.
+
+* PR/issue management
+    - Renaming PRs
+    - Reviewing PRs
+    - Closing PRs and issues
+    - Assisting contributors
+    - Notifying appropriate core developers
+* Applying appropriate labels to PRs/Issues
+    - Skip news
+    - Skip issue
+    - Good first issue
+    - Other categorizations
+
+It is also of paramount importance to treat every contributor to the Python
+project kindly and with respect. Regardless of whether they're entirely new
+or a veteran core developer, they're actively choosing to voluntarily donate their
+time towards the improvement of Python. As is the case with any member of
+the Python Software Foundation, always follow the `PSF Code of Conduct`_.
+
+Note: Existing python triagers on the `issue tracker`_ are welcome to
+self-nominate themselves for the bug triager role if they are interested.
 
 Fields in the Issue Tracker
 ---------------------------
@@ -406,37 +437,6 @@ Checklist for Triaging
 * (Optional) Leave a brief comment about the proposed next action needed. If
   there is a long message list, a summary can be very helpful.
 
-Bug Triager
-------------
-
-The bug triager is a role dedicated towards improving workflow efficiency and
-lessening the workload of the core developers. The expectations of this role
-expand upon the "python triager" role on the `issue tracker`_. The responsibilities
-listed below are primarily centered around the Python GitHub repositories. This
-extends beyond cpython, to the other repos such as devguide, core-workflow, and
-python.org.
-
-* PR/issue management
-    - Renaming PRs
-    - Reviewing PRs
-    - Closing PRs and issues
-    - Assisting contributors
-    - Notifying appropriate core developers
-* Applying appropriate labels to PRs/Issues
-    - Skip news
-    - Skip issue
-    - Good first issue
-    - Other categorizations
-
-It is also of paramount importance to treat every contributor to the Python
-project kindly and with respect. Regardless of whether they're entirely new
-or a veteran core developer, they're actively choosing to voluntarily donate their
-time towards the improvement of Python. As is the case with any member of
-the Python Software Foundation, always follow the `PSF Code of Conduct`_.
-
-Note: Existing python triagers on the `issue tracker`_ are welcome to
-self-nominate themselves for the bug triager role if they are interested.
-
 
 .. _CPython: https://github.com/python/cpython/
 .. _Doc: https://github.com/python/cpython/tree/master/Doc/
@@ -472,5 +472,4 @@ self-nominate themselves for the bug triager role if they are interested.
 .. _Reporting security issues in Python: https://www.python.org/news/security/
 .. _python-ideas: https://mail.python.org/mailman/listinfo/python-ideas
 .. _release schedule: https://devguide.python.org/#status-of-python-branches
-.. _bug triager: https://devguide.python.org/triaging#Bug_Triager
 .. _PSF Code of Conduct: https://www.python.org/psf/codeofconduct/

--- a/triaging.rst
+++ b/triaging.rst
@@ -9,6 +9,8 @@ and developers.
 Contributors with the Developer role on the `issue tracker`_ can triage issues
 directly without any assistance.
 
+Additionally, this section provides an overview of the `bug triager`_ role.
+
 Fields in the Issue Tracker
 ---------------------------
 
@@ -404,6 +406,37 @@ Checklist for Triaging
 * (Optional) Leave a brief comment about the proposed next action needed. If
   there is a long message list, a summary can be very helpful.
 
+Bug Triager
+---------------------------
+
+The bug triager is a role dedicated towards improving workflow efficiency and
+lessening the workload of the core developers. The expectations of this role
+expand upon the "python triager" role on the `issue tracker`_. The responsibilities
+listed below are primarily centered around the Python GitHub repositories. This
+extends beyond cpython, to the other repos such as devguide, core-workflow, and
+python.org.
+
+* PR/issue management
+    - Renaming PRs
+    - Reviewing PRs
+    - Closing PRs and issues
+    - Assisting contributors
+    - Notifying appropriate core developers
+* Applying appropriate labels to PRs/Issues
+    - Skip news
+    - Skip issue
+    - Good first issue
+    - Other categorizations
+
+It is also of paramount importance to treat every contributor to the Python
+project kindly and with respect. Regardless of whether they're entirely new
+or a veteran core developer, they're actively choosing to voluntarily donate their
+time towards the improvement of Python. As is the case with any member of
+the Python Software Foundation, always follow the `PSF Code of Conduct`_.
+
+Note: Existing python triagers on the `issue tracker`_ are welcome to
+self-nominate themselves for the bug triager role if they are interested.
+
 
 .. _CPython: https://github.com/python/cpython/
 .. _Doc: https://github.com/python/cpython/tree/master/Doc/
@@ -439,3 +472,5 @@ Checklist for Triaging
 .. _Reporting security issues in Python: https://www.python.org/news/security/
 .. _python-ideas: https://mail.python.org/mailman/listinfo/python-ideas
 .. _release schedule: https://devguide.python.org/#status-of-python-branches
+.. _bug triager: https://devguide.python.org/triaging#Bug_Triager
+.. _PSF Code of Conduct: https://www.python.org/psf/codeofconduct/

--- a/triaging.rst
+++ b/triaging.rst
@@ -15,7 +15,7 @@ Python triage team
 -----------------------------
 
 The Python triage team is a group dedicated towards improving workflow
-efficiency and lessening the workload of the core developers. The expectations of
+efficiency through thoughtful review and triage of open issues and pull requests. This helps contributors receive timely feedback and enables core developers to focus on reviewed items which reduces their workload. The expectations of
 this role expand upon the "Developer" role on the `issue tracker`_. The
 responsibilities listed below are primarily centered around the Python GitHub
 repositories. This extends beyond CPython, and, as needed, to other repos such as devguide

--- a/triaging.rst
+++ b/triaging.rst
@@ -407,7 +407,7 @@ Checklist for Triaging
   there is a long message list, a summary can be very helpful.
 
 Bug Triager
----------------------------
+------------
 
 The bug triager is a role dedicated towards improving workflow efficiency and
 lessening the workload of the core developers. The expectations of this role

--- a/triaging.rst
+++ b/triaging.rst
@@ -39,8 +39,10 @@ or a veteran core developer, they're actively choosing to voluntarily donate the
 time towards the improvement of Python. As is the case with any member of
 the Python Software Foundation, always follow the `PSF Code of Conduct`_.
 
-Note: Existing python triagers on the `issue tracker`_ are welcome to
-self-nominate themselves for the bug triager role if they are interested.
+.. note::
+
+   Existing python triagers on the `issue tracker`_ are welcome to
+   self-nominate themselves for the bug triager role if they are interested.
 
 Fields in the Issue Tracker
 ---------------------------

--- a/triaging.rst
+++ b/triaging.rst
@@ -16,7 +16,7 @@ Python triage team
 
 The Python triage team is a role dedicated towards improving workflow efficiency and
 lessening the workload of the core developers. The expectations of this role
-expand upon the "python triager" role on the `issue tracker`_. The responsibilities
+expand upon the "Developer" role on the `issue tracker`_. The responsibilities
 listed below are primarily centered around the Python GitHub repositories. This
 extends beyond CPython, to the other repos such as devguide and core-workflow.
 
@@ -40,8 +40,8 @@ the Python Software Foundation, always follow the `PSF Code of Conduct`_.
 
 .. note::
 
-   Existing python triagers on the `issue tracker`_ are welcome to
-   self-nominate themselves for the bug triager role if they are interested.
+   Existing members of the "Developer" role on the `issue tracker`_ are welcome to
+   self-nominate for the bug triager role if they are interested.
 
 Fields in the Issue Tracker
 ---------------------------

--- a/triaging.rst
+++ b/triaging.rst
@@ -12,7 +12,7 @@ directly without any assistance.
 Additionally, this section provides an overview of the Python triage team.
 
 Python triage team
----------------------
+------------------
 
 The Python triage team is a group dedicated towards improving workflow
 efficiency through thoughtful review and triage of open issues and pull

--- a/triaging.rst
+++ b/triaging.rst
@@ -42,7 +42,7 @@ the Python Software Foundation, always follow the `PSF Code of Conduct`_.
 .. note::
 
    Existing members of the "Developer" role on the `issue tracker`_ are welcome to
-   self-nominate for the bug triager role if they are interested.
+   self-nominate for triage team membership if they are interested.
 
 Fields in the Issue Tracker
 ---------------------------

--- a/triaging.rst
+++ b/triaging.rst
@@ -41,7 +41,7 @@ the Python Software Foundation, always follow the `PSF Code of Conduct`_.
 
 .. note::
 
-   Existing members of the "Developer" role on the `issue tracker`_ are welcome to
+   Existing members with the "Developer" role on the `issue tracker`_ are welcome to
    self-nominate for triage team membership if they are interested.
 
 Fields in the Issue Tracker

--- a/triaging.rst
+++ b/triaging.rst
@@ -18,7 +18,7 @@ The Python triage team is a group dedicated towards improving workflow
 efficiency and lessening the workload of the core developers. The expectations of
 this role expand upon the "Developer" role on the `issue tracker`_. The
 responsibilities listed below are primarily centered around the Python GitHub
-repositories. This extends beyond CPython, to the other repos such as devguide
+repositories. This extends beyond CPython, and, as needed, to other repos such as devguide
 and core-workflow.
 
 * PR/issue management

--- a/triaging.rst
+++ b/triaging.rst
@@ -18,7 +18,7 @@ The bug triager is a role dedicated towards improving workflow efficiency and
 lessening the workload of the core developers. The expectations of this role
 expand upon the "python triager" role on the `issue tracker`_. The responsibilities
 listed below are primarily centered around the Python GitHub repositories. This
-extends beyond cpython, to the other repos such as devguide, core-workflow, and
+extends beyond CPython, to the other repos such as devguide, core-workflow, and
 python.org.
 
 * PR/issue management

--- a/triaging.rst
+++ b/triaging.rst
@@ -15,11 +15,13 @@ Python triage team
 -----------------------------
 
 The Python triage team is a group dedicated towards improving workflow
-efficiency through thoughtful review and triage of open issues and pull requests. This helps contributors receive timely feedback and enables core developers to focus on reviewed items which reduces their workload. The expectations of
-this role expand upon the "Developer" role on the `issue tracker`_. The
-responsibilities listed below are primarily centered around the Python GitHub
-repositories. This extends beyond CPython, and, as needed, to other repos such as devguide
-and core-workflow.
+efficiency through thoughtful review and triage of open issues and pull
+requests. This helps contributors receive timely feedback and enables core 
+developers to focus on reviewed items which reduces their workload. The 
+expectations of this role expand upon the "Developer" role on the 
+`issue tracker`_. The responsibilities listed below are primarily centered 
+around the Python GitHub repositories. This extends beyond CPython, and, as 
+needed, to other repos such as devguide and core-workflow.
 
 Responsibilities include:
 

--- a/triaging.rst
+++ b/triaging.rst
@@ -9,16 +9,17 @@ and developers.
 Contributors with the Developer role on the `issue tracker`_ can triage issues
 directly without any assistance.
 
-Additionally, this section provides an overview of the bug triager role.
+Additionally, this section provides an overview of the Python triage team.
 
 Python triage team
 -----------------------------
 
-The Python triage team is a role dedicated towards improving workflow efficiency and
-lessening the workload of the core developers. The expectations of this role
-expand upon the "Developer" role on the `issue tracker`_. The responsibilities
-listed below are primarily centered around the Python GitHub repositories. This
-extends beyond CPython, to the other repos such as devguide and core-workflow.
+The Python triage team is a group dedicated towards improving workflow
+efficiency and lessening the workload of the core developers. The expectations of
+this role expand upon the "Developer" role on the `issue tracker`_. The
+responsibilities listed below are primarily centered around the Python GitHub
+repositories. This extends beyond CPython, to the other repos such as devguide
+and core-workflow.
 
 * PR/issue management
     - Renaming PRs

--- a/triaging.rst
+++ b/triaging.rst
@@ -14,7 +14,7 @@ Additionally, this section provides an overview of the bug triager role.
 Python triage team
 ------------
 
-The bug triager is a role dedicated towards improving workflow efficiency and
+The Python triage team is a role dedicated towards improving workflow efficiency and
 lessening the workload of the core developers. The expectations of this role
 expand upon the "python triager" role on the `issue tracker`_. The responsibilities
 listed below are primarily centered around the Python GitHub repositories. This

--- a/triaging.rst
+++ b/triaging.rst
@@ -21,6 +21,8 @@ responsibilities listed below are primarily centered around the Python GitHub
 repositories. This extends beyond CPython, and, as needed, to other repos such as devguide
 and core-workflow.
 
+Responsibilities include:
+
 * PR/issue management
     - Renaming PRs
     - Reviewing PRs

--- a/triaging.rst
+++ b/triaging.rst
@@ -18,8 +18,7 @@ The Python triage team is a role dedicated towards improving workflow efficiency
 lessening the workload of the core developers. The expectations of this role
 expand upon the "python triager" role on the `issue tracker`_. The responsibilities
 listed below are primarily centered around the Python GitHub repositories. This
-extends beyond CPython, to the other repos such as devguide, core-workflow, and
-python.org.
+extends beyond CPython, to the other repos such as devguide and core-workflow.
 
 * PR/issue management
     - Renaming PRs

--- a/triaging.rst
+++ b/triaging.rst
@@ -12,7 +12,7 @@ directly without any assistance.
 Additionally, this section provides an overview of the Python triage team.
 
 Python triage team
------------------------------
+---------------------
 
 The Python triage team is a group dedicated towards improving workflow
 efficiency through thoughtful review and triage of open issues and pull

--- a/triaging.rst
+++ b/triaging.rst
@@ -11,7 +11,7 @@ directly without any assistance.
 
 Additionally, this section provides an overview of the bug triager role.
 
-Bug Triager
+Python triage team
 ------------
 
 The bug triager is a role dedicated towards improving workflow efficiency and


### PR DESCRIPTION
Component of issue python/core-workflow#339 and based on the proposal from https://discuss.python.org/t/proposal-create-bug-triage-team-on-github/992/19.