### PR TITLE
Add "GitHub Labels" section to "triaging.rst"

### DIFF
--- a/triaging.rst
+++ b/triaging.rst
@@ -52,44 +52,44 @@ the Python Software Foundation, always follow the `PSF Code of Conduct`_.
 GitHub Labels 
 '''''''''''''
 
-An important component of triaging PRs and issues involves appropriately 
+An important component of triaging PRs and issues involves appropriately
 categorizing them through the usage of labels.
 
-invalid - Used manually for PRs that do not meet basic requirements and can 
+invalid - Used manually for PRs that do not meet basic requirements and can
 be automatically added by bedevere when authors attempt to merge maintenace
 branches into the master branch. During competitions, this label casues the
 PR to not count towards the author's contributions.
 
-needs backport to X.Y - Used for PRs which are appropriate to backport to 
-branches prior to master. Generally, backports to the maintenance branches 
-are primarily bugfixes and documentation clarifications. Backports to the 
+needs backport to X.Y - Used for PRs which are appropriate to backport to
+branches prior to master. Generally, backports to the maintenance branches
+are primarily bugfixes and documentation clarifications. Backports to the
 security branches are strictly reserved for PRs involving security fixes, such as
-crashes, privilege escalation, and DoS. The use of this label will cause 
-miss-islington to attempt to automatically merge the PR into the branches 
+crashes, privilege escalation, and DoS. The use of this label will cause
+miss-islington to attempt to automatically merge the PR into the branches
 specified.
 
 skip issue - Used for PRs which involve trivial changes, such as typo fixes,
 comment changes, and section rephrases. The majority of PRs require
-an issue to be attached to, but if there are no code changes and the 
+an issue to be attached to, but if there are no code changes and the
 section being modified retains the same meaning, this label might be
-appropriate. 
+appropriate.
 
 skip news - Similar to the skip issue label, this label is used for PRs which
 involve trivial changes, backports, or already have a relevant news entry
 in another PR. Any potentially impactful changes should have a
-corresponding news entry, but for trivial changes it's commonly at the 
+corresponding news entry, but for trivial changes it's commonly at the
 discretion of the PR author if they wish to opt-out of making one.
 
 OS-X - Used for PRs involving changes which only have an effect upon
-a specific operating system. Current variations of the label include 
+a specific operating system. Current variations of the label include
 OS-Windows and OS-Mac.
 
-sprint - Used for PRs authored during an in-person sprint, such as 
+sprint - Used for PRs authored during an in-person sprint, such as
 PyCons, EuroPython, or other official Python events. The label is
 used to prioritize the review of those PRs during the sprint.
 
-type-bugfix - Used for PRs that fix unintentional behavior, but do not 
-pose significant security concerns. Generally, bugfixes will be attached 
+type-bugfix - Used for PRs that fix unintentional behavior, but do not
+pose significant security concerns. Generally, bugfixes will be attached
 to a specific issue where the unintended behavior was first reported.
 
 Fields in the Issue Tracker

--- a/triaging.rst
+++ b/triaging.rst
@@ -49,7 +49,8 @@ the Python Software Foundation, always follow the `PSF Code of Conduct`_.
    self-nominate for triage team membership if they are interested.
    
 GitHub Labels
