### PR TITLE
Add guidelines for triagers closing PRs

### DIFF
--- a/triaging.rst
+++ b/triaging.rst
@@ -39,9 +39,9 @@ Responsibilities include:
     
  .. note::
  
-    Triagers should only close PRs that could be considered spam. They can
-    suggest for other PRs to be closed, but core developers are responsible for
-    making the final decision.
+   Triagers should only close PRs that could be considered spam. They can
+   suggest for other PRs to be closed, but core developers are responsible for
+   making the final decision.
 
 It is also of paramount importance to treat every contributor to the Python
 project kindly and with respect. Regardless of whether they're entirely new

--- a/triaging.rst
+++ b/triaging.rst
@@ -35,18 +35,16 @@ Responsibilities include:
     - Skip issue
     - Good first issue
     - Other categorizations
-    
- .. note::
 
-   Triagers may have some understanding of when a PR should be closed, but the
-   final decision must be made by a core developer. This is because the creation
-   of a PR constitutes a significant amount of effort from the author. Closing one
-   without careful consideration and proper handling can easily dissaude the
-   author from making further contributions.
+Triagers may have some understanding of when a PR should be closed, but the
+final decision must be made by a core developer. This is because the creation
+of a PR constitutes a significant amount of effort from the author. Closing one
+without careful consideration and proper handling can easily dissaude the
+author from making further contributions.
 
-   Instead of directly closing a PR, triagers can make use of the ``invalid`` and
-   ``stale`` labels to suggest that it should be closed. For more information, see
-   the :ref:`GitHub PR labels <github-pr-labels>` section.
+Instead of directly closing a PR, triagers can make use of the ``invalid`` and
+``stale`` labels to suggest that it should be closed. For more information, see
+the :ref:`GitHub PR labels <github-pr-labels>` section.
 
 It is also of paramount importance to treat every contributor to the Python
 project kindly and with respect. Regardless of whether they're entirely new

--- a/triaging.rst
+++ b/triaging.rst
@@ -38,9 +38,9 @@ Responsibilities include:
     
  .. note::
  
-   Although triagers have the permission to close PRs/issues, a core
+   Although triagers have the permission to close PRs, a core
    developer must take the final action in doing so. A triager should
-   never directly close a PR/issue. Instead, triagers can make use of the
+   never directly close a PR. Instead, triagers can make use of the
    ``stale`` and ``invalid`` labels to suggest that it should be closed.
    
 

--- a/triaging.rst
+++ b/triaging.rst
@@ -28,7 +28,6 @@ Responsibilities include:
 * PR/issue management
     - Renaming PRs
     - Reviewing PRs
-    - Closing PRs and issues
     - Assisting contributors
     - Notifying appropriate core developers
 * Applying appropriate labels to PRs/Issues
@@ -39,9 +38,11 @@ Responsibilities include:
     
  .. note::
  
-   Triagers should only close PRs that could be considered spam. They can
-   suggest for other PRs to be closed, but core developers are responsible for
-   making the final decision.
+   Although triagers have the permission to close PRs/issues, a core
+   developer must take the final action in doing so. A triager should
+   never directly close a PR/issue. Instead, triagers can make use of the
+   ``stale`` and ``invalid`` labels to suggest that it should be closed.
+   
 
 It is also of paramount importance to treat every contributor to the Python
 project kindly and with respect. Regardless of whether they're entirely new
@@ -100,7 +101,8 @@ invalid
     Used manually for PRs that do not meet basic requirements and
     automatically added by bedevere when PR authors attempt to merge maintenace
     branches into the master branch. During competitions, this label causes the
-    PR to not count towards the author's contributions.
+    PR to not count towards the author's contributions. This label is generally
+    used to suggest that a PR should be closed.
 
 needs backport to X.Y
     Used for PRs which are appropriate to backport to
@@ -124,7 +126,13 @@ skip news
     in another PR. Any potentially impactful changes should have a
     corresponding news entry, but for trivial changes it's commonly at the
     discretion of the PR author if they wish to opt-out of making one.
-
+    
+stale
+    Used for PRs which have not received a response from the author in a
+    significant period of time or are no longer relevant. This label is
+    generally used to suggest that the PR should be closed. In some cases,
+    it is appropriate to open an updated version of the PR.
+    
 OS-X
     Used for PRs involving changes which only have an effect upon
     a specific operating system. Current variations of the label include

--- a/triaging.rst
+++ b/triaging.rst
@@ -36,13 +36,15 @@ Responsibilities include:
     - Good first issue
     - Other categorizations
 
-As triagers gain experience, they may have some intuition of when a PR should be closed. The triager can recommend closing a PR, but the
-final decision must be made by a core developer. This is because the creation
-of a PR constitutes a significant amount of effort from the author. Closing one
+As triagers gain experience, they may have some intuition of when a PR should
+be closed. Triagers can recommend closing a PR, but the final decision must be
+made by a core developer. By having triagers and core developers work together,
+the author receives a careful consideration of their PR. This encourages future
+contributions, regardless of whether their PR is accepted or closed.
 
