### PR TITLE
Skip minor version on apt build dep

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -336,7 +336,7 @@ Then you should update the packages index::
 
 Now you can install the build dependencies via ``apt``::
 
-   $ sudo apt-get build-dep python3.6
+   $ sudo apt-get build-dep python3
 
 If that package is not available for your system, try reducing the minor
 version until you find a package that is available.


### PR DESCRIPTION
The current Debian (buster) seems to allow users to use `apt-get build-dep python3` to install the build dependencies (the 3.6 version is also out of date)