### PR TITLE
Fix link to custom builders

### DIFF
--- a/buildbots.rst
+++ b/buildbots.rst
@@ -209,7 +209,7 @@ Custom builders
 When working on a platform-specific issue, you may want to test your changes on
 the buildbot fleet rather than just on Travis and AppVeyor.  To do so, you can
 make use of the `custom builders
-<http://buildbot.python.org/all/#/builders?tags=custom.unstable&tags=custom.stable>`_.
+<https://buildbot.python.org/all/#/builders?tags=%2Bcustom>`_.
 These builders track the ``buildbot-custom`` short-lived branch of the
 ``python/cpython`` repository, which is only accessible to core developers.
 


### PR DESCRIPTION
The name of the tags classifying the various builders has changed at some point, but the devguide hasn't been updated, so the current link points to a list of 0 builders.