### PR TITLE
Expand "What's New and News Entries" to include Sphinx

### DIFF
--- a/committing.rst
+++ b/committing.rst
@@ -202,35 +202,19 @@ So a file name may be
 The contents of a news file should be valid reStructuredText. An 80 character
 column width should be used. There is no indentation or leading marker in the
 file (e.g. ``-``). There is also no need to start the entry with the issue
-number as it's part of the file name itself. Example news entry::
-
-   Fix warning message when ``os.chdir()`` fails inside
-   ``test.support.temp_cwd()``.  Patch by Chris Jerdonek.
-
-In addition to inline reST, news entries also support the usage of
-`Sphinx roles <https://devguide.python.org/documenting/#id4>`_. Several
-commonly used roles include :func:, :class:, and :meth:. When a
-corresponding entry is found within the documentation, the text within
-the role is converted into a hyperlink. Example news entry with Sphinx::
+number as it's part of the file name itself. You can use
+:ref:`inline markups <rest-inline-markup>` too. Example news entry::
 
    Fix warning message when :func:`os.chdir` fails inside
    :func:`test.support.temp_cwd`. Patch by Chris Jerdonek.
 
-The inline Sphinx roles can be used to assist readers in finding more
-information and context on the changes made. If the inline link does not
-provide additional context, an inline reST code block can be used instead::
+The inline Sphinx roles like ``:func:`` can be used to assist readers in finding
+more information. You can build html and verify that the link target is
+appropriate by using :ref:`make html <building-using-make>`.
 
-   ``<object>``
+While Sphinx roles can be beneficial to readers, they are not required.
+Inline ````code blocks```` can be used instead.
 
-Before using any Sphinx roles, ensure that a corresponding entry exists
-within the documentation. When adding rich formatting to news entries,
-use the netlify deploy preview to verify that the documentation was
-appropriately modified. Alternatively, `make html 
-<https://devguide.python.org/documenting/#using-make-make-bat>`_
-can be used instead.
-
-The Sphinx roles can be beneficial to readers, but they are not required.
-Inline code blocks can be used as a viable substitute.
 
 Working with Git_
 -----------------

--- a/committing.rst
+++ b/committing.rst
@@ -223,7 +223,7 @@ provide additional context, an inline reST code block should be used instead::
    ``<object>``
 
 Before using a Sphinx role, ensure that a corresponding entry exists
-within the documentation. Also, `build the HTML using make 
+within the documentation. Also, `build the HTML locally using make 
 <https://devguide.python.org/documenting/#using-make-make-bat>`_ to
 verify that the link leads to the correct location.
 

--- a/committing.rst
+++ b/committing.rst
@@ -223,10 +223,11 @@ provide additional context, an inline reST code block can be used instead::
    ``<object>``
 
 Before using any Sphinx roles, ensure that a corresponding entry exists
-within the documentation. When adding rich formatting to news entries
-`build the HTML locally using make 
-<https://devguide.python.org/documenting/#using-make-make-bat>`_ to
-verify that the links lead to the correct locations.
+within the documentation. When adding rich formatting to news entries,
+use the netlify deploy preview to verify that the documentation was
+appropriately modified. Alternatively, `make html 
+<https://devguide.python.org/documenting/#using-make-make-bat>`_
+can be used instead.
 
 The Sphinx roles can be beneficial to readers, but they are not required.
 Inline code blocks can be used as a viable substitute.

--- a/committing.rst
+++ b/committing.rst
@@ -222,7 +222,7 @@ provide additional context, an inline reST code block should be used instead::
 
    ``<object>``
 
-Before using a Sphinx role, ensure that a corresponding entry exists
+Before using any Sphinx roles, ensure that a corresponding entry exists
 within the documentation. Also, `build the HTML locally using make 
 <https://devguide.python.org/documenting/#using-make-make-bat>`_ to
 verify that the link leads to the correct location.

--- a/committing.rst
+++ b/committing.rst
@@ -217,14 +217,14 @@ the role is converted into a hyperlink. Example news entry with Sphinx::
    :func:`test.support.temp_cwd()`. Patch by Chris Jerdonek.
 
 The inline Sphinx roles should be used to assist readers find more
