### PR TITLE
Most broken/outdated hyperlinks are cleaned up 

### DIFF
--- a/.github/CODE_OF_CONDUCT.rst
+++ b/.github/CODE_OF_CONDUCT.rst
@@ -7,7 +7,7 @@ Please note that all interactions on
 `Python Software Foundation <https://www.python.org/psf-landing/>`__-supported
 infrastructure is `covered
 <https://www.python.org/psf/records/board/minutes/2014-01-06/#management-of-the-psfs-web-properties>`__
-by the `PSF Code of Conduct <https://www.python.org/psf/codeofconduct/>`__,
+by the `PSF Code of Conduct <https://www.python.org/psf/conduct/>`__,
 which includes all infrastructure used in the development of Python itself
 (e.g. mailing lists, issue trackers, GitHub, etc.).
 

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ venv/
 
 # Rope project settings
 .ropeproject
+.vscode/settings.json

--- a/appendix.rst
+++ b/appendix.rst
@@ -1,4 +1,4 @@
-Appendix: Topics 
+Appendix: Topics
 ================
 
 Basics for contributors
@@ -65,4 +65,3 @@ Testing and continuous integration
 * :doc:`buildbots`
 * :doc:`buildworker`
 * :doc:`coverity`
-  

--- a/buildbots.rst
+++ b/buildbots.rst
@@ -45,7 +45,7 @@ There are three ways of visualizing recent build results:
 
       bbreport.py -q 3.x
 
-* The buildbot "console" interface at http://buildbot.python.org/all/#/console
+* The buildbot "console" interface at https://buildbot.python.org/all/#/console
   This works best on a wide, high resolution
   monitor.  Clicking on the colored circles will allow you to open a new page
   containing whatever information about that particular build is of interest to
@@ -209,7 +209,7 @@ Custom builders
 When working on a platform-specific issue, you may want to test your changes on
 the buildbot fleet rather than just on Travis and AppVeyor.  To do so, you can
 make use of the `custom builders
-<http://buildbot.python.org/all/#/builders?tags=custom.unstable&tags=custom.stable>`_.
+<https://buildbot.python.org/all/#/builders?tags=custom.unstable&tags=custom.stable>`_.
 These builders track the ``buildbot-custom`` short-lived branch of the
 ``python/cpython`` repository, which is only accessible to core developers.
 

--- a/buildworker.rst
+++ b/buildworker.rst
@@ -19,12 +19,12 @@ to go about setting up a buildbot worker, getting it added, and some hints about
 buildbot maintenance.
 
 Anyone running a buildbot that is part of the fleet should subscribe to the
-`python-buildbots <https://mail.python.org/mailman/listinfo/python-buildbots>`_
+`python-buildbots <https://mail.python.org/mailman3/lists/python-buildbots.python.org/>`_
 mailing list.  This mailing list is also the place to contact if you want to
 contribute a buildbot but have questions.
 
 As for what kind of buildbot to run...take a look at our `current fleet
-<http://buildbot.python.org/all/#/workers>`_.  Pretty much anything that isn't
+<https://buildbot.python.org/all/#/workers>`_.  Pretty much anything that isn't
 on that list would be interesting: different Linux/UNIX distributions,
 different versions of the various OSes, other OSes if you or someone are
 prepared to make the test suite actually pass on that new OS.  Even if you only
@@ -185,7 +185,7 @@ To start the worker running for your initial testing, you can do::
 
 Then you can either wait for someone to make a commit, or you can pick a
 builder associated with your worker from the `list of builders
-<http://buildbot.python.org/all/#/builders>`_ and force a build.
+<https://buildbot.python.org/all/#/builders>`_ and force a build.
 
 In any case you should initially monitor builds on your builders to make sure
 the tests are passing and to resolve any platform issues that may be revealed
@@ -221,7 +221,7 @@ instance(s), so it is recommended to periodically check and make sure
 there are no "zombie" instances running on your account, created by the
 buildbot master.  Also, if you notice that your worker seems to have been
 down for an unexpectedly long time, please ping the `python-buildbots
-<https://mail.python.org/mailman/listinfo/python-buildbots>`_ list to
+<https://mail.python.org/mailman3/lists/python-buildbots.python.org/>`_ list to
 request that the master be restarted.
 
 Latent workers should also be updated periodically to include operating system

--- a/committing.rst
+++ b/committing.rst
@@ -88,7 +88,7 @@ name in ``Misc/ACKS`` if they aren't already there (and didn't add themselves
 in their patch) and by mentioning "Patch by <x>" in the ``Misc/NEWS.d`` entry
 and the check-in message. If the patch has been heavily modified then "Initial
 patch by <x>" is an appropriate alternate wording.  GitHub now supports `multiple
-authors <https://help.github.com/articles/creating-a-commit-with-multiple-authors/>`_
+authors <https://docs.github.com/en/free-pro-team@latest/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors>`_
 in a commit. Add ``Co-authored-by: name <name@example.com>`` at the end of the commit message.
 
 If you omit correct attribution in the initial check-in, then update ``ACKS``

--- a/communication.rst
+++ b/communication.rst
@@ -52,7 +52,7 @@ General Python questions should go to `python-list`_ or `tutor`_
 or similar resources, such as StackOverflow_ or the ``#python`` IRC channel
 on Freenode_.
 
-`Core-Workflow <https://mail.python.org/mm3/mailman3/lists/core-workflow.python.org/>`_
+`Core-Workflow <https://mail.python.org/mailman3/lists/core-workflow.python.org/>`_
 mailing list is the place to discuss and work on improvements to the CPython
 core development workflow.
 
@@ -65,10 +65,10 @@ RSS feed readers.
 .. _new-bugs-announce: https://mail.python.org/mailman/listinfo/new-bugs-announce
 .. _python-bugs-list: https://mail.python.org/mailman/listinfo/python-bugs-list
 .. _python-checkins: https://mail.python.org/mailman/listinfo/python-checkins
-.. _python-committers: https://mail.python.org/mailman/listinfo/python-committers
-.. _python-dev: https://mail.python.org/mailman/listinfo/python-dev
+.. _python-committers: https://mail.python.org/mailman3/lists/python-committers.python.org/
+.. _python-dev: https://mail.python.org/mailman3/lists/python-dev.python.org/
 .. _python-help: https://mail.python.org/mailman/listinfo/python-help
