### PR TITLE
developers.csv: Escape dot to prevent <ol>

### DIFF
--- a/developers.csv
+++ b/developers.csv
@@ -73,7 +73,7 @@ Frank Wierzbicki,,2009-08-02
 Ezio Melotti,ezio-melotti,2009-06-07
 Philip Jenvey,pjenvey,2009-05-07
 Michael Foord,voidspace,2009-04-01
-R. David Murray,bitdancer,2009-03-30
+R\. David Murray,bitdancer,2009-03-30
 Chris Withers,cjw296,2009-03-08
 Tarek Ziadé,,2008-12-21
 Hirokazu Yamamoto,,2008-08-12


### PR DESCRIPTION
Re-apply commit 0427168c1ae4f69aff299fa215dd2ae7aaa0ff15.
This time the issue was fixed in the script that generates the data,
so it shouldn't reappear.

Co-Authored-By: Hugo van Kemenade <hugovk@users.noreply.github.com>