### PR TITLE
Fix RemovedInSphinx40Warning: Replace deprecated add_stylesheet with add_css_file

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -237,7 +237,8 @@ linkcheck_anchors_ignore = [
     '\/.*',
 ]
 
+
 # Use our custom CSS stylesheet to differentiate us from the official python
 # docs.
 def setup(app):
-    app.add_stylesheet('custom.css')
+    app.add_css_file('custom.css')


### PR DESCRIPTION
# Before

```console
$ sphinx-build -n -W -q -b html -d _build/doctrees . _build/html
/home/travis/build/python/devguide/conf.py:243: RemovedInSphinx40Warning: The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
  app.add_stylesheet('custom.css')
The command "sphinx-build -n -W -q -b html -d _build/doctrees . _build/html" exited with 0.
```

https://travis-ci.com/github/python/devguide/jobs/402257689#L244

# After

```console
$ sphinx-build -n -W -q -b html -d _build/doctrees . _build/html
The command "sphinx-build -n -W -q -b html -d _build/doctrees . _build/html" exited with 0.
```

https://travis-ci.com/github/hugovk/devguide/jobs/402347688#L246