-''''''''''''''''
+GitHub Labels
+'''''''''''''
 
 An important component of triaging PRs and issues involves appropriately 
 categorizing them through the usage of labels. Here are several of the

--- a/triaging.rst
+++ b/triaging.rst
@@ -88,7 +88,7 @@ sprint - Used for PRs authored during an in-person sprint, such as
 PyCons, EuroPython, or other official Python events. The label is
 used to prioritize the review of those PRs during the sprint.
 
-type-bugfix - Used for PRs that fix unintentional behavior, but do not
+type-bugfix - Used for PRs that address unintentional behavior, but do not
 pose significant security concerns. Generally, bugfixes will be attached
 to a specific issue where the unintended behavior was first reported.
 

--- a/triaging.rst
+++ b/triaging.rst
@@ -61,6 +61,9 @@ DO-NOT-MERGE - Used on PRs to prevent miss-islington from being able
 to automatically merge to pull request. This label is appropriate when a PR
 has a non-trivial conflict with the branch it is being merged into.
 
+expert-asyncio - Used for PRs which involve changes to the asyncio module
+or other asynchronous frameworks that utilize it.
+
 invalid - Used manually for PRs that do not meet basic requirements and
 automatically added by bedevere when PR authors attempt to merge maintenace
 branches into the master branch. During competitions, this label casues the

--- a/triaging.rst
+++ b/triaging.rst
@@ -95,6 +95,9 @@ to a specific issue where the unintended behavior was first reported.
 type-documentation - Used for PRs which exclusively involve changes to
 documentation.
 
+type-enhancement - Used for PRs which provide additional functionality
+or capabilities beyond the existing specifications. 
+
 Fields in the Issue Tracker
 ---------------------------
 

--- a/triaging.rst
+++ b/triaging.rst
@@ -93,10 +93,12 @@ pose significant security concerns. Generally, bugfixes will be attached
 to a specific issue where the unintended behavior was first reported.
 
 type-documentation - Used for PRs which exclusively involve changes to
-documentation.
+the documentation.
 
 type-enhancement - Used for PRs which provide additional functionality
 or capabilities beyond the existing specifications. 
+
+type-tests - Used for PRs which exclusively involve changes to the tests.
 
 Fields in the Issue Tracker
 ---------------------------

--- a/triaging.rst
+++ b/triaging.rst
@@ -48,7 +48,7 @@ the Python Software Foundation, always follow the `PSF Code of Conduct`_.
    Existing members with the "Developer" role on the `issue tracker`_ are welcome to
    self-nominate for triage team membership if they are interested.
    
-GitHub Labels
+
 GitHub Labels
 '''''''''''''
 

--- a/triaging.rst
+++ b/triaging.rst
@@ -53,8 +53,7 @@ GitHub Labels
 '''''''''''''
 
 An important component of triaging PRs and issues involves appropriately 
-categorizing them through the usage of labels. Here are several of the
-common ones utilized by the Python triage team:
+categorizing them through the usage of labels.
 
 +-----------------------+----------------------------------------------------------------------------+
 | Label                 | Description                                                                |

--- a/triaging.rst
+++ b/triaging.rst
@@ -55,8 +55,8 @@ GitHub Labels
 An important component of triaging PRs and issues on GitHub involves
 appropriately categorizing them through the usage of labels.
 
-invalid - Used manually for PRs that do not meet basic requirements and can
-be automatically added by bedevere when authors attempt to merge maintenace
+invalid - Used manually for PRs that do not meet basic requirements and
+automatically added by bedevere when PR authors attempt to merge maintenace
 branches into the master branch. During competitions, this label casues the
 PR to not count towards the author's contributions.
 

--- a/triaging.rst
+++ b/triaging.rst
@@ -74,6 +74,10 @@ in another PR. Any potentially impactful changes should have a
 corresponding news entry, but for trivial changes it's commonly at the 
 discretion of the PR author if they wish to opt-out of making one.
 
+OS-X - Used for PRs involving changes which only have an effect upon
+a specific operating system. Current variations of the label include 
+OS-Windows and OS-Mac.
+
 
 Fields in the Issue Tracker
 ---------------------------

--- a/triaging.rst
+++ b/triaging.rst
@@ -47,6 +47,29 @@ the Python Software Foundation, always follow the `PSF Code of Conduct`_.
 
    Existing members with the "Developer" role on the `issue tracker`_ are welcome to
    self-nominate for triage team membership if they are interested.
+   
+GitHub Labels
+''''''''''''''''
+
+An important component of triaging PRs and issues involves appropriately 
+categorizing them through the usage of labels. Here are several of the
+common ones utilized:
+
++------------+----------------------------------------------------------------------------+
+| Label      | Description                                                                |
++------------+----------------------------------------------------------------------------+
+| skip issue | Used for PRs which involve trivial changes, such as typo fixes,            |
+|            | comment changes, and section rephrases. The majority of PRs require        |
+|            | an issue to be attached to, but if there are no code changes and the       |
+|            | section being modified retains the same meaning, this label might be       |
+|            | appropriate. It is also used commonly for backports.                       |
++------------+----------------------------------------------------------------------------+
+| skip news  | Used frequently in combination with the skip issue label for PRs that      |
+|            | involve trivial changes, backports, or already have a relevant news entry  |
+|            | in another PR. Any potentially impactful changes should have a             |
+|            | corresponding  news entry, but for trivial changes it's commonly at the    |
+|            | discretion of the PR author if they wish to opt-out of making one.         |
++------------+----------------------------------------------------------------------------+
 
 Fields in the Issue Tracker
 ---------------------------

