### PR TITLE
Add ast.unparse to grammar change checklist

### DIFF
--- a/grammar.rst
+++ b/grammar.rst
@@ -54,6 +54,9 @@ Note: sometimes things mysteriously don't work.  Before giving up, try ``make cl
 * The :mod:`parser` module.  Add some of your new syntax to ``test_parser``,
   bang on :file:`Modules/parsermodule.c` until it passes.
 
+* ``_Unparser`` in the :file:`Lib/ast.py` will need changes to unparse
+  created / modified AST nodes.
+
 * Add some usage of your new syntax to ``test_grammar.py``.
 
 * Certain changes may require tweaks to the library module :mod:`pyclbr`.

--- a/grammar.rst
+++ b/grammar.rst
@@ -54,8 +54,8 @@ Note: sometimes things mysteriously don't work.  Before giving up, try ``make cl
 * The :mod:`parser` module.  Add some of your new syntax to ``test_parser``,
   bang on :file:`Modules/parsermodule.c` until it passes.
 
-* ``_Unparser`` in the :file:`Lib/ast.py` will need changes to unparse
-  created / modified AST nodes.
+* ``_Unparser`` in the :file:`Lib/ast.py` file may need changes to accommodate
+any modifications in the AST nodes.
 
 * Add some usage of your new syntax to ``test_grammar.py``.
 

--- a/grammar.rst
+++ b/grammar.rst
@@ -55,7 +55,7 @@ Note: sometimes things mysteriously don't work.  Before giving up, try ``make cl
   bang on :file:`Modules/parsermodule.c` until it passes.
 
 * ``_Unparser`` in the :file:`Lib/ast.py` file may need changes to accommodate
-any modifications in the AST nodes.
+  any modifications in the AST nodes.
 
 * Add some usage of your new syntax to ``test_grammar.py``.
 


### PR DESCRIPTION
Now, with the exposed `ast.unparse` interface it is more important then a standard `Tool/` script and needs to reflect changes in the ast.