### PR TITLE
Add an entry for Doc/library/ast.rst

### DIFF
--- a/grammar.rst
+++ b/grammar.rst
@@ -49,6 +49,9 @@ Note: sometimes things mysteriously don't work.  Before giving up, try ``make cl
 * ``_Unparser`` in the :file:`Lib/ast.py` file may need changes to accommodate
   any modifications in the AST nodes.
 
+* If any AST node introduced or updated, changes needs to be reflacted to
+  :file:`Doc/library/ast.rst`. 
+
 * Add some usage of your new syntax to ``test_grammar.py``.
 
 * Certain changes may require tweaks to the library module :mod:`pyclbr`.

--- a/grammar.rst
+++ b/grammar.rst
@@ -49,8 +49,7 @@ Note: sometimes things mysteriously don't work.  Before giving up, try ``make cl
 * ``_Unparser`` in the :file:`Lib/ast.py` file may need changes to accommodate
   any modifications in the AST nodes.
 
-* If any AST node introduced or updated, changes needs to be reflacted to
-  :file:`Doc/library/ast.rst`. 
+* :file:`Doc/library/ast.rst` may need to be updated to reflect changes to AST nodes.
 
 * Add some usage of your new syntax to ``test_grammar.py``.
 


### PR DESCRIPTION
Since 3.9, we started to document each each individual node in the [AST](https://docs.python.org/library/3/ast.html) docs. It might be a common catch to forget when a new node is introduced or existing ones are updated / removed, so added a checklist entry.