--- a/triaging.rst
+++ b/triaging.rst
@@ -95,7 +95,8 @@ pose significant security concerns. Generally, bugfixes will be attached
 to a specific issue where the unintended behavior was first reported.
 
 type-documentation - Used for PRs that exclusively involve changes to
-the documentation.
+the documentation. Documentation includes `*.rst` files, docstrings,
+and code comments.
 
 type-enhancement - Used for PRs that provide additional functionality
 or capabilities beyond the existing specifications.

--- a/triaging.rst
+++ b/triaging.rst
@@ -55,12 +55,18 @@ GitHub Labels
 An important component of triaging PRs and issues involves appropriately 
 categorizing them through the usage of labels.
 
-needs backport to X.Y - Used for PRs which are appropriate to backport to branches prior to 
-master. Generally, backports to the maintenance branches are primarily
-bugfixes and documentation clarifications. Backports to the security
-branches are strictly reserved for PRs involving security fixes, such as
-crashes, privilege escalation, and DoS. The use of this label will cause the 
-bot to attempt to automatically merge the PR into the branches specified.
+invalid - Used manually for PRs that do not meet basic requirements and can 
+be automatically added by bedevere when authors attempt to merge maintenace
+branches into the master branch. During competitions, this label casues the
+PR to not count towards the author's contributions.
+
+needs backport to X.Y - Used for PRs which are appropriate to backport to 
+branches prior to master. Generally, backports to the maintenance branches 
+are primarily bugfixes and documentation clarifications. Backports to the 
+security branches are strictly reserved for PRs involving security fixes, such as
+crashes, privilege escalation, and DoS. The use of this label will cause 
+miss-islington to attempt to automatically merge the PR into the branches 
+specified.
 
 skip issue - Used for PRs which involve trivial changes, such as typo fixes,
 comment changes, and section rephrases. The majority of PRs require

--- a/triaging.rst
+++ b/triaging.rst
@@ -92,6 +92,9 @@ type-bugfix - Used for PRs that address unintentional behavior, but do not
 pose significant security concerns. Generally, bugfixes will be attached
 to a specific issue where the unintended behavior was first reported.
 
+type-documentation - Used for PRs which exclusively involve changes to
+documentation.
+
 Fields in the Issue Tracker
 ---------------------------
 

--- a/triaging.rst
+++ b/triaging.rst
@@ -88,6 +88,9 @@ sprint - Used for PRs authored during an in-person sprint, such as
 PyCons, EuroPython, or other official Python events. The label is
 used to prioritize the review of those PRs during the sprint.
 
+type-bugfix - Used for PRs that fix unintentional behavior, but do not 
+pose significant security concerns. Generally, bugfixes will be attached 
+to a specific issue where the unintendedbehavior was first reported.
 
 Fields in the Issue Tracker
 ---------------------------

--- a/triaging.rst
+++ b/triaging.rst
@@ -57,63 +57,77 @@ appropriately categorizing them through the usage of labels.
 
 Labels for PRs include:
 
-DO-NOT-MERGE - Used on PRs to prevent miss-islington from being able
-to automatically merge to pull request. This label is appropriate when a PR
-has a non-trivial conflict with the branch it is being merged into.
+DO-NOT-MERGE
+    Used on PRs to prevent miss-islington from being able
+    to automatically merge to pull request. This label is appropriate when a PR
+    has a non-trivial conflict with the branch it is being merged into.
 
-expert-asyncio - Used for PRs which involve changes to the asyncio module
-or other asynchronous frameworks that utilize it.
+expert-asyncio
+    Used for PRs which involve changes to the asyncio module
+    or other asynchronous frameworks that utilize it.
 
-invalid - Used manually for PRs that do not meet basic requirements and
-automatically added by bedevere when PR authors attempt to merge maintenace
-branches into the master branch. During competitions, this label casues the
-PR to not count towards the author's contributions.
+invalid
+    Used manually for PRs that do not meet basic requirements and
+    automatically added by bedevere when PR authors attempt to merge maintenace
+    branches into the master branch. During competitions, this label casues the
+    PR to not count towards the author's contributions.
 
