### PR TITLE
Simplify core developer log

### DIFF
--- a/developers.rst
+++ b/developers.rst
@@ -22,6 +22,118 @@ This file is encoded in UTF-8.  If the usual form for a name is not in
 a Latin or extended Latin alphabet, make sure to include an ASCII
 transliteration too.
 
+Active Python core developers (GitHub)
+----------------------
+
+* 2019
+   + Abhilash Raj
+   + Paul Ganssle
+   + Stefan Behnel
+   + Stéphane Wirtel
+   + Cheryl Sabella
+
+* 2018
+   + Lisa Roach
+   + Emily Morehouse
+   + Pablo Galindo Salgado
+   + Mark Shannon
+   + Petr Viktorin
+   + Nathaniel J. Smith
+
+* 2017
+   + Julien Palard
+   + Ivan Levkivskyi
+   + Carol Willing
+   + Mariatta Wijaya
+
+* 2016
+   + Xiang Zhang
+   + Inada Naoki
+   + Davin Potts
+
+* 2015
+   + Martin Panter
+   + Paul Moore
+
+* 2014
+   + Robert Collins
+   + Berker Peksağ
+   + Steve Dower
+   + Kushal Das
+   + Steven d'Aprano
+   + Yury Selivanov
+
+* 2013
+   + Zachary Ware
+   + Donald Stufft
+   + Ethan Furman
+
+* 2012
+   + Serhiy Storchaka
+   + Chris Jerdonek
+   + Eric Snow
+   + Hynek Schlawack
+   + Andrew Svetlov
+
+* 2011
+   + Petri Lehtinen
+   + Meador Inge
+   + Sandro Tosi
+   + Jeff Hardy
+   + Alex Gaynor
+   + Eli Bendersky
+   + Ned Deily
+   + Jason R. Coombs
+ 
+* 2010
+   + David Malcolm
+   + Tal Einat
+   + Łukasz Langa
+   + Éric Araujo
+   + Terry Reedy
+   + Brian Quinlan
+   + Alexander Belopolsky
+   + Tim Golden
+   + Giampaolo Rodolà
+   + Brian Curtin
+   + Dino Viehland
+   + Larry Hastings
+   + Victor Stinner
+   + Stefan Krah
+ 
+* 2009
+   + Doug Hellmann
+   + Ezio Melotti
+   + R. David Murray
+   + Chris Withers
+
+* 2008
+   + Antoine Pitrou
+   + Jesús Cea
+   + Benjamin Peterson
+   + Jerry Seutter
+   + David Wolever
+   + Trent Nelson
+   + Mark Dickinson
+
+* 2007
+   + Amaury Forgeot d'Arc
+   + Christian Heimes
+   + Armin Ronacher
+   + Senthil Kumaran
+   + Alexandre Vassalotti
+   + Eric V. Smith
+ 
+* 2006
+   + Lars Gustäbel
+   + Ronald Oussoren
+   + Jack Diederich
+
+* 2005
+   + Georg Brandl
+   + Terry Reedy
+   + Nick Coghlan
+
 Permissions History
 -------------------
 

--- a/developers.rst
+++ b/developers.rst
@@ -104,7 +104,7 @@ Active Python core developers (GitHub)
 * 2009
    + Doug Hellmann
    + Ezio Melotti
-   + R. David Murray
+   + R\. David Murray
    + Chris Withers
 
 * 2008


### PR DESCRIPTION
Based on https://github.com/python/devguide/pull/404, I used the same formatting but added several recent core developers, and removed anyone from the list that wasn't on the [GitHub python-core team](https://github.com/orgs/python/teams/python-core/members). I also changed the title of the section slightly to make it clear that it was exclusively active Python core developers on GitHub. 

Also, I noticed the following members of the python-core team were missing from the developers page entirely:

Andrew Kuchling
Alex Martelli
Walter Dörwald 
Matthias Klose 
Facundo Batista
Fred Drake
Hyeshik Chang
Jack Jansen
Jeremy Hylton
Kurt B. Kaiser
Marc-Andre Lemburg 
Mark Hammond
Michael Hudson-Doyle
Neil Schemenauer
Sjoerd Mullender
Thomas Heller
Vinay Sajip
T. Wouters 

Additionally, I noticed that there were several older core developers missing from the list, but were mentioned later on the page. Should they be mentioned on the list, or is it okay since they're mentioned later on the page? 

Brett Cannon
Tim Peters
Raymond Hettinger

If there's anyone missing from the list, or if anyone knows the year when any of the above developers were granted commit access, let me know.