### PR TITLE
Fix issue467- Use the imperative form for the bullet list

### DIFF
--- a/buildbots.rst
+++ b/buildbots.rst
@@ -15,10 +15,10 @@ will schedule a new build to be run as soon as possible.
 
 The build steps run by the buildbots are the following:
 
-* Checkout of the source tree for the changeset which triggered the build
+* Check out the source tree for the changeset which triggered the build
 * Compile Python
 * Run the test suite using :ref:`strenuous settings <strenuous_testing>`
-* Cleanup the build tree
+* Clean up the build tree
 
 It is your responsibility, as a core developer, to check the automatic
 build results after you push a change to the repository.  It is therefore

--- a/buildbots.rst
+++ b/buildbots.rst
@@ -16,9 +16,9 @@ will schedule a new build to be run as soon as possible.
 The build steps run by the buildbots are the following:
 
 * Checkout of the source tree for the changeset which triggered the build
-* Compiling Python
-* Running the test suite using :ref:`strenuous settings <strenuous_testing>`
-* Cleaning up the build tree
+* Compile Python
+* Run the test suite using :ref:`strenuous settings <strenuous_testing>`
+* Cleanup the build tree
 
 It is your responsibility, as a core developer, to check the automatic
 build results after you push a change to the repository.  It is therefore


### PR DESCRIPTION
Fixes issue #467 
Use the Imperative form for the bullet list on the Continuous Integration page ( in buildbots.rst file )
