### PR TITLE
Activate the environment created by make venv

### DIFF
--- a/documenting.rst
+++ b/documenting.rst
@@ -1542,9 +1542,8 @@ Using make / make.bat
 
    cd Doc
    make venv
+   source ./venv/bin/activate
    make html
-
-or alternatively ``make -C Doc/ venv html``.
 
 You can also use ``make help`` to see a list of targets supported by
 :command:`make`.  Note that ``make check`` is automatically run when


### PR DESCRIPTION
The Doc/Makefile venv
(https://github.com/python/cpython/blob/24ddd9c2d6ab61cbce7e68d6de36d4df9bd2c3fb/Doc/Makefile#L143)
does not actually activate the virtual environment.

Subsequently, the build command (via make html) would fail
because none of the programs just installed are actually
available, hence user would always get

    Missing the required blurb or sphinx-build tools

if they did not activate the virtualenv.

This also voids the usability of `make -C Doc/ venv html`.