### PR TITLE
Replace Zulip with Discourse

### DIFF
--- a/communication.rst
+++ b/communication.rst
@@ -74,11 +74,17 @@ RSS feed readers.
 .. _StackOverflow: https://stackoverflow.com/
 .. _Freenode: http://freenode.net/
 
-Zulip
------
 
-We have our own `zulipchat <https://python.zulipchat.com>`_ instance. This should be
-used to discuss the development of Python only.
+Discourse
+---------
+
+We have our own `_Discourse`_ forum for both developers and users. This forum
+complements the `_python-dev`_, `_python-ideas`_, `_python-help`_, and
+`_python-list`_ mailing lists. Also, voting for new core developers takes place
+at `_Discourse`_.
+
+.. _Discourse: https://discuss.python.org/
+
 
 IRC
 ---

--- a/communication.rst
+++ b/communication.rst
@@ -78,10 +78,10 @@ RSS feed readers.
 Discourse
 ---------
 
-We have our own `_Discourse`_ forum for both developers and users. This forum
-complements the `_python-dev`_, `_python-ideas`_, `_python-help`_, and
-`_python-list`_ mailing lists. Also, voting for new core developers takes place
-at `_Discourse`_.
+We have our own `Discourse`_ forum for both developers and users. This forum
+complements the `python-dev`_, `python-ideas`_, `python-help`_, and
+`python-list`_ mailing lists. Also, voting for new core developers takes place
+at `Discourse`_.
 
 .. _Discourse: https://discuss.python.org/
 

--- a/triaging.rst
+++ b/triaging.rst
@@ -66,13 +66,13 @@ They can request this to any core developer, and the core developer
 can pass the request to the `Python organization admin
 <https://devguide.python.org/devcycle/?highlight=organization%20admin#current-owners>`_
 on GitHub. The request
-can be made confidentially via a DM in Zulip or Discourse, or publicly by opening
+can be made confidentially via a DM in Discourse, or publicly by opening
 an `issue in the core-workflow repository
 <https://github.com/python/core-workflow/issues/new?template=triage_membership.md>`_.
 
 Any contributor who is not already a developer on b.p.o can also self-nominate
 to be a member of Python triage team. They can request this to any core developer,
-confidentially via DM in Zulip or Discourse, or publicly by opening an issue in core-workflow.
+confidentially via DM in Discourse, or publicly by opening an issue in core-workflow.
 If a core developer agrees and is willing to vouch for them, the core developer
 can pass the request to the GitHub administrator. They should also be added as
 developer on bpo.


### PR DESCRIPTION
- Section 11: Remove Zulip refs
- Section 12.2: Replace Zulip with Discourse

Resolves #669 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->