### PR TITLE
Escape dot to prevent <ol>

### DIFF
--- a/developers.csv
+++ b/developers.csv
@@ -72,7 +72,7 @@ Frank Wierzbicki,,2009-08-02
 Ezio Melotti,ezio-melotti,2009-06-07
 Philip Jenvey,pjenvey,2009-05-07
 Michael Foord,voidspace,2009-04-01
-R. David Murray,bitdancer,2009-03-30
+R\. David Murray,bitdancer,2009-03-30
 Chris Withers,cjw296,2009-03-08
 Tarek Ziadé,,2008-12-21
 Hirokazu Yamamoto,,2008-08-12


### PR DESCRIPTION
https://devguide.python.org/developers/ shows an unexpected indention for one name which begins with an initial and a period:

![image](https://user-images.githubusercontent.com/1324225/89128670-f297b900-d4ff-11ea-9e64-40e13e95e616.png)

It's being parsed as an alphabetic `<ol>` starting at the 18th letter, R.

Escaping the intial's dot fixes it:

![image](https://user-images.githubusercontent.com/1324225/89128731-7487e200-d500-11ea-8c82-c3eb87294a4e.png)

