### PR TITLE
Add a note about not modifying the git history to the quick guide

### DIFF
--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -37,7 +37,7 @@ Here is a quick overview of how you can contribute to CPython:
 
 #. `Create Pull Request`_ on GitHub to merge a branch from your fork
 
-#. Review and address `comments on your Pull Request`_ (without force-pushing)
+#. Review and address `comments on your Pull Request`_
 
 #. When your changes are merged, you can :ref:`delete the PR branch
    <deleting_branches>`
@@ -48,8 +48,8 @@ Here is a quick overview of how you can contribute to CPython:
        you can skip this step.
 
 .. note::
-   Please keep the commit history in the pull request intact by not squashing,
-   amending, or anything that would require a force push to GitHub.
+   In order to keep the commit history intact, please avoid force-pushing to
+   the PR.
 
 .. _Clear communication: https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
 .. _Open Source: https://opensource.guide/

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -49,7 +49,7 @@ Here is a quick overview of how you can contribute to CPython:
 
 .. note::
    In order to keep the commit history intact, please avoid force-pushing to
-   the PR.
+   the PR. Reviewers often want to look at individual commits.
 
 .. _Clear communication: https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
 .. _Open Source: https://opensource.guide/

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -48,8 +48,9 @@ Here is a quick overview of how you can contribute to CPython:
        you can skip this step.
 
 .. note::
-   In order to keep the commit history intact, please avoid force-pushing to
-   the PR. Reviewers often want to look at individual commits.
+   In order to keep the commit history intact, please avoid squashing or amending
+   history and then force-pushing to the PR. Reviewers often want to look at
+   individual commits.
 
 .. _Clear communication: https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
 .. _Open Source: https://opensource.guide/

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -37,7 +37,7 @@ Here is a quick overview of how you can contribute to CPython:
 
 #. `Create Pull Request`_ on GitHub to merge a branch from your fork
 
-#. Review and address `comments on your Pull Request`_
+#. Review and address `comments on your Pull Request`_ (without force-pushing)
 
 #. When your changes are merged, you can :ref:`delete the PR branch
    <deleting_branches>`
@@ -46,6 +46,10 @@ Here is a quick overview of how you can contribute to CPython:
 
 .. [*] If an issue is trivial (e.g. typo fixes), or if an issue already exists,
        you can skip this step.
+
+.. note::
+   Please keep the commit history in the pull request intact by not squashing,
+   amending, or anything that would require a force push to GitHub.
 
 .. _Clear communication: https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
 .. _Open Source: https://opensource.guide/


### PR DESCRIPTION
Closes: #579 

- Add a note to the quick about not modifying the git history
- Explicitly state not using force-pushing at point "7. Review and address comments on your Pull Request"

@aeros What do you think about it?