### PR TITLE
Added copyright link for the devguide

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -97,6 +97,7 @@ html_theme = 'python_docs_theme'
 html_theme_options = {
     'collapsiblesidebar': True,
     'issues_url': 'https://github.com/python/devguide/issues/new',
+    'copyright_url': 'https://github.com/python/devguide/blob/master/LICENSE',
 }
 
 


### PR DESCRIPTION
In order to resolve issues #652 and #653 in the devguide (which are duplicates of each other), we added a theme variable to `python_docs_theme/layout.html` in PR #67. This will allow all users of the python-docs-theme library to have more functionality and backwards compatibility. In addition, if users don't define a link for copyright information, then they won't have a broken link that leads to nowhere in their page footer.

In order to have the correct copyright link for the devguide specifically, we just needed to specify it in the `html_theme_options` dictionary in the devguide's `conf.py`, which I did in this commit.