### PR TITLE
Remove mention of old coverage comment from checklist

### DIFF
--- a/committing.rst
+++ b/committing.rst
@@ -23,10 +23,6 @@ to enter the public source tree. Ask yourself the following questions:
    in-development branch. Pull requests should only target bug-fix branches
    if an issue appears in only that version and possibly older versions.
 
-* **Are there comments on the pull request?** 
-   Look for explanations about whether the code coverage increased or 
-   stayed the same.
-
 * **Are the changes acceptable?** 
    If you want to share your work-in-progress code on a feature or bugfix, 
    then you can open a ``WIP``-prefixed pull request, publish patches on 


### PR DESCRIPTION
This comment seems to be an old revised mention about codecov's coverage comments from here: https://github.com/python/devguide/pull/80/files#diff-eb1b0e0746ead0f2c05fe91ab3cf886a06b30c20459147869209616b5d2279cbR20-R21

We've long disabled codecov posting comments on pull requests about coverage, and with https://github.com/python/cpython/pull/25679 working to remove the coverage build, we can get rid of this mention.