### PR TITLE
Fix the pyperformance Repo URL.

### DIFF
--- a/communication.rst
+++ b/communication.rst
@@ -130,4 +130,4 @@ source of benchmarks for all Python implementations.
 .. _Python Core Workflow: https://github.com/python/core-workflow
 .. _cherry_picker: https://pypi.org/project/cherry-picker/
 .. _blurb: https://pypi.org/project/blurb
-.. _Performance Benchmark: https://github.com/python/performance
+.. _Performance Benchmark: https://github.com/python/pyperformance

--- a/runtests.rst
+++ b/runtests.rst
@@ -129,7 +129,7 @@ Benchmarks
 ----------
 Benchmarking is useful to test that a change does not degrade performance.
 
-`The Python Benchmark Suite <https://github.com/python/performance>`_
+`The Python Benchmark Suite <https://github.com/python/pyperformance>`_
 has a collection of benchmarks for all Python implementations. Documentation
 about running the benchmarks is in the `README.txt
-<https://github.com/python/performance/blob/master/README.rst>`_ of the repo.
+<https://github.com/python/pyperformance/blob/master/README.rst>`_ of the repo.


### PR DESCRIPTION
The repo changed name, from "performance" to "pyperformance", a while back.  Looks like the devguide did not get updated.  GitHub is kind enough to rewrite the old URL in requests but we may as well update the actual links.