### PR TITLE
Add procedure for adding people to the Python Triage team

### DIFF
--- a/triaging.rst
+++ b/triaging.rst
@@ -43,29 +43,29 @@ or a veteran core developer, they're actively choosing to voluntarily donate the
 time towards the improvement of Python. As is the case with any member of
 the Python Software Foundation, always follow the `PSF Code of Conduct`_.
 
-Becoming a member of Python Triage team
+Becoming a member of the Python triage team
 ---------------------------------------
 
 Any Python core developers are welcome to invite a Python contributor to the
-Python Triage team. Do note that the responsibilities of a Python Triage member
-is more elevated than a bug triager in bpo. For example, the Python Triage member
-has access to more repositories than just CPython. Triages will be responsible
-to handle not just issues, but also pull requests, and even commanding backports.
+Python triage team. Do note that the responsibilities of a Python triager
+is more elevated than a developer on bpo. For example, the Python triager
+has access to more repositories than just CPython. Triagers will be responsible
+to handle not just issues, but also pull requests, and even managing backports.
 
-Any existing triagers in b.p.o can transition to the Python Triage role.
+Any existing developers on b.p.o can transition into becoming a Python triager.
 They can request this to any core developer, and the core developer
 can pass the request to the Python organization admin on GitHub. The request
-can be made privately via DM in Zulip or Discourse, or publicly by opening
-an issue in core-workflow.
+can be made privately via a DM in Zulip or Discourse, or publicly by opening
+an issue in the core-workflow repository.
 
-Any contributor who is not already a triager in b.p.o can also self-nominate
-to be a member of Python Triage team. They can request this to any core developer,
+Any contributor who is not already a developer on b.p.o can also self-nominate
+to be a member of Python triage team. They can request this to any core developer,
 via DM in Zulip or Discourse, or publicly by opening an issue in core-workflow.
-If a core developer agrees and willing to vouch for them, the core developer
-can pass the request to the administrator. They should also be added as
-triager in bpo.
+If a core developer agrees and is willing to vouch for them, the core developer
+can pass the request to the GitHub administrator. They should also be added as
+developer on bpo.
 
-For every new triager, it would be great to announce them in Python-committers
+For every new triager, it would be great to announce them in the python-committers
 mailing list and core-workflow category in Discourse. `Example announcement
 <https://discuss.python.org/t/abhilash-raj-has-been-granted-triage-role-on-github/2089>`_.
 

--- a/triaging.rst
+++ b/triaging.rst
@@ -54,14 +54,16 @@ to handle not just issues, but also pull requests, and even managing backports.
 
 Any existing developers on b.p.o can transition into becoming a Python triager.
 They can request this to any core developer, and the core developer
-can pass the request to the Python organization admin on GitHub. The request
-can be made privately via a DM in Zulip or Discourse, or publicly by opening
+can pass the request to the `Python organization admin
+<https://devguide.python.org/devcycle/?highlight=organization%20admin#current-owners>`_
+on GitHub. The request
+can be made confidentially via a DM in Zulip or Discourse, or publicly by opening
 an `issue in the core-workflow repository
 <https://github.com/python/core-workflow/issues/new?template=triage_membership.md>`_.
 
 Any contributor who is not already a developer on b.p.o can also self-nominate
 to be a member of Python triage team. They can request this to any core developer,
-via DM in Zulip or Discourse, or publicly by opening an issue in core-workflow.
+confidentially via DM in Zulip or Discourse, or publicly by opening an issue in core-workflow.
 If a core developer agrees and is willing to vouch for them, the core developer
 can pass the request to the GitHub administrator. They should also be added as
 developer on bpo.

--- a/triaging.rst
+++ b/triaging.rst
@@ -44,7 +44,7 @@ time towards the improvement of Python. As is the case with any member of
 the Python Software Foundation, always follow the `PSF Code of Conduct`_.
 
 Becoming a member of the Python triage team
----------------------------------------
+-------------------------------------------
 
 Any Python core developers are welcome to invite a Python contributor to the
 Python triage team. Do note that the responsibilities of a Python triager

--- a/triaging.rst
+++ b/triaging.rst
@@ -56,7 +56,8 @@ Any existing developers on b.p.o can transition into becoming a Python triager.
 They can request this to any core developer, and the core developer
 can pass the request to the Python organization admin on GitHub. The request
 can be made privately via a DM in Zulip or Discourse, or publicly by opening
-an issue in the core-workflow repository.
+an `issue in the core-workflow repository
+<https://github.com/python/core-workflow/issues/new?template=triage_membership.md>`_.
 
 Any contributor who is not already a developer on b.p.o can also self-nominate
 to be a member of Python triage team. They can request this to any core developer,

--- a/triaging.rst
+++ b/triaging.rst
@@ -43,11 +43,32 @@ or a veteran core developer, they're actively choosing to voluntarily donate the
 time towards the improvement of Python. As is the case with any member of
 the Python Software Foundation, always follow the `PSF Code of Conduct`_.
 
-.. note::
+Becoming a member of Python Triage team
+---------------------------------------
 
-   Existing members with the "Developer" role on the `issue tracker`_ are welcome to
-   self-nominate for triage team membership if they are interested.
-   
+Any Python core developers are welcome to invite a Python contributor to the
+Python Triage team. Do note that the responsibilities of a Python Triage member
+is more elevated than a bug triager in bpo. For example, the Python Triage member
+has access to more repositories than just CPython. Triages will be responsible
+to handle not just issues, but also pull requests, and even commanding backports.
+
+Any existing triagers in b.p.o can transition to the Python Triage role.
+They can request this to any core developer, and the core developer
+can pass the request to the Python organization admin on GitHub. The request
+can be made privately via DM in Zulip or Discourse, or publicly by opening
+an issue in core-workflow.
+
+Any contributor who is not already a triager in b.p.o can also self-nominate
+to be a member of Python Triage team. They can request this to any core developer,
+via DM in Zulip or Discourse, or publicly by opening an issue in core-workflow.
+If a core developer agrees and willing to vouch for them, the core developer
+can pass the request to the administrator. They should also be added as
+triager in bpo.
+
+For every new triager, it would be great to announce them in Python-committers
+mailing list and core-workflow category in Discourse. `Example announcement
+<https://discuss.python.org/t/abhilash-raj-has-been-granted-triage-role-on-github/2089>`_.
+
 
 GitHub Labels for PRs
 '''''''''''''''''''''


### PR DESCRIPTION
Based on discussion: https://discuss.python.org/t/criteria-for-promoting-people-to-the-python-triage-team/2105/

Closes https://github.com/python/devguide/issues/308