-needs backport to X.Y - Used for PRs which are appropriate to backport to
-branches prior to master. Generally, backports to the maintenance branches
-are primarily bugfixes and documentation clarifications. Backports to the
-security branches are strictly reserved for PRs involving security fixes, such as
-crashes, privilege escalation, and DoS. The use of this label will cause
-miss-islington to attempt to automatically merge the PR into the branches
-specified.
+needs backport to X.Y
+    Used for PRs which are appropriate to backport to
+    branches prior to master. Generally, backports to the maintenance branches
+    are primarily bugfixes and documentation clarifications. Backports to the
+    security branches are strictly reserved for PRs involving security fixes, such as
+    crashes, privilege escalation, and DoS. The use of this label will cause
+    miss-islington to attempt to automatically merge the PR into the branches
+    specified.
 
-skip issue - Used for PRs which involve trivial changes, such as typo fixes,
-comment changes, and section rephrases. The majority of PRs require
-an issue to be attached to, but if there are no code changes and the
-section being modified retains the same meaning, this label might be
-appropriate.
+skip issue
+    Used for PRs which involve trivial changes, such as typo fixes,
+    comment changes, and section rephrases. The majority of PRs require
+    an issue to be attached to, but if there are no code changes and the
+    section being modified retains the same meaning, this label might be
+    appropriate.
 
-skip news - Similar to the skip issue label, this label is used for PRs which
-involve trivial changes, backports, or already have a relevant news entry
-in another PR. Any potentially impactful changes should have a
-corresponding news entry, but for trivial changes it's commonly at the
-discretion of the PR author if they wish to opt-out of making one.
+skip news
+    Similar to the skip issue label, this label is used for PRs which
+    involve trivial changes, backports, or already have a relevant news entry
+    in another PR. Any potentially impactful changes should have a
+    corresponding news entry, but for trivial changes it's commonly at the
+    discretion of the PR author if they wish to opt-out of making one.
 
-OS-X - Used for PRs involving changes which only have an effect upon
-a specific operating system. Current variations of the label include
-OS-Windows and OS-Mac.
+OS-X
+    Used for PRs involving changes which only have an effect upon
+    a specific operating system. Current variations of the label include
+    OS-Windows and OS-Mac.
 
-sprint - Used for PRs authored during an in-person sprint, such as
-at PyCon, EuroPython, or other official Python events. The label is
-used to prioritize the review of those PRs during the sprint.
+sprint
+    Used for PRs authored during an in-person sprint, such as
+    at PyCon, EuroPython, or other official Python events. The label is
+    used to prioritize the review of those PRs during the sprint.
 
-type-bugfix - Used for PRs that address unintentional behavior, but do not
-pose significant security concerns. Generally, bugfixes will be attached
-to a specific issue where the unintended behavior was first reported.
+type-bugfix
+    Used for PRs that address unintentional behavior, but do not
+    pose significant security concerns. Generally, bugfixes will be attached
+    to a specific issue where the unintended behavior was first reported.
 
-type-documentation - Used for PRs that exclusively involve changes to
-the documentation. Documentation includes `*.rst` files, docstrings,
-and code comments.
+type-documentation
+    Used for PRs that exclusively involve changes to
+    the documentation. Documentation includes `*.rst` files, docstrings,
+    and code comments.
 
-type-enhancement - Used for PRs that provide additional functionality
-or capabilities beyond the existing specifications.
+type-enhancement
+    Used for PRs that provide additional functionality
+    or capabilities beyond the existing specifications.
 
-type-performance - Used for PRs that provide performance optimizations.
+type-performance
+    Used for PRs that provide performance optimizations.
 
-type-security - Used for PRs that involve critical security issues. Less severe 
-security concerns can instead use the type-bugfix label.
+type-security
+    Used for PRs that involve critical security issues. Less severe 
+    security concerns can instead use the type-bugfix label.
 
-type-tests - Used for PRs that exclusively involve changes to the tests.
+type-tests
+    Used for PRs that exclusively involve changes to the tests.
 
 Fields in the Issue Tracker
 ---------------------------

--- a/triaging.rst
+++ b/triaging.rst
@@ -59,7 +59,8 @@ needs backport to X.Y - Used for PRs which are appropriate to backport to branch
 master. Generally, backports to the maintenance branches are primarily
 bugfixes and documentation clarifications. Backports to the security
 branches are strictly reserved for PRs involving security fixes, such as
-crashes, privilege escalation, and DoS.
+crashes, privilege escalation, and DoS. The use of this label will cause the 
+bot to attempt to automatically merge the PR into the branches specified.
 
 skip issue - Used for PRs which involve trivial changes, such as typo fixes,
 comment changes, and section rephrases. The majority of PRs require
