### PR TITLE
removed reference of testing through IDLE

### DIFF
--- a/runtests.rst
+++ b/runtests.rst
@@ -24,11 +24,6 @@ On :ref:`most <mac-python.exe>` Mac OS X systems, replace :file:`./python`
 with :file:`./python.exe`.  On Windows, use :file:`python.bat`.  If using
 Python 2.7, replace ``test`` with ``test.regrtest``.
 
-If you don't have easy access to a command line, you can run the test suite from
-a Python or IDLE shell::
-
-    >>> from test import autotest
-
 This will run the majority of tests, but exclude a small portion of them; these
 excluded tests use special kinds of resources: for example, accessing the
 Internet, or trying to play a sound or to display a graphical interface on


### PR DESCRIPTION
Fixes #280

The section pointing that tests can be run from IDLE using the below construct is no longer relevant as suggested in this [message](https://bugs.python.org/issue31761#msg304273):
```>>> from test import autotest```

Hence, this section was removed from the `Running & Writing Tests` section of the devguide. 
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->