### PR TITLE
minor grammar improvement

### DIFF
--- a/docquality.rst
+++ b/docquality.rst
@@ -99,7 +99,7 @@ lives in a `separate repository`_ and bug reports should be submitted to the
 
 Our devguide workflow uses continuous integration and deployment so changes to
 the devguide are normally published when the pull request is merged. Changes
-to CPython documentation follows the workflow of a CPython release and is
+to CPython documentation follow the workflow of a CPython release and are
 published in the release.
 
 


### PR DESCRIPTION
The former sentence used to say "Changes (...) follows (...) and is (...)", but since the sentence subject is a plural then the verbs should be replaced with (they) "follow" and "are". Does that make sense?


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->