### PR TITLE
fixes #502: include infromation about auto-closure of bpo isssues

### DIFF
--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -286,6 +286,11 @@ to explain in proper depth what has happened (detail should be good enough
 that a core developer reading the commit message understands the
 justification for the change).
 
+Additionally, commit message when started with these words-
+**close**, **closes**, **closed**, **closing**, **fix**, **fixes** or **fixed**
+along with the issue number(bpo-NNN) like ``closes bpo-NNN: ....`` ensure
+auto-closure of the issue in bug tracker as the PR containing the commit is merged.
+
 Check :ref:`the git bootcamp <accepting-and-merging-a-pr>` for further
 instructions on how the commit message should look like when merging a pull
 request.


### PR DESCRIPTION
Fixes #502

Feature that was included in PEP-595 to automatically close issue
in the bug tracker when a PR with commit message including words like-
close, closes, closed, closing, fix, fixes or fixed being used with
issue number is merged is documented in the devguide.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->