@@ -67,10 +68,10 @@ an issue to be attached to, but if there are no code changes and the
 section being modified retains the same meaning, this label might be
 appropriate. 
 
-skip news - Used frequently in combination with the skip issue label for PRs that
+skip news - Similar to the skip issue label, this label is used for PRs which
 involve trivial changes, backports, or already have a relevant news entry
 in another PR. Any potentially impactful changes should have a
-corresponding  news entry, but for trivial changes it's commonly at the 
+corresponding news entry, but for trivial changes it's commonly at the 
 discretion of the PR author if they wish to opt-out of making one.
 
 

--- a/triaging.rst
+++ b/triaging.rst
@@ -92,11 +92,13 @@ type-bugfix - Used for PRs that address unintentional behavior, but do not
 pose significant security concerns. Generally, bugfixes will be attached
 to a specific issue where the unintended behavior was first reported.
 
-type-documentation - Used for PRs which exclusively involve changes to
+type-documentation - Used for PRs that exclusively involve changes to
 the documentation.
 
-type-enhancement - Used for PRs which provide additional functionality
-or capabilities beyond the existing specifications. 
+type-enhancement - Used for PRs that provide additional functionality
+or capabilities beyond the existing specifications.
+
+type-performance - Used for PRs that provide performance optimizations.
 
 type-tests - Used for PRs which exclusively involve changes to the tests.
 

--- a/triaging.rst
+++ b/triaging.rst
@@ -110,6 +110,9 @@ or capabilities beyond the existing specifications.
 
 type-performance - Used for PRs that provide performance optimizations.
 
+type-security - Used for PRs that involve critical security issues. Less severe 
+security concerns can instead use the type-bugfix label.
+
 type-tests - Used for PRs that exclusively involve changes to the tests.
 
 Fields in the Issue Tracker

--- a/triaging.rst
+++ b/triaging.rst
@@ -49,8 +49,8 @@ the Python Software Foundation, always follow the `PSF Code of Conduct`_.
    self-nominate for triage team membership if they are interested.
    
 
