### PR TITLE
Note removal of privileges for akuchling

### DIFF
--- a/developers.csv
+++ b/developers.csv
@@ -163,7 +163,7 @@ Eric S. Raymond,,2000-06-02,2017-02-10,Did not make GitHub transition
 Greg Stein,,1999-11-07,2017-02-10,Did not make GitHub transition
 Just van Rossum,,1999-01-22,2017-02-10,Did not make GitHub transition
 Greg Ward,,1998-12-18,2017-02-10,Did not make GitHub transition
-Andrew Kuchling,akuchling,1998-04-09,,
+Andrew Kuchling,akuchling,1998-04-09,2021-02-22,Privileges relinquished on 2021-02-22
 Ken Manheimer,,1998-03-03,2005-04-08,Privileges relinquished on 2005-04-08
 Jeremy Hylton,jeremyhylton,1997-08-13,,
 Roger E. Masse,,1996-12-09,2017-02-10,Did not make GitHub transition


### PR DESCRIPTION
I've removed myself from the Python teams on Github.

In theory, doing open-source development on Python has been my professional-development activity for the past year, but in practice I've gotten very little done on Python, and it seems like time to look for other projects.  If I have Python-related changes or documentation in the future, I'll just file a PR for someone else to assess and merge.
