### PR TITLE
Add advice on building all modules on Debian-like

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -325,10 +325,14 @@ Then you should update the packages index::
 
 Now you can install the build dependencies via ``apt``::
 
-   $ sudo apt-get build-dep python3.6
+   $ sudo apt-get build-dep python3
 
-If that package is not available for your system, try reducing the minor
-version until you find a package that is available.
+If you want to build all optional modules, install the following packages and
+their dependencies::
+
+   $ sudo apt-get install build-essential gdb lcov libbz2-dev libffi-dev \
+         libgdbm-dev liblzma-dev libncurses5-dev libreadline6-dev \
+         libsqlite3-dev libssl-dev lzma lzma-dev tk-dev uuid-dev zlib1g-dev
 
 
 .. _MacOS:


### PR DESCRIPTION
Current advice regarding installing dependencies is insufficient to build all optional modules:

```
The necessary bits to build these optional modules were not found:                                                            
_bz2                  _curses               _curses_panel
_dbm                  _gdbm                 _hashlib
_lzma                 _sqlite3              _ssl
_tkinter              _uuid                 readline
zlib                                                   
To find the necessary bits, look in setup.py in detect_modules() for the module's name. 
```

Some users may like the convenience of getting a head start on choosing OS packages that get them closer to a complete build.