-information and context on the changes made. If the inline link does not 
-provide additional context, an inline reST code block should be used instead:: 
+information and context on the changes made. If the inline link does not
+provide additional context, an inline reST code block should be used instead::
 
    ``<object>``
 
 Before using a Sphinx role, ensure that a corresponding entry exists
-within the documentation. Also, ``build the HTML using make
-<https://devguide.python.org/documenting/#using-make-make-bat>``_ to 
+within the documentation. Also, `build the HTML using make 
+<https://devguide.python.org/documenting/#using-make-make-bat>`_ to
 verify that the link leads to the correct location.
 
 Working with Git_

--- a/committing.rst
+++ b/committing.rst
@@ -213,8 +213,8 @@ commonly used roles include :func:, :class:, and :meth:. When a
 corresponding entry is found within the documentation, the text within
 the role is converted into a hyperlink. Example news entry with Sphinx::
 
-   Fix warning message when :func:`os.chdir()` fails inside
-   :func:`test.support.temp_cwd()`. Patch by Chris Jerdonek.
+   Fix warning message when :func:`os.chdir` fails inside
+   :func:`test.support.temp_cwd`. Patch by Chris Jerdonek.
 
 The inline Sphinx roles should be used to assist readers find more
 information and context on the changes made. If the inline link does not

--- a/committing.rst
+++ b/committing.rst
@@ -223,14 +223,13 @@ provide additional context, an inline reST code block can be used instead::
    ``<object>``
 
 Before using any Sphinx roles, ensure that a corresponding entry exists
-within the documentation. When editing multiple news entries at once in
-"What's New" or Misc/NEWS.d/, `build the HTML locally using make 
+within the documentation. When adding rich formatting to news entries
+`build the HTML locally using make 
 <https://devguide.python.org/documenting/#using-make-make-bat>`_ to
-verify that the links lead to the correct locations. This does not need to be
-done for individual PR news entries.
+verify that the links lead to the correct locations.
 
-The Sphinx roles provide the maximum benefit in "What's New" entries,
-as they are read by the largest volume of users.
+The Sphinx roles can be beneficial to readers, but they are not required.
+Inline code blocks can be used as a viable substitute.
 
 Working with Git_
 -----------------

--- a/committing.rst
+++ b/committing.rst
@@ -216,7 +216,7 @@ the role is converted into a hyperlink. Example news entry with Sphinx::
    Fix warning message when :func:`os.chdir` fails inside
    :func:`test.support.temp_cwd`. Patch by Chris Jerdonek.
 
-The inline Sphinx roles should be used to assist readers in finding more
+The inline Sphinx roles can be used to assist readers in finding more
 information and context on the changes made. If the inline link does not
 provide additional context, an inline reST code block should be used instead::
 

--- a/committing.rst
+++ b/committing.rst
@@ -204,9 +204,28 @@ column width should be used. There is no indentation or leading marker in the
 file (e.g. ``-``). There is also no need to start the entry with the issue
 number as it's part of the file name itself. Example news entry::
 
-  Fix warning message when ``os.chdir()`` fails inside
-  ``test.support.temp_cwd()``.  Patch by Chris Jerdonek.
+   Fix warning message when ``os.chdir()`` fails inside
+   ``test.support.temp_cwd()``.  Patch by Chris Jerdonek.
 
+In addition to inline reST, Misc/NEWS entries also support the usage of
+`Sphinx roles <https://devguide.python.org/documenting/#id4>`. Several
+commonly used roles include :func:, :class:, and :meth:. When a
+corresponding entry is found within the documentation, the text within
+the role is converted into a hyperlink. Example news entry with Sphinx::
+
+   Fix warning message when :func:`os.chdir()` fails inside
+   :func:`test.support.temp_cwd()`. Patch by Chris Jerdonek.
+
+The inline Sphinx roles should be used to assist readers find more
+information and context on the changes made. If the inline link does not 
+provide additional context, an inline reST code block should be used instead:: 
+
+   ``<object>``
+
+Before using a Sphinx role, ensure that a corresponding entry exists
+within the documentation. Also, ``build the HTML using make
+<https://devguide.python.org/documenting/#using-make-make-bat>``_ to 
+verify that the link leads to the correct location.
 
 Working with Git_
 -----------------

