### PR TITLE
Add missing git command to pull request guide

### DIFF
--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -66,6 +66,7 @@ You should have already :ref:`set up your system <setup>`,
 
 * Create a new branch in your local clone::
 
+     git fetch upstream
      git checkout -b <branch-name> upstream/master
 
 * Make changes to the code, and use ``git status`` and ``git diff`` to see them.

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -64,9 +64,12 @@ Step-by-step Guide
 You should have already :ref:`set up your system <setup>`,
 :ref:`got the source code <checkout>`, and :ref:`built Python <compiling>`.
 
+* Update data from your ``upstream`` repository::
+
+     git fetch upstream
+
 * Create a new branch in your local clone::
 
-     git fetch upstream # upstream must be configured as a remote
      git checkout -b <branch-name> upstream/master
 
 * Make changes to the code, and use ``git status`` and ``git diff`` to see them.

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -66,7 +66,7 @@ You should have already :ref:`set up your system <setup>`,
 
 * Create a new branch in your local clone::
 
-     git fetch upstream
+     git fetch upstream # upstream must be configured as a remote
      git checkout -b <branch-name> upstream/master
 
 * Make changes to the code, and use ``git status`` and ``git diff`` to see them.


### PR DESCRIPTION
The pull request step-by-step guide provides instructions to create a
git branch using upstream/master as the start-point.  This commit adds
a command to the guide which safely makes sure that this start-point
exists in the local repository.  Fixes #509.