### PR TITLE
Add Python Language Reference docs to Grammar checklist.

### DIFF
--- a/grammar.rst
+++ b/grammar.rst
@@ -65,4 +65,5 @@ Note: sometimes things mysteriously don't work.  Before giving up, try ``make cl
 
 * :file:`Lib/lib2to3/Grammar.txt` may need changes to match the Grammar.
 
-* Documentation must be written!
+* Documentation must be written! Specifically, one or more of the pages in
+  :file:`Doc/reference/` will need to be updated.


### PR DESCRIPTION
It looks like these docs (specifically the grammar reference for [expressions](https://docs.python.org/3/reference/expressions.html)) got stale when the walrus was added. It's making documenting PEP 614 very tricky.

Also, this checklist is an amazing resource. I was halfway through debugging segfaults in `importlib` before I found this!