--- a/committing.rst
+++ b/committing.rst
@@ -207,7 +207,7 @@ number as it's part of the file name itself. Example news entry::
    Fix warning message when ``os.chdir()`` fails inside
    ``test.support.temp_cwd()``.  Patch by Chris Jerdonek.
 
-In addition to inline reST, Misc/NEWS entries also support the usage of
+In addition to inline reST, news entries also support the usage of
 `Sphinx roles <https://devguide.python.org/documenting/#id4>`_. Several
 commonly used roles include :func:, :class:, and :meth:. When a
 corresponding entry is found within the documentation, the text within
@@ -218,14 +218,19 @@ the role is converted into a hyperlink. Example news entry with Sphinx::
 
 The inline Sphinx roles can be used to assist readers in finding more
 information and context on the changes made. If the inline link does not
-provide additional context, an inline reST code block should be used instead::
+provide additional context, an inline reST code block can be used instead::
 
    ``<object>``
 
 Before using any Sphinx roles, ensure that a corresponding entry exists
-within the documentation. Also, `build the HTML locally using make 
+within the documentation. When editing multiple news entries at once in
+"What's New" or Misc/NEWS.d/, `build the HTML locally using make 
 <https://devguide.python.org/documenting/#using-make-make-bat>`_ to
-verify that the link leads to the correct location.
+verify that the links lead to the correct locations. This does not need to be
+done for individual PR news entries.
+
+The Sphinx roles provide the maximum benefit in "What's New" entries,
+as they are read by the largest volume of users.
 
 Working with Git_
 -----------------

--- a/committing.rst
+++ b/committing.rst
@@ -208,7 +208,7 @@ number as it's part of the file name itself. Example news entry::
    ``test.support.temp_cwd()``.  Patch by Chris Jerdonek.
 
 In addition to inline reST, Misc/NEWS entries also support the usage of
-`Sphinx roles <https://devguide.python.org/documenting/#id4>`. Several
+`Sphinx roles <https://devguide.python.org/documenting/#id4>`_. Several
 commonly used roles include :func:, :class:, and :meth:. When a
 corresponding entry is found within the documentation, the text within
 the role is converted into a hyperlink. Example news entry with Sphinx::

--- a/committing.rst
+++ b/committing.rst
@@ -216,7 +216,7 @@ the role is converted into a hyperlink. Example news entry with Sphinx::
    Fix warning message when :func:`os.chdir` fails inside
    :func:`test.support.temp_cwd`. Patch by Chris Jerdonek.
 
-The inline Sphinx roles should be used to assist readers find more
+The inline Sphinx roles should be used to assist readers in finding more
 information and context on the changes made. If the inline link does not
 provide additional context, an inline reST code block should be used instead::
 

--- a/documenting.rst
+++ b/documenting.rst
@@ -902,6 +902,7 @@ file :file:`example.py`, use::
 The file name is relative to the current file's path.  Documentation-specific
 include files should be placed in the ``Doc/includes`` subdirectory.
 
+.. _rest-inline-markup:
 
 Inline markup
 -------------
@@ -1530,6 +1531,8 @@ created using ``make venv``), so that the Makefile can find the
 ``sphinx-build`` command.  You can also specify the location of
 ``sphinx-build`` with the ``SPHINXBUILD`` :command:`make` variable.
 
+
+.. _building-using-make:
 
 Using make / make.bat
 ---------------------


### PR DESCRIPTION
Based on the feedback from the [ML thread in Python-Dev](https://mail.python.org/archives/list/python-dev@python.org/thread/HTAFGTQIZJQUCU6QCVF3KFD3VFGFOBWV/#HTAFGTQIZJQUCU6QCVF3KFD3VFGFOBWV) and [Discuss topic](https://discuss.python.org/t/should-news-entries-contain-documentation-links/2127) it seems appropriate to update the devguide accordingly. 

I also adjusted the number of spaces in the indentation from the existing example from 2 to 3 in order to meet [reST standards](https://devguide.python.org/documenting/#use-of-whitespace). 