### PR TITLE
Update Spanish documentation translation repository link

### DIFF
--- a/documenting.rst
+++ b/documenting.rst
@@ -1661,7 +1661,7 @@ in production, other are work in progress:
 .. _doc_zh_tw: https://docs.python.org/zh-tw/
 .. _github_ar: https://github.com/Abdur-rahmaanJ/py-docs-ar
 .. _github_bn_in: https://github.com/python/python-docs-bn-in
-.. _github_es: https://github.com/PyCampES/python-docs-es
+.. _github_es: https://github.com/python/python-docs-es
 .. _github_fr: https://github.com/python/python-docs-fr
 .. _github_hi_in: https://github.com/CuriousLearner/python-docs-hi-in
 .. _github_hu: https://github.com/python/python-docs-hu


### PR DESCRIPTION
Spanish translation of Python documentation is located at new repository under `python` organization.