-GitHub Labels 
-'''''''''''''
+GitHub Labels for PRs
+'''''''''''''''''''''
 
 An important component of triaging PRs for the CPython repo involves
 appropriately categorizing them through the usage of labels.

--- a/triaging.rst
+++ b/triaging.rst
@@ -84,6 +84,10 @@ OS-X - Used for PRs involving changes which only have an effect upon
 a specific operating system. Current variations of the label include 
 OS-Windows and OS-Mac.
 
+sprint - Used for PRs authored during an in-person sprint, such as 
+PyCons, EuroPython, or other official Python events. The label is
+used to prioritize the review of those PRs during the sprint.
+
 
 Fields in the Issue Tracker
 ---------------------------

--- a/triaging.rst
+++ b/triaging.rst
@@ -55,6 +55,8 @@ GitHub Labels
 An important component of triaging PRs and issues on GitHub involves
 appropriately categorizing them through the usage of labels.
 
+Labels include:
+
 invalid - Used manually for PRs that do not meet basic requirements and
 automatically added by bedevere when PR authors attempt to merge maintenace
 branches into the master branch. During competitions, this label casues the

--- a/triaging.rst
+++ b/triaging.rst
@@ -55,21 +55,27 @@ An important component of triaging PRs and issues involves appropriately
 categorizing them through the usage of labels. Here are several of the
 common ones utilized:
 
-+------------+----------------------------------------------------------------------------+
-| Label      | Description                                                                |
-+------------+----------------------------------------------------------------------------+
-| skip issue | Used for PRs which involve trivial changes, such as typo fixes,            |
-|            | comment changes, and section rephrases. The majority of PRs require        |
-|            | an issue to be attached to, but if there are no code changes and the       |
-|            | section being modified retains the same meaning, this label might be       |
-|            | appropriate. It is also used commonly for backports.                       |
-+------------+----------------------------------------------------------------------------+
-| skip news  | Used frequently in combination with the skip issue label for PRs that      |
-|            | involve trivial changes, backports, or already have a relevant news entry  |
-|            | in another PR. Any potentially impactful changes should have a             |
-|            | corresponding  news entry, but for trivial changes it's commonly at the    |
-|            | discretion of the PR author if they wish to opt-out of making one.         |
-+------------+----------------------------------------------------------------------------+
++-----------------------+----------------------------------------------------------------------------+
+| Label                 | Description                                                                |
++-----------------------+----------------------------------------------------------------------------+
+| needs backport to X.Y | Used for PRs which are appropriate to backport to branches prior to        |
+|                       | master. Generally, backports to the maintenance branches are primarily     |
+|                       | bugfixes and documentation clarifications. Backports to the security       |
+|                       | branches are strictly reserved for PRs involving security fixes, such as   |
+|                       | crashes, privilege escalation, and DoS.                                    |
++-----------------------+----------------------------------------------------------------------------+
+| skip issue            | Used for PRs which involve trivial changes, such as typo fixes,            |
+|                       | comment changes, and section rephrases. The majority of PRs require        |
+|                       | an issue to be attached to, but if there are no code changes and the       |
+|                       | section being modified retains the same meaning, this label might be       |
+|                       | appropriate. It is also used commonly for backports.                       |
++-----------------------+----------------------------------------------------------------------------+
+| skip news             | Used frequently in combination with the skip issue label for PRs that      |
+|                       | involve trivial changes, backports, or already have a relevant news entry  |
+|                       | in another PR. Any potentially impactful changes should have a             |
+|                       | corresponding  news entry, but for trivial changes it's commonly at the    |
+|                       | discretion of the PR author if they wish to opt-out of making one.         |
++-----------------------+----------------------------------------------------------------------------+
 
 Fields in the Issue Tracker
 ---------------------------

--- a/triaging.rst
+++ b/triaging.rst
@@ -49,33 +49,30 @@ the Python Software Foundation, always follow the `PSF Code of Conduct`_.
    self-nominate for triage team membership if they are interested.
    
 
-GitHub Labels
+GitHub Labels 
 '''''''''''''
 
 An important component of triaging PRs and issues involves appropriately 
 categorizing them through the usage of labels.
 
-+-----------------------+----------------------------------------------------------------------------+
-| Label                 | Description                                                                |
-+-----------------------+----------------------------------------------------------------------------+
-| needs backport to X.Y | Used for PRs which are appropriate to backport to branches prior to        |
-|                       | master. Generally, backports to the maintenance branches are primarily     |
-|                       | bugfixes and documentation clarifications. Backports to the security       |
-|                       | branches are strictly reserved for PRs involving security fixes, such as   |
-|                       | crashes, privilege escalation, and DoS.                                    |
-+-----------------------+----------------------------------------------------------------------------+
-| skip issue            | Used for PRs which involve trivial changes, such as typo fixes,            |
-|                       | comment changes, and section rephrases. The majority of PRs require        |
-|                       | an issue to be attached to, but if there are no code changes and the       |
-|                       | section being modified retains the same meaning, this label might be       |
-|                       | appropriate. It is also used commonly for backports.                       |
-+-----------------------+----------------------------------------------------------------------------+
-| skip news             | Used frequently in combination with the skip issue label for PRs that      |
-|                       | involve trivial changes, backports, or already have a relevant news entry  |
-|                       | in another PR. Any potentially impactful changes should have a             |
-|                       | corresponding  news entry, but for trivial changes it's commonly at the    |
-|                       | discretion of the PR author if they wish to opt-out of making one.         |
-+-----------------------+----------------------------------------------------------------------------+
+needs backport to X.Y - Used for PRs which are appropriate to backport to branches prior to 
+master. Generally, backports to the maintenance branches are primarily
+bugfixes and documentation clarifications. Backports to the security
+branches are strictly reserved for PRs involving security fixes, such as
+crashes, privilege escalation, and DoS.
+
+skip issue - Used for PRs which involve trivial changes, such as typo fixes,
+comment changes, and section rephrases. The majority of PRs require
+an issue to be attached to, but if there are no code changes and the 
+section being modified retains the same meaning, this label might be
+appropriate. It is also used commonly for backports.
+
+skip news - Used frequently in combination with the skip issue label for PRs that
+involve trivial changes, backports, or already have a relevant news entry
+in another PR. Any potentially impactful changes should have a
+corresponding  news entry, but for trivial changes it's commonly at the 
+discretion of the PR author if they wish to opt-out of making one.
+
 
 Fields in the Issue Tracker
 ---------------------------

--- a/triaging.rst
+++ b/triaging.rst
@@ -53,7 +53,7 @@ GitHub Labels
 
 An important component of triaging PRs and issues involves appropriately 
 categorizing them through the usage of labels. Here are several of the
-common ones utilized:
+common ones utilized by the Python triage team:
 
 +-----------------------+----------------------------------------------------------------------------+
 | Label                 | Description                                                                |

--- a/triaging.rst
+++ b/triaging.rst
@@ -85,7 +85,7 @@ a specific operating system. Current variations of the label include
 OS-Windows and OS-Mac.
 
 sprint - Used for PRs authored during an in-person sprint, such as
-PyCons, EuroPython, or other official Python events. The label is
+at PyCon, EuroPython, or other official Python events. The label is
 used to prioritize the review of those PRs during the sprint.
 
 type-bugfix - Used for PRs that address unintentional behavior, but do not

--- a/triaging.rst
+++ b/triaging.rst
@@ -57,6 +57,10 @@ appropriately categorizing them through the usage of labels.
 
 Labels include:
 
+DO-NOT-MERGE - Used on PRs to prevent miss-islington from being able
+to automatically merge to pull request. This label is appropriate when a PR
+has a non-trivial conflict with the branch it is being merged into.
+
 invalid - Used manually for PRs that do not meet basic requirements and
 automatically added by bedevere when PR authors attempt to merge maintenace
 branches into the master branch. During competitions, this label casues the

--- a/triaging.rst
+++ b/triaging.rst
@@ -52,10 +52,10 @@ the Python Software Foundation, always follow the `PSF Code of Conduct`_.
 GitHub Labels 
 '''''''''''''
 
-An important component of triaging PRs and issues on GitHub involves
+An important component of triaging PRs for the CPython repo involves
 appropriately categorizing them through the usage of labels.
 
-Labels include:
+Labels for PRs include:
 
 DO-NOT-MERGE - Used on PRs to prevent miss-islington from being able
 to automatically merge to pull request. This label is appropriate when a PR

--- a/triaging.rst
+++ b/triaging.rst
@@ -90,7 +90,7 @@ used to prioritize the review of those PRs during the sprint.
 
 type-bugfix - Used for PRs that fix unintentional behavior, but do not 
 pose significant security concerns. Generally, bugfixes will be attached 
-to a specific issue where the unintendedbehavior was first reported.
+to a specific issue where the unintended behavior was first reported.
 
 Fields in the Issue Tracker
 ---------------------------

--- a/triaging.rst
+++ b/triaging.rst
@@ -100,7 +100,7 @@ or capabilities beyond the existing specifications.
 
 type-performance - Used for PRs that provide performance optimizations.
 
-type-tests - Used for PRs which exclusively involve changes to the tests.
+type-tests - Used for PRs that exclusively involve changes to the tests.
 
 Fields in the Issue Tracker
 ---------------------------

--- a/triaging.rst
+++ b/triaging.rst
@@ -52,8 +52,8 @@ the Python Software Foundation, always follow the `PSF Code of Conduct`_.
 GitHub Labels 
 '''''''''''''
 
-An important component of triaging PRs and issues involves appropriately
-categorizing them through the usage of labels.
+An important component of triaging PRs and issues on GitHub involves
+appropriately categorizing them through the usage of labels.
 
 invalid - Used manually for PRs that do not meet basic requirements and can
 be automatically added by bedevere when authors attempt to merge maintenace

--- a/triaging.rst
+++ b/triaging.rst
@@ -65,7 +65,7 @@ skip issue - Used for PRs which involve trivial changes, such as typo fixes,
 comment changes, and section rephrases. The majority of PRs require
 an issue to be attached to, but if there are no code changes and the 
 section being modified retains the same meaning, this label might be
-appropriate. It is also used commonly for backports.
+appropriate. 
 
 skip news - Used frequently in combination with the skip issue label for PRs that
 involve trivial changes, backports, or already have a relevant news entry


### PR DESCRIPTION
Component of https://github.com/python/devguide/issues/296.

Currently, this is just a draft including a brief summary and a couple of labels. Working on adding most of the other common labels and applying the correct formatting for the table before opening it for review. Only includes labels that are going to be addable by those in the Python triage team (currently only from the CPython repository). Let me know if I missed any.

Labels to add:

~~DO-NOT-MERGE~~
~~expert-asyncio~~
~~invalid~~
~~needs backport to X.Y~~
~~skip issue~~
~~skip news~~
~~OS-X~~
~~sprint~~
~~type-bugfix~~
~~type-documentation~~
~~type-enhancement~~
~~type-performance~~
~~type-security~~
~~type-tests~~


