### PR TITLE
Remove replace description for py27 in setup step

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -46,9 +46,8 @@ instructions please see the :ref:`setup guide <setup>`.
 
       ./python -m test -j3
 
-   On :ref:`most <mac-python.exe>` Mac OS X systems, replace :file:`./python`
-   with :file:`./python.exe`.  On Windows, use :file:`python.bat`.  With Python
-   2.7, replace ``test`` with ``test.regrtest``.
+   On :ref:`most <mac-python.exe>` Mac OS X systems or WSL, replace :file:`./python`
+   with :file:`./python.exe`.  On Windows, use :file:`python.bat`.
 
 5. Create a new branch where your work for the issue will go, e.g.::
 

--- a/index.rst
+++ b/index.rst
@@ -46,7 +46,7 @@ instructions please see the :ref:`setup guide <setup>`.
 
       ./python -m test -j3
 
-   On :ref:`most <mac-python.exe>` Mac OS X systems or WSL, replace :file:`./python`
+   On :ref:`most <mac-python.exe>` Mac OS X systems, replace :file:`./python`
    with :file:`./python.exe`.  On Windows, use :file:`python.bat`.
 
 5. Create a new branch where your work for the issue will go, e.g.::

--- a/setup.rst
+++ b/setup.rst
@@ -199,7 +199,7 @@ If you decide to :ref:`build-dependencies`, you will need to re-run both
 Once CPython is done building you will then have a working build
 that can be run in-place; ``./python`` on most machines (and what is used in
 all examples), ``./python.exe`` wherever a case-insensitive filesystem is used
-(e.g. on OS X or WSL by default), in order to avoid conflicts with the ``Python``
+(e.g. on OS X by default), in order to avoid conflicts with the ``Python``
 directory. There is normally no need to install your built copy
 of Python! The interpreter will realize where it is being run from
 and thus use the files found in the working copy.  If you are worried

--- a/setup.rst
+++ b/setup.rst
@@ -199,7 +199,7 @@ If you decide to :ref:`build-dependencies`, you will need to re-run both
 Once CPython is done building you will then have a working build
 that can be run in-place; ``./python`` on most machines (and what is used in
 all examples), ``./python.exe`` wherever a case-insensitive filesystem is used
-(e.g. on OS X by default), in order to avoid conflicts with the ``Python``
+(e.g. on OS X or WSL by default), in order to avoid conflicts with the ``Python``
 directory. There is normally no need to install your built copy
 of Python! The interpreter will realize where it is being run from
 and thus use the files found in the working copy.  If you are worried


### PR DESCRIPTION
Remove replace description for python2. (It's no longer needed after EOL)