-.. _python-ideas: https://mail.python.org/mailman/listinfo/python-ideas
+.. _python-ideas: permanently to https://mail.python.org/mailman3/lists/python-ideas.python.org/
 .. _python-list: https://mail.python.org/mailman/listinfo/python-list
 .. _tutor: https://mail.python.org/mailman/listinfo/tutor
 .. _StackOverflow: https://stackoverflow.com/
@@ -96,7 +96,7 @@ Blogs
 
 Several core developers are active bloggers and discuss Python's development
 that way. You can find their blogs (and various other developers who use Python)
-at http://planetpython.org/.
+at https://planetpython.org/.
 
 
 Standards of behaviour in these communication channels
@@ -130,4 +130,4 @@ source of benchmarks for all Python implementations.
 .. _Python Core Workflow: https://github.com/python/core-workflow
 .. _cherry_picker: https://pypi.org/project/cherry-picker/
 .. _blurb: https://pypi.org/project/blurb
-.. _Performance Benchmark: https://github.com/python/performance
+.. _Performance Benchmark: https://github.com/python/pyperformance

--- a/compiler.rst
+++ b/compiler.rst
@@ -364,9 +364,9 @@ Changing this number will lead to all .pyc files with the old ``MAGIC_NUMBER``
 to be recompiled by the interpreter on import.  Whenever ``MAGIC_NUMBER`` is
 changed, the ranges in the ``magic_values`` array in :file:`PC/launcher.c`
 must also be updated.  Changes to :file:`Lib/importlib/_bootstrap_external.py`
-will take effect only after running ``make regen-importlib``. Running this 
-command before adding the new bytecode target to :file:`Python/ceval.c` will 
-result in an error. You should only run ``make regen-importlib`` after the new 
+will take effect only after running ``make regen-importlib``. Running this
+command before adding the new bytecode target to :file:`Python/ceval.c` will
+result in an error. You should only run ``make regen-importlib`` after the new
 bytecode target has been added.
 
 Finally, you need to introduce the use of the new bytecode.  Altering

--- a/coredev.rst
+++ b/coredev.rst
@@ -63,7 +63,7 @@ Gaining Commit Privileges
 
 The steps to gaining commit privileges are:
 
-1. A core developer starts a poll at https://discuss.python.org/c/committers/
+1. A core developer starts a poll at https://discuss.python.org/c/committers/5
 
    - Open for 7 days
    - Results shown upon close
@@ -173,4 +173,4 @@ And finally, enjoy yourself! Contributing to open source software should be fun
 break or figure out what you need to do to make it enjoyable again.
 
 
-.. _PSF Code of Conduct: https://www.python.org/psf/codeofconduct/
+.. _PSF Code of Conduct: https://www.python.org/psf/conduct/

--- a/coverage.rst
+++ b/coverage.rst
@@ -101,7 +101,7 @@ If this does not work for you for some reason, you should try using the
 in-development version of coverage.py to see if it has been updated as needed.
 To do this you should clone/check out the development version of coverage.py:
 
-    git clone https://github.com/nedbat/coveragepy.git
+    git clone https://github.com/nedbat/coveragepy
 
 You will need to use the full path to the installation.
 

--- a/devcycle.rst
+++ b/devcycle.rst
@@ -245,7 +245,7 @@ at all levels including organization membership, team membership, access
 control, and merge privileges on all repositories. For full details of the
 permission levels see `GitHub's documentation on Organization permission
 levels
-<https://help.github.com/articles/permission-levels-for-an-organization/#permission-levels-for-an-organization>`_.
+<https://docs.github.com/en/free-pro-team@latest/github/setting-up-and-managing-organizations-and-teams/permission-levels-for-an-organization#permission-levels-for-an-organization>`_.
 This role is paramount to the security of the Python Language, Community, and
 Infrastructure.
 
@@ -287,7 +287,7 @@ The Administrator role on the repository allows for managing all aspects
 including collaborators, access control, integrations, webhooks, and branch
 protection. For full details of the permission levels see `GitHub's
 documentation on Repository permission levels
-<https://help.github.com/articles/repository-permission-levels-for-an-organization/>`_.
+<https://docs.github.com/en/free-pro-team@latest/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization>`_.
 Common reasons for this role are: maintenance of Core Developer
 Workflow tooling, Release Managers for all :ref:`in-development <indevbranch>`,
 :ref:`maintenance <maintbranch>`, and :ref:`security mode <secbranch>`

--- a/docquality.rst
+++ b/docquality.rst
@@ -36,7 +36,7 @@ The in-development and most recent 3.x (as well as 2.x) maintenance
 branches are rebuilt once per day.
 
 If you would like to be more involved with documentation, consider subscribing
-to the `docs@python.org <https://mail.python.org/mailman/listinfo/docs>`_
+to the `docs@python.org <https://mail.python.org/mailman3/lists/docs.python.org/>`_
 mailing list. The `issue tracker`_ sends new documentation issues to this
 mailing list, and, less frequently, the list receives some directly mailed bug
 reports. The `docs-sig@python.org <https://mail.python.org/mailman/listinfo/doc-sig>`_

--- a/documenting.rst
+++ b/documenting.rst
@@ -1814,7 +1814,7 @@ style.
 
 
 
-.. _docutils: http://docutils.sourceforge.io/
+.. _docutils: https://docutils.sourceforge.io/
 .. _python-docs-theme: https://pypi.org/project/python-docs-theme/
 .. _Sphinx: http://sphinx-doc.org/
 .. _virtualenv: https://virtualenv.pypa.io/

--- a/documenting.rst
+++ b/documenting.rst
@@ -19,7 +19,7 @@ The documentation in HTML, PDF or EPUB format is generated from text files
 written using the :ref:`reStructuredText format <markup>` and contained in the
 :ref:`CPython Git repository <setup>`.
 
-.. _reStructuredText: http://docutils.sourceforge.net/rst.html
+.. _reStructuredText: https://docutils.sourceforge.io/rst.html
 
 .. note::
 
