### PR TITLE
fixes #613: remove redundant references to setup guide

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -14,8 +14,8 @@ community that maintains Python.  We welcome your contributions to Python!
 Quick Reference
 ---------------
 
-Here are the basic steps needed to get :ref:`set up <setup>` and contribute a
-patch. This is meant as a checklist, once you know the basics. For complete
+Here are the basic steps needed to get set up and contribute a patch.
+This is meant as a checklist, once you know the basics. For complete
 instructions please see the :ref:`setup guide <setup>`.
 
 1. Install and set up :ref:`Git <vcsetup>` and other dependencies


### PR DESCRIPTION
fixes #613

The first paragraph of the `Quick References` section of the `Devguide` referenced the setup guide linked here(https://devguide.python.org/setup/#setup). This redundant reference is removed in this PR.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->