### PR TITLE
Adding Stale label

### DIFF
--- a/triaging.rst
+++ b/triaging.rst
@@ -131,7 +131,7 @@ sprint
 
 stale
     Used for stale PRs or inactive for a long period of time. This label
-    help to core dev identify quickly the PRs candidate to be closed or make
+    help to core dev identify quickly the PR candidate to be closed or make
     a ping to the author.
 
 type-bugfix

--- a/triaging.rst
+++ b/triaging.rst
@@ -131,7 +131,7 @@ sprint
 
 stale
     Used for stale PRs or inactive for a long period of time. This label
-    help to core dev identify quickly the PR candidate to be closed or make
+    helps core developers identify quickly the PR candidate to be closed or make
     a ping to the author.
 
 type-bugfix

--- a/triaging.rst
+++ b/triaging.rst
@@ -105,6 +105,11 @@ needs backport to X.Y
     miss-islington to attempt to automatically merge the PR into the branches
     specified.
 
+OS-X
+    Used for PRs involving changes which only have an effect upon
+    a specific operating system. Current variations of the label include
+    OS-Windows and OS-Mac.
+
 skip issue
     Used for PRs which involve trivial changes, such as typo fixes,
     comment changes, and section rephrases. The majority of PRs require
@@ -119,15 +124,15 @@ skip news
     corresponding news entry, but for trivial changes it's commonly at the
     discretion of the PR author if they wish to opt-out of making one.
 
-OS-X
-    Used for PRs involving changes which only have an effect upon
-    a specific operating system. Current variations of the label include
-    OS-Windows and OS-Mac.
-
 sprint
     Used for PRs authored during an in-person sprint, such as
     at PyCon, EuroPython, or other official Python events. The label is
     used to prioritize the review of those PRs during the sprint.
+
+stale
+    Used for stale PRs or inactive for a long period of time. This label
+    help to core dev identify quickly the PRs candidate to be closed or make
+    a ping to the author.
 
 type-bugfix
     Used for PRs that address unintentional behavior, but do not

--- a/triaging.rst
+++ b/triaging.rst
@@ -130,9 +130,10 @@ sprint
     used to prioritize the review of those PRs during the sprint.
 
 stale
-    Used for stale PRs or inactive for a long period of time. This label
-    helps core developers identify quickly the PR candidate to be closed or make
-    a ping to the author.
+    Used for PRs that include changes which are no longer relevant or when the
+    author hasn't responded to feedback in a long period of time. This label
+    helps core developers quickly identify PRs that are candidates for closure 
+    or require a ping to the author.
 
 type-bugfix
     Used for PRs that address unintentional behavior, but do not


### PR DESCRIPTION
In this PR I propose add the stale label on devguide.

Also, move OS-X label to above for a correct alphabetic order.

I would like document the ```awaiting *``` labels, but I don't know if in this section (Github label for PR) is the correct. Some opinion about it? 