@@ -291,7 +291,7 @@ language, this will not take too long.
 .. seealso::
 
     The authoritative `reStructuredText User
-    Documentation <http://docutils.sourceforge.net/rst.html>`_.
+    Documentation <https://docutils.sourceforge.io/rst.html>`_.
 
 
 Paragraphs
@@ -1647,7 +1647,7 @@ in production, other are work in progress:
 | Turkish (tr)    |                               | `GitHub <github_tr_>`_     |
 +-----------------+-------------------------------+----------------------------+
 
-.. _article_pt_br: http://rgth.co/blog/python-ptbr-cenario-atual
+.. _article_pt_br: https://rgth.co/blog/python-ptbr-cenario-atual/
 .. _bpo_cocoatomo: https://bugs.python.org/user19001
 .. _bpo_gbtami: https://bugs.python.org/user25857
 .. _bpo_kushal: https://bugs.python.org/user16382
@@ -1657,9 +1657,9 @@ in production, other are work in progress:
 .. _chat_pt_br: https://t.me/pybr_i18n
 .. _doc_ja: https://docs.python.org/ja/
 .. _doc_ko: https://docs.python.org/ko/
-.. _doc_zh_cn: https://docs.python.org/zh-cn/
-.. _doc_zh_tw: https://docs.python.org/zh-tw/
-.. _github_ar: https://github.com/Abdur-rahmaanJ/py-docs-ar
+.. _doc_zh_cn: https://docs.python.org/zh-cn/3/
+.. _doc_zh_tw: https://docs.python.org/zh-tw/3/
+.. _github_ar: https://github.com/Abdur-rahmaanJ/python-docs-ar
 .. _github_bn_in: https://github.com/python/python-docs-bn-in
 .. _github_es: https://github.com/python/python-docs-es
 .. _github_fr: https://github.com/python/python-docs-fr
@@ -1680,7 +1680,7 @@ in production, other are work in progress:
 .. _tx_pl: https://www.transifex.com/python-doc/python-newest/language/pl/
 .. _tx_zh_cn: https://www.transifex.com/python-doc/python-newest/language/
 .. _tx_zh_tw: https://www.transifex.com/python-tw-doc/python-36-tw
-.. _wiki_pt_br: http://python.org.br/traducao
+.. _wiki_pt_br: https://python.org.br/traducao/
 
 Starting a new translation
 --------------------------
@@ -1745,7 +1745,7 @@ Which version of Python documentation should be translated?
 
 Consensus is to work on current stable, you can then propagate your
 translation from a branch to another using `pomerge
-<https://pypi.org/p/pomerge>`__.
+<https://pypi.org/project/pomerge/>`__.
 
 
 Are there some tools to help in managing the repo?
@@ -1753,12 +1753,12 @@ Are there some tools to help in managing the repo?
 
 Here's what's we're using:
 
-- `pomerge <https://pypi.org/p/pomerge>`__ to propagate translation
+- `pomerge <https://pypi.org/project/pomerge/>`__ to propagate translation
   from a files to others.
-- `pospell <https://pypi.org/p/pospell>`__ to check for typo in po files.
-- `powrap <https://pypi.org/p/powrap>`__ to rewrap the ``.po`` files
+- `pospell <https://pypi.org/project/pospell/>`__ to check for typo in po files.
+- `powrap <https://pypi.org/project/powrap/>`__ to rewrap the ``.po`` files
   before committing, this helps keeping git diffs short.
-- `potodo <https://pypi.org/p/potodo>`__ to list what needs to be translated.
+- `potodo <https://pypi.org/project/potodo/>`__ to list what needs to be translated.
 
 
 
@@ -1814,7 +1814,7 @@ style.
 
 
 
-.. _docutils: http://docutils.sourceforge.net/
+.. _docutils: http://docutils.sourceforge.io/
 .. _python-docs-theme: https://pypi.org/project/python-docs-theme/
 .. _Sphinx: http://sphinx-doc.org/
 .. _virtualenv: https://virtualenv.pypa.io/

--- a/exploring.rst
+++ b/exploring.rst
@@ -63,7 +63,6 @@ building your understanding of both the 2.x and 3.x versions of CPython:
     "`A guide from parser to objects, observed using GDB`_", "Code walk from Parser, AST, Sym Table and Objects", Louie Lu, 3.7.a0
     "`Green Tree Snakes`_", "The missing Python AST docs", Thomas Kluyver, 3.6
     "`Yet another guided tour of CPython`_", "A guide for how CPython REPL works", Guido van Rossum, 3.5
-    "`Python Asynchronous I/O Walkthrough`_", "How CPython async I/O, generator and coroutine works", Philip Guo, 3.5
     "`Coding Patterns for Python Extensions`_", "Reliable patterns of coding Python Extensions in C", Paul Ross, 3.4
     "`Your Guide to the CPython Source Code`_", "Your Guide to the CPython Source Code", Anthony Shaw, 3.8
 
@@ -83,8 +82,6 @@ building your understanding of both the 2.x and 3.x versions of CPython:
 
 .. _Yet another guided tour of CPython: https://paper.dropbox.com/doc/Yet-another-guided-tour-of-CPython-XY7KgFGn88zMNivGJ4Jzv
 
-.. _Python Asynchronous I/O Walkthrough: http://pgbovine.net/python-async-io-walkthrough.htm
-
 .. _Coding Patterns for Python Extensions: https://pythonextensionpatterns.readthedocs.io/en/latest/
 
 .. _Your Guide to the CPython Source Code: https://realpython.com/cpython-source-code-guide/
@@ -95,4 +92,4 @@ building your understanding of both the 2.x and 3.x versions of CPython:
 
 .. _A guide from parser to objects, observed using Eclipse: https://docs.google.com/document/d/1nzNN1jeNCC_bg1LADCvtTuGKvcyMskV1w8Ad2iLlwoI/
 
-.. _CPython internals\: A ten-hour codewalk through the Python interpreter source code: http://pgbovine.net/cpython-internals.htm
+.. _CPython internals\: A ten-hour codewalk through the Python interpreter source code: https://pg.ucsd.edu/cpython-internals.htm