-Triagers can make use of the ``invalid`` and
-``stale`` labels to suggest that it should be closed. For more information, see
-the :ref:`GitHub PR labels <github-pr-labels>` section.
+Triagers can make use of the ``invalid`` and ``stale`` labels to suggest that a
+PR may be suitable for closure. For more information, see the
+:ref:`GitHub PR labels <github-pr-labels>` section.
 
 It is also of paramount importance to treat every contributor to the Python
 project kindly and with respect. Regardless of whether they're entirely new
@@ -101,9 +103,9 @@ expert-asyncio
 invalid
     Used manually for PRs that do not meet basic requirements and
     automatically added by bedevere when PR authors attempt to merge maintenace
-    branches into the master branch. During competitions, this label causes the
-    PR to not count towards the author's contributions. This label is generally
-    used to suggest that a PR should be closed.
+    branches into the master branch. During events such as the October
+    Hacktoberfest, this label will prevent the PR from counting toward the
+    author's contributions.
 
 needs backport to X.Y
     Used for PRs which are appropriate to backport to

--- a/triaging.rst
+++ b/triaging.rst
@@ -36,13 +36,11 @@ Responsibilities include:
     - Good first issue
     - Other categorizations
 
-Triagers may have some understanding of when a PR should be closed, but the
+As triagers gain experience, they may have some intuition of when a PR should be closed. The triager can recommend closing a PR, but the
 final decision must be made by a core developer. This is because the creation
 of a PR constitutes a significant amount of effort from the author. Closing one
-without careful consideration and proper handling can easily dissaude the
-author from making further contributions.
 
-Instead of directly closing a PR, triagers can make use of the ``invalid`` and
+Triagers can make use of the ``invalid`` and
 ``stale`` labels to suggest that it should be closed. For more information, see
 the :ref:`GitHub PR labels <github-pr-labels>` section.
 

--- a/triaging.rst
+++ b/triaging.rst
@@ -37,12 +37,16 @@ Responsibilities include:
     - Other categorizations
     
  .. note::
- 
-   Although triagers have the permission to close PRs, a core
-   developer must take the final action in doing so. A triager should
-   never directly close a PR. Instead, triagers can make use of the
-   ``stale`` and ``invalid`` labels to suggest that it should be closed.
-   
+
+   Triagers may have some understanding of when a PR should be closed, but the
+   final decision must be made by a core developer. This is because the creation
+   of a PR constitutes a significant amount of effort from the author. Closing one
+   without careful consideration and proper handling can easily dissaude the
+   author from making further contributions.
+
+   Instead of directly closing a PR, triagers can make use of the ``invalid`` and
+   ``stale`` labels to suggest that it should be closed. For more information, see
+   the :ref:`GitHub PR labels <github-pr-labels>` section.
 
 It is also of paramount importance to treat every contributor to the Python
 project kindly and with respect. Regardless of whether they're entirely new
@@ -79,6 +83,7 @@ For every new triager, it would be great to announce them in the python-committe
 mailing list and core-workflow category in Discourse. `Example announcement
 <https://discuss.python.org/t/abhilash-raj-has-been-granted-triage-role-on-github/2089>`_.
 
+.. _github-pr-labels:
 
 GitHub Labels for PRs
 '''''''''''''''''''''

--- a/triaging.rst
+++ b/triaging.rst
@@ -129,13 +129,7 @@ skip news
     in another PR. Any potentially impactful changes should have a
     corresponding news entry, but for trivial changes it's commonly at the
     discretion of the PR author if they wish to opt-out of making one.
-    
-stale
-    Used for PRs which have not received a response from the author in a
-    significant period of time or are no longer relevant. This label is
-    generally used to suggest that the PR should be closed. In some cases,
-    it is appropriate to open an updated version of the PR.
-    
+
 OS-X
     Used for PRs involving changes which only have an effect upon
     a specific operating system. Current variations of the label include

--- a/triaging.rst
+++ b/triaging.rst
@@ -36,6 +36,12 @@ Responsibilities include:
     - Skip issue
     - Good first issue
     - Other categorizations
+    
+ .. note::
+ 
+    Triagers should only close PRs that could be considered spam. They can
+    suggest for other PRs to be closed, but core developers are responsible for
+    making the final decision.
 
 It is also of paramount importance to treat every contributor to the Python
 project kindly and with respect. Regardless of whether they're entirely new


### PR DESCRIPTION
Based on the conversation in https://github.com/python/devguide/issues/527, I added a note after the "Responsibilities include" list which specifies that triagers should only close PRs that could be considered spam, but they can suggest for other PRs to be closed. For anything potentially valid (including recently active and older PRs), a core developer should make the final decision.