### PR TITLE
Update experts index

### DIFF
--- a/experts.rst
+++ b/experts.rst
@@ -50,7 +50,7 @@ __future__
 __main__              gvanrossum, ncoghlan
 _dummy_thread         brett.cannon
 _thread
-_testbuffer           skrah
+_testbuffer           
 abc
 aifc                  r.david.murray
 argparse              rhettinger*
@@ -96,7 +96,7 @@ curses                twouters
 dataclasses           eric.smith
 datetime              belopolsky, p-ganssle
 dbm
-decimal               facundobatista, rhettinger, mark.dickinson, skrah
+decimal               facundobatista, rhettinger, mark.dickinson
 difflib               tim.peters (inactive)
 dis                   yselivanov
 distutils             eric.araujo, dstufft
@@ -141,7 +141,7 @@ itertools             rhettinger*
 json                  bob.ippolito (inactive), ezio.melotti, rhettinger
 keyword
 lib2to3               benjamin.peterson
-libmpdec              skrah
+libmpdec              
 linecache
 locale                lemburg
 logging               vinay.sajip
@@ -334,7 +334,7 @@ io                  benjamin.peterson, stutzbach
 locale              lemburg
 mathematics         mark.dickinson, lemburg, stutzbach, rhettinger
 memory management   tim.peters, lemburg, twouters
-memoryview          skrah
+memoryview          
 networking          giampaolo.rodola,
 object model        benjamin.peterson, twouters
 packaging           tarek, lemburg, alexis, eric.araujo, dstufft, paul.moore


### PR DESCRIPTION
Considering that Stefan is no longer a core developer, it would make sense not to tag them as nosy for issues under his interest. Alternatively, should they be marked as inactive instead?