--- a/garbage_collector.rst
+++ b/garbage_collector.rst
@@ -65,7 +65,7 @@ Normally the C structure supporting a regular Python object looks as follows:
                   |                    *ob_type                   | |
                   +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+ /
                   |                      ...                      |
-                  
+
 
 In order to support the garbage collector, the memory layout of objects is altered
 to accommodate extra information **before** the normal layout:
@@ -82,7 +82,7 @@ to accommodate extra information **before** the normal layout:
                   |                    *ob_type                   | |
                   +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+ /
                   |                      ...                      |
-                  
+
 
 In this way the object can be treated as a normal python object and when the extra
 information associated to the GC is needed the previous fields can be accessed by a
@@ -179,7 +179,7 @@ Every object that supports garbage collection will have an extra reference
 count field initialized to the reference count (``gc_ref`` in the figures)
 of that object when the algorithm starts. This is because the algorithm needs
 to modify the reference count to do the computations and in this way the
-interpreter will not modify the real reference count field. 
+interpreter will not modify the real reference count field.
 
 .. figure:: images/python-cyclic-gc-1-new-page.png
 
@@ -337,7 +337,7 @@ specifically in a generation by calling ``gc.collect(generation=NUM)``.
     >>> import gc
     >>> class MyObj:
     ...     pass
-    ... 
+    ...
 
     # Move everything to the last generation so it's easier to inspect
     # the younger generations.
@@ -462,7 +462,7 @@ benefit from delayed tracking:
   when created. During garbage collection it is determined whether any surviving
   tuples can be untracked. A tuple can be untracked if all of its contents are
   already not tracked. Tuples are examined for untracking in all garbage collection
-  cycles. It may take more than one cycle to untrack a tuple. 
+  cycles. It may take more than one cycle to untrack a tuple.
 
 * Dictionaries containing only immutable objects also do not need to be tracked.
   Dictionaries are untracked when created. If a tracked item is inserted into a
@@ -472,7 +472,7 @@ benefit from delayed tracking:
 
 The garbage collector module provides the python function is_tracked(obj), which returns
 the current tracking status of the object. Subsequent garbage collections may change the
-tracking status of the object. 
+tracking status of the object.
 
 .. code-block:: python
 

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -276,8 +276,8 @@ you run ``git merge upstream/master``.
 
 When it happens, you need to resolve conflict.  See these articles about resolving conflicts:
 
-- `About merge conflicts <https://help.github.com/en/articles/about-merge-conflicts>`_
-- `Resolving a merge conflict using the command line <https://help.github.com/en/articles/resolving-a-merge-conflict-using-the-command-line>`_
+- `About merge conflicts <https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-merge-conflicts>`_
+- `Resolving a merge conflict using the command line <https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/resolving-a-merge-conflict-using-the-command-line>`_
 
 .. _git_from_mercurial:
 
@@ -450,7 +450,7 @@ prior to merging themselves, rather than asking the submitter to do them. This
 can be particularly appropriate when the remaining changes are bookkeeping
 items like updating ``Misc/ACKS``.
 
-.. _Allow edits from maintainers: https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/
+.. _Allow edits from maintainers: https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork
 
 To edit an open pull request that targets ``master``:
 

--- a/help.rst
+++ b/help.rst
@@ -91,8 +91,8 @@ existing releases.  As with ``#python-dev``, these mailing lists are for
 questions involving the development *of* Python, **not** for development
 *with* Python.
 
-.. _python-ideas: https://mail.python.org/mailman/listinfo/python-ideas
-.. _python-dev: https://mail.python.org/mailman/listinfo/python-dev
+.. _python-ideas: https://mail.python.org/mailman3/lists/python-ideas.python.org/
+.. _python-dev: https://mail.python.org/mailman3/lists/python-dev.python.org/
 
 
 File a Bug

--- a/index.rst
+++ b/index.rst
@@ -233,14 +233,14 @@ Key Resources
     * :PEP:`7` (Style Guide for C Code)
     * :PEP:`8` (Style Guide for Python Code)
 * `Issue tracker`_
-    * `Meta tracker <http://psf.upfronthosting.co.za/roundup/meta>`_ (issue
+   * `Meta tracker <http://psf.upfronthosting.co.za/roundup/meta>`_ (issue
       tracker for the issue tracker)
-    * :doc:`experts`
+   * :doc:`experts`
 * `Buildbot status`_
 * Source code
     * `Browse online <https://github.com/python/cpython/>`_
     * `Snapshot of the *master* branch <https://github.com/python/cpython/archive/master.zip>`_
-    * `Daily OS X installer <http://buildbot.python.org/daily-dmg/>`_
+    * `Daily OS X installer <https://buildbot.python.org/daily-dmg/>`_
 * PEPs_ (Python Enhancement Proposals)
 * :doc:`help`
 * :doc:`developers`
@@ -275,7 +275,7 @@ Please note that all interactions on
 `Python Software Foundation <https://www.python.org/psf-landing/>`__-supported
 infrastructure is `covered
 <https://www.python.org/psf/records/board/minutes/2014-01-06/#management-of-the-psfs-web-properties>`__
-by the `PSF Code of Conduct <https://www.python.org/psf/codeofconduct/>`__,
+by the `PSF Code of Conduct <https://www.python.org/psf/conduct/>`__,
 which includes all infrastructure used in the development of Python itself
 (e.g. mailing lists, issue trackers, GitHub, etc.).
 In general this means everyone is expected to be open, considerate, and
@@ -330,9 +330,9 @@ Full Table of Contents
 .. _python.org maintenance: https://pythondotorg.readthedocs.io/
 .. _Python: https://www.python.org/
 .. _Core Python Mentorship: https://www.python.org/dev/core-mentorship/
-.. _PyPy: http://www.pypy.org/
-.. _Jython: http://www.jython.org/
-.. _IronPython: http://ironpython.net/
+.. _PyPy: https://www.pypy.org/
+.. _Jython: https://www.jython.org/
+.. _IronPython: https://ironpython.net/
 .. _Stackless: http://www.stackless.com/
 .. _Issue tracker: https://bugs.python.org/
 .. _open pull requests: https://github.com/python/cpython/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Aopen%20label%3A%22awaiting%20review%22

--- a/langchanges.rst
+++ b/langchanges.rst
@@ -89,7 +89,7 @@ unconvinced. When there isn't an obvious victor then the
 For some examples on language changes that were accepted please read
 `Justifying Python Language Changes`_.
 
-.. _python-ideas: https://mail.python.org/mailman/listinfo/python-ideas
+.. _python-ideas: https://mail.python.org/mailman3/lists/python-ideas.python.org/python-ideas
 .. _issue tracker: https://bugs.python.org
 .. _PEP Index: https://www.python.org/dev/peps/
 .. _draft PEP: https://www.python.org/dev/peps/pep-0001/

--- a/langchanges.rst
+++ b/langchanges.rst
@@ -89,7 +89,7 @@ unconvinced. When there isn't an obvious victor then the
 For some examples on language changes that were accepted please read
 `Justifying Python Language Changes`_.
 
-.. _python-ideas: https://mail.python.org/mailman3/lists/python-ideas.python.org/python-ideas
+.. _python-ideas: https://mail.python.org/mailman3/lists/python-ideas.python.org/
 .. _issue tracker: https://bugs.python.org
 .. _PEP Index: https://www.python.org/dev/peps/
 .. _draft PEP: https://www.python.org/dev/peps/pep-0001/

--- a/motivations.rst
+++ b/motivations.rst
@@ -118,8 +118,8 @@ participating in the CPython core development process:
 
    * Microsoft (Software Developer)
    * Personal site: `stevedower.id.au <https://stevedower.id.au/>`_
-   * Speaking: `stevedower.id.au/speaking <https://stevedower.id.au/speaking/>`_
-   * Work blog: `aka.ms/pythonblog <https://aka.ms/pythonblog>`_
+   * Speaking: `stevedower.id.au/speaking <https://stevedower.id.au/speaking>`_
+   * Work blog: `devblogs.microsoft.com/python <https://devblogs.microsoft.com/python/>`_
    * Email address: steve.dower@python.org
 
    Steve started with Python while automating a test harness for medical
@@ -137,17 +137,17 @@ participating in the CPython core development process:
 
 .. topic:: Mariatta (Canada)
 
-   * Personal site: `mariatta.ca <http://mariatta.ca>`_
+   * Personal site: `mariatta.ca <https://mariatta.ca>`_
    * Works as a `Software Engineer <https://www.linkedin.com/in/mariatta/>`_
      in Vancouver, helps organize `Vancouver PyLadies
      <https://www.meetup.com/PyLadies-Vancouver/>`_ meetup on the side, and
-     sometimes `speaks <http://mariatta.ca/pages/talk-chronology.html#talk-chronology>`_
+     sometimes `speaks <https://mariatta.ca/pages/talk-chronology.html#talk-chronology>`_
      at conferences.
    * Email address: mariatta@python.org
-   * `Sponsor Mariatta on GitHub <https://github.com/users/Mariatta/sponsorship>`_
+   * `Sponsor Mariatta on GitHub <https://github.com/sponsors/Mariatta>`_
    * `Patreon <https://www.patreon.com/Mariatta>`_
 
-   Support Mariatta by `becoming a sponsor <https://github.com/users/Mariatta/sponsorship>`_,
+   Support Mariatta by `becoming a sponsor <https://github.com/sponsors/Mariatta>`_,
    sending her a `happiness packet <https://www.happinesspackets.io/send/>`_,
    or `paypal <https://www.paypal.me/mariatta>`_.
 
@@ -155,7 +155,7 @@ participating in the CPython core development process:
 
    * Personal site: `bitdance.com <http://www.bitdance.com>`_
    * Available for `Python and Internet Services Consulting
-     and Python contract programming <http://www.murrayandwalker.com/>`_
+     and Python contract programming <https://www.murrayandwalker.com/>`_
 
    David has been involved in the Internet since the days when the old IBM
    BITNET and the ARPANet got cross connected, and in Python programming since
@@ -171,7 +171,7 @@ participating in the CPython core development process:
 
    David currently does both proprietary and open source development work,
    primarily in Python, through the company in which he is a partner, `Murray &
-   Walker, Inc <http://www.murrayandwalker.com>`_.  He has done contract work
+   Walker, Inc <https://www.murrayandwalker.com>`_.  He has done contract work
    focused specifically on CPython development both through the PSF (the
    kickstart of the email unicode API development) and directly funded by
    interested corporations (additional development work on email funded by
@@ -229,11 +229,11 @@ participating in the CPython core development process:
    Gaithersburg, MD in 1994, where he met Guido and several other early Python
    adopters.  Barry subsequently worked with Guido for 8 years while at `CNRI
    <http://cnri.reston.va.us/>`_.  From 2007 until 2017, Barry worked for
-   `Canonical <https://www.canonical.com/>`_, corporate sponsor of `Ubuntu
-   <https://www.ubuntu.com/>`_ Linux, primarily on the Python ecosystem, and
+   `Canonical <https://canonical.com/>`_, corporate sponsor of `Ubuntu
+   <https://ubuntu.com/>`_ Linux, primarily on the Python ecosystem, and
    is both an Ubuntu and a `Debian <http://www.debian.org/>`_ uploading
    developer.  Barry has served as Python's postmaster, webmaster, release
-   manager, Language Summit co-chair, `Jython <http://www.jython.org/>`_
+   manager, Language Summit co-chair, `Jython <https://www.jython.org/>`_
    project leader, `GNU Mailman <http://www.list.org/>`_ project leader, and
    probably lots of other things he shouldn't admit to.
 
@@ -252,7 +252,7 @@ participating in the CPython core development process:
    developers on the project for 6 years.  After that he started the Python
    Tools for Visual Studio project focusing on providing advanced code completion
    and debugging features for Python.  Today he works on
-   `Azure Notebooks <http://notebooks.azure.com/>`_ bringing the Python based
+   `Azure Notebooks <https://notebooks.azure.com/>`_ bringing the Python based
    Jupyter notebook as a hosted on-line service.
 
 .. topic:: Carol Willing (United States)
@@ -324,8 +324,8 @@ time contributing to CPython development.
 .. _issue metrics: https://bugs.python.org/issue?@template=stats
 .. _OpenHub: https://www.openhub.net/p/python/contributors
 .. _core mentorship program: https://www.python.org/dev/core-mentorship/
-.. _internships: https://www.gnome.org/outreachy/
-.. _Summer of Code: https://wiki.python.org/moin/SummerOfCode/2016
+.. _internships:  https://www.outreachy.org/
+.. _Summer of Code: https://python-gsoc.org/
 
 
 Limitations on scope

--- a/motivations.rst
+++ b/motivations.rst
@@ -212,7 +212,7 @@ participating in the CPython core development process:
 .. topic:: Kushal Das (India)
 
    * `Personal website <https://kushaldas.in>`__
-   * `Freedom of the Press Foundation <https://freedom.press>`__ (Staff)
+   * `Freedom of the Press Foundation <https://freedom.press/>`__ (Staff)
    * Python Software Foundation (Fellow)
 
 .. topic:: Barry Warsaw (United States)

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -57,8 +57,8 @@ Here is a quick overview of how you can contribute to CPython:
 .. _create an issue: https://bugs.python.org/
 .. _CPython: https://github.com/python/cpython
 .. _use HTTPS: https://help.github.com/articles/which-remote-url-should-i-use/
-.. _Create Pull Request: https://help.github.com/articles/creating-a-pull-request/
-.. _comments on your Pull Request: https://help.github.com/articles/commenting-on-a-pull-request/
+.. _Create Pull Request: https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request
+.. _comments on your Pull Request: https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/commenting-on-a-pull-request
 
 
 .. _pullrequest-steps:
@@ -344,7 +344,7 @@ This will get your changes up to GitHub.
 
 Now you want to
 `create a pull request from your fork
-<https://help.github.com/articles/creating-a-pull-request-from-a-fork/>`_.
+<https://help.github.com/articles/https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork>`_.
 If this is a pull request in response to a pre-existing issue on the
 `issue tracker`_, please make sure to reference the issue number using
 ``bpo-NNNN`` in the pull request title or message.
@@ -381,7 +381,7 @@ existing patch. In this case, both parties should sign the :ref:`CLA <cla>`.
 When creating a pull request based on another person's patch, provide
 attribution to the original patch author by adding "Co-authored-by:
 Author Name <email_address> ." to the pull request description and commit message.
-See `the GitHub article <https://help.github.com/articles/creating-a-commit-with-multiple-authors/>`_
+See `the GitHub article <https://docs.github.com/en/free-pro-team@latest/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors>`_
 on how to properly add the co-author info.
 
 See also :ref:`Applying a Patch from Mercurial to Git <git_from_mercurial>`.
@@ -456,7 +456,7 @@ Leaving a Pull Request Review on GitHub
 ---------------------------------------
 
 When you review a pull request, you should provide additional details and context
-of your review process. 
+of your review process.
 
 Instead of simply "approving" the pull request, leave comments.  For example:
 

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -344,7 +344,7 @@ This will get your changes up to GitHub.
 
 Now you want to
 `create a pull request from your fork
-<https://help.github.com/articles/https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork>`_.
+<https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork>`_.
 If this is a pull request in response to a pre-existing issue on the
 `issue tracker`_, please make sure to reference the issue number using
 ``bpo-NNNN`` in the pull request title or message.

--- a/runtests.rst
+++ b/runtests.rst
@@ -129,7 +129,7 @@ Benchmarks
 ----------
 Benchmarking is useful to test that a change does not degrade performance.
 
-`The Python Benchmark Suite <https://github.com/python/performance>`_
+`The Python Benchmark Suite <https://github.com/python/pyperformance>`_
 has a collection of benchmarks for all Python implementations. Documentation
 about running the benchmarks is in the `README.txt
-<https://github.com/python/performance/blob/master/README.rst>`_ of the repo.
+<https://github.com/python/pyperformance/blob/master/README.rst>`_ of the repo.

--- a/setup.rst
+++ b/setup.rst
@@ -34,7 +34,7 @@ itself. git is easily available for all common operating systems.
 - **Install**
 
   As the CPython repo is hosted on GitHub, please refer to either the
-  `GitHub setup instructions <https://help.github.com/articles/set-up-git/>`_
+  `GitHub setup instructions <https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/set-up-git>`_
   or the `git project instructions <https://git-scm.com>`_ for step-by-step
   installation directions. You may also want to consider a graphical client
   such as `TortoiseGit <https://tortoisegit.org/>`_ or
@@ -43,7 +43,7 @@ itself. git is easily available for all common operating systems.
 - **Configure**
 
   Configure :ref:`your name and email <set-up-name-email>` and create
-  `an SSH key <https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/>`_
+  `an SSH key <permanently to https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account>`_
   as this will allow you to interact with GitHub without typing a username
   and password each time you execute a command, such as ``git pull``,
   ``git push``, or ``git fetch``.  On Windows, you should also
@@ -279,7 +279,7 @@ to build.
    not be able to find all the project's files and will fail the build.
 
 .. _this documentation: https://cpython-core-tutorial.readthedocs.io/en/latest/build_cpython_windows.html
-.. _Visual Studio 2017: https://www.visualstudio.com/
+.. _Visual Studio 2017: permanently to https://visualstudio.microsoft.com/
 .. _readme: https://github.com/python/cpython/blob/master/PCbuild/readme.txt
 .. _PCbuild directory: https://github.com/python/cpython/tree/2.7/PCbuild/
 .. _2.7 readme: https://github.com/python/cpython/blob/2.7/PCbuild/readme.txt
@@ -423,7 +423,7 @@ Explaining how to build optional dependencies on a UNIX based system without
 root access is beyond the scope of this guide.
 
 .. _clang: https://clang.llvm.org/
-.. _ccache: https://ccache.samba.org/
+.. _ccache: https://ccache.dev/
 
 .. note:: While you need a C compiler to build CPython, you don't need any
    knowledge of the C language to contribute!  Vast areas of CPython are
@@ -551,4 +551,3 @@ every rule.
 
 ``Tools``
      Various tools that are (or have been) used to maintain Python.
-

--- a/tracker.rst
+++ b/tracker.rst
@@ -8,7 +8,7 @@ Using the Issue Tracker
 =======================
 
 If you think you have found a bug in Python, you can report it to the
-`issue tracker`_. The `issue tracker`_ is also commonly referred to as 
+`issue tracker`_. The `issue tracker`_ is also commonly referred to as
 `bugs.python.org` and `bpo`.  Documentation bugs can also be reported there.
 
 You can report bugs with the issue tracker itself to the `meta tracker`_.
@@ -27,10 +27,10 @@ already been reported.  Checking if the problem is an existing issue will:
   the next release
 * save time for you and the developers
 * help you learn what needs to be done to fix it
-* determine if additional information, such as how to replicate the issue, 
+* determine if additional information, such as how to replicate the issue,
   is needed
 
-To do see if the issue already exists, search the bug database using the 
+To do see if the issue already exists, search the bug database using the
 search box on the top of the issue tracker page. An `advanced search`_ is also
 available by clicking on "Search" in the sidebar.
 
@@ -59,7 +59,7 @@ in the :ref:`triaging` page.  This is a short summary:
   you can select these too; otherwise, leave them blank;
 * last but not least, you have to describe the problem in detail, including
   what you expected to happen, what did happen, and how to replicate the
-  problem in the **Comment** field. Be sure to include whether any extension 
+  problem in the **Comment** field. Be sure to include whether any extension
   modules were involved, and what hardware and software platform you were using
   (including version information as appropriate).
 
@@ -79,7 +79,7 @@ As humans, we will have differences of opinions from time to time. First and
 foremost, please be respectful that care, thought, and volunteer time went into
 the resolution.
 
-With this in mind, take some time to consider any comments made in association 
+With this in mind, take some time to consider any comments made in association
 with the resolution of the issue. On reflection, the resolution steps may seem
 more reasonable than you initially thought.
 
@@ -91,7 +91,7 @@ win any converts.
 As a reminder, issues closed by a core developer have already been carefully
 considered. Please do not reopen a closed issue.
 
-.. _python-dev: https://mail.python.org/mailman/listinfo/python-dev
+.. _python-dev: https://mail.python.org/mailman3/lists/python-dev.python.org/
 
 
 .. _helptriage:
@@ -122,8 +122,8 @@ For bugs, an issue needs to:
 These are things you can help with once you have experience developing for
 Python:
 
-* try reproducing the bug: For instance, if a bug is not clearly explained 
-  enough for you to reproduce it then there is a good chance a core developer 
+* try reproducing the bug: For instance, if a bug is not clearly explained
+  enough for you to reproduce it then there is a good chance a core developer
   won't be able to either.
 * see if the issue happens on a different Python version: It is always helpful
   to know if a bug not only affects the in-development version of Python, but
@@ -160,12 +160,12 @@ Finding an Issue You Can Help With
 
 If you want to help triage issues, you might also want to search for issues
 in modules which you have a working knowledge.  Search for the name of a module
-in the issue tracker or use the `advanced search`_ to search for specific 
+in the issue tracker or use the `advanced search`_ to search for specific
 components (e.g. "Windows" if you are a Windows developer, "Extension Modules"
 if you are familiar with C, etc.). Finally you can use the "Random issue" link
-in the sidebar to pick random issues until you find an issue that you like.  
+in the sidebar to pick random issues until you find an issue that you like.
 You may find old issues that can be closed, either because they
-are no longer valid or they have a patch that is ready to be committed, 
+are no longer valid or they have a patch that is ready to be committed,
 but no one has had the time to do so.
 
 In the sidebar you can also find links to summaries for easy issues and

--- a/triaging.rst
+++ b/triaging.rst
@@ -16,11 +16,11 @@ Python triage team
 
 The Python triage team is a group dedicated towards improving workflow
 efficiency through thoughtful review and triage of open issues and pull
-requests. This helps contributors receive timely feedback and enables core 
-developers to focus on reviewed items which reduces their workload. The 
-expectations of this role expand upon the "Developer" role on the 
-`issue tracker`_. The responsibilities listed below are primarily centered 
-around the Python GitHub repositories. This extends beyond CPython, and, as 
+requests. This helps contributors receive timely feedback and enables core
+developers to focus on reviewed items which reduces their workload. The
+expectations of this role expand upon the "Developer" role on the
+`issue tracker`_. The responsibilities listed below are primarily centered
+around the Python GitHub repositories. This extends beyond CPython, and, as
 needed, to other repos such as devguide and core-workflow.
 
 Responsibilities include:
@@ -64,7 +64,7 @@ to handle not just issues, but also pull requests, and even managing backports.
 Any existing developers on b.p.o can transition into becoming a Python triager.
 They can request this to any core developer, and the core developer
 can pass the request to the `Python organization admin
-<https://devguide.python.org/devcycle/?highlight=organization%20admin#current-owners>`_
+<https://devguide.python.org/devcycle/#current-owners>`_
 on GitHub. The request
 can be made confidentially via a DM in Zulip or Discourse, or publicly by opening
 an `issue in the core-workflow repository
@@ -143,7 +143,7 @@ sprint
 stale
     Used for PRs that include changes which are no longer relevant or when the
     author hasn't responded to feedback in a long period of time. This label
-    helps core developers quickly identify PRs that are candidates for closure 
+    helps core developers quickly identify PRs that are candidates for closure
     or require a ping to the author.
 
 type-bugfix
@@ -164,7 +164,7 @@ type-performance
     Used for PRs that provide performance optimizations.
 
 type-security
-    Used for PRs that involve critical security issues. Less severe 
+    Used for PRs that involve critical security issues. Less severe
     security concerns can instead use the type-bugfix label.
 
 type-tests
@@ -588,32 +588,32 @@ Checklist for Triaging
 .. _Lib/lib2to3: https://github.com/python/cpython/tree/master/Lib/lib2to3/
 .. _Lib/ctypes: https://github.com/python/cpython/tree/master/Lib/ctypes/
 .. _Lib/distutils: https://github.com/python/cpython/tree/master/Lib/distutils/
-.. _Lib/doctest.py: https://github.com/python/cpython/tree/master/Lib/doctest.py
+.. _Lib/doctest.py: https://github.com/python/cpython/blob/master/Lib/doctest.py
 .. _Lib/idlelib: https://github.com/python/cpython/tree/master/Lib/idlelib/
-.. _Lib/io.py: https://github.com/python/cpython/tree/master/Lib/io.py
-.. _Lib/re.py: https://github.com/python/cpython/tree/master/Lib/re.py
+.. _Lib/io.py: https://github.com/python/cpython/blob/master/Lib/io.py
+.. _Lib/re.py: https://github.com/python/cpython/blob/master/Lib/re.py
 .. _Lib/test: https://github.com/python/cpython/tree/master/Lib/test/
-.. _Lib/test/regrtest.py: https://github.com/python/cpython/tree/master/Lib/test/regrtest.py
+.. _Lib/test/regrtest.py: https://github.com/python/cpython/blob/master/Lib/test/regrtest.py
 .. _Lib/test/support: https://github.com/python/cpython/tree/master/Lib/test/support/
 .. _Lib/tkinter: https://github.com/python/cpython/tree/master/Lib/tkinter/
 .. _Lib/unittest: https://github.com/python/cpython/tree/master/Lib/unittest/
 .. _Lib/xml: https://github.com/python/cpython/tree/master/Lib/xml/
 .. _Modules: https://github.com/python/cpython/tree/master/Modules/
 .. _Modules/_io: https://github.com/python/cpython/tree/master/Modules/_io/
-.. _Modules/_sre.c: https://github.com/python/cpython/tree/master/Modules/_sre.c
+.. _Modules/_sre.c: https://github.com/python/cpython/blob/master/Modules/_sre.c
 .. _Objects: https://github.com/python/cpython/tree/master/Objects/
-.. _Objects/unicodeobject.c: https://github.com/python/cpython/tree/master/Objects/unicodeobject.c
+.. _Objects/unicodeobject.c: https://github.com/python/cpython/blob/master/Objects/unicodeobject.c
 .. _Parser: https://github.com/python/cpython/tree/master/Parser/
 .. _Python: https://github.com/python/cpython/tree/master/Python/
 .. _Tools: https://github.com/python/cpython/tree/master/Tools/
 .. _Tools/demo: https://github.com/python/cpython/tree/master/Tools/demo/
 .. _Developer's guide: https://github.com/python/devguide/
-.. _GSoC: https://summerofcode.withgoogle.com/
+.. _GSoC: https://summerofcode.withgoogle.com/archive/
 .. _issue tracker: https://bugs.python.org
 .. _GitHub pull requests: https://github.com/python/cpython/pulls
 .. _Python source code repositories: https://github.com/python/cpython/
 .. _Reporting security issues in Python: https://www.python.org/dev/security/
-.. _python-ideas: https://mail.python.org/mailman/listinfo/python-ideas
+.. _python-ideas: https://mail.python.org/mailman3/lists/python-ideas.python.org/
 .. _release schedule: https://devguide.python.org/#status-of-python-branches
-.. _PSF Code of Conduct: https://www.python.org/psf/codeofconduct/
+.. _PSF Code of Conduct: https://www.python.org/psf/conduct/
 .. _PEP 3121: https://www.python.org/dev/peps/pep-3121/


### PR DESCRIPTION
Most of the broken hyperlinks as detailed in #371 are fixed. As [stated](https://github.com/python/devguide/issues/371#issuecomment-389481360) by @willingc, only the permanently moved links were cleaned, for now. Although a few links are still broken as I couldn't find relevant alternative sources anywhere else. So I'll need further clarification to resolve those.

Following are some of the files & the hyperlinks for which I need some clarification:
- `exploring.rst` - The article [Python Asynchronous I/O Walkthrough](http://pgbovine.net/python-async-io-walkthrough.htm) under [Additional Resources](https://devguide.python.org/exploring/#additional-references) doesn't exist anymore. There's a [YouTube playlist](https://www.youtube.com/playlist?list=PLpEcQSRWP2IjVRlTUptdD05kG-UkJynQT) though. The same author has another article [CPython internals: A ten-hour code walk through the Python interpreter source code](http://pgbovine.net/cpython-internals.htm) which has a warning about not linking it, as it might be removed any day.

- `index.rst` - [Meta Tracker](http://psf.upfronthosting.co.za/roundup/meta) under [Key Resources](https://devguide.python.org/#key-resources) at the address doesn't work.

- `motivations.rst` - Link to [Summer of Code](https://wiki.python.org/moin/SummerOfCode/2016) under [Goals of this page](https://devguide.python.org/motivations/#goals-of-this-page) isn't broken but its moved to https://python-gsoc.org/. Hence, I updated it accordingly but I can revert it back if necessary.

- `buildworker.rst` - Documentation for `buildbot` has changed addresses. Hence the link [latent worker](http://docs.buildbot.net/current/manual/cfg-workers.html#latent-workers) under the anchor [Latent Workers](https://devguide.python.org/buildworker/#latent-workers) returns a 404 Status Code. Perhaps, this address http://docs.buildbot.net/current/manual/configuration/workers.html#latent-workers would be a better alternative. I can update the links upon clarification.

- `communication.rst` - Mailing list archives at GMANE has been moved to [news.gmane.io](http://news.gmane.io/) as per discussions at https://discuss.python.org/t/ot-gmane-server-moving/2967. Thus the original link to gmane.org returns a 522 status code.

- `coredev.rst` - The link https://github.com/python/voters/ under [Gaining Commit Privileges](https://devguide.python.org/coredev/#gaining-commit-privileges) returns a 404 code as well. Is it accessible only to the members?

- `documenting.rst` - The Polish translations at https://www.transifex.com/python-doc/python-newest/language/pl/ under the anchor [Translations](https://devguide.python.org/documenting/#translating) is broken. Although a link exists in some form at this address - https://www.transifex.com/python-doc/python-newest/

- `help.rst` - The link to Python Zulip chat under Mariatta Wijaya's Office Hours isn't broke, instead, it requires the user to be logged in.

- `tracker.rst` - The link https://mail.python.org/mailman/listinfo/tracker-discuss towards the end of the file returns 404 Status Code. Shouldn't link to the https://discuss.python.org/ Discourse channel?

I can fix the remaining hyperlinks upon clarification on what should be done.