### PR TITLE
Add @pablogsal to CPython Repository Administrators

### DIFF
--- a/devcycle.rst
+++ b/devcycle.rst
@@ -322,6 +322,8 @@ Current Administrators
 +-------------------+----------------------------------------------------------+-----------------+
 | Mariatta Wijaya   | Maintainer of blurb_it and miss-islington                | Mariatta        |
 +-------------------+----------------------------------------------------------+-----------------+
+| Pablo Galindo     | Maintainer of buildbot.python.org                        | pablogsal       |
++-------------------+----------------------------------------------------------+-----------------+
 
 Repository Release Manager Role Policy
 --------------------------------------


### PR DESCRIPTION
As requested by Pablo on infrastructure-staff mailing list, for managing webhook integrations with the buildbot infrastructure.

If I could get @brettcannon to confirm, we'll merge this and add them to the appropriate team.