### PR TITLE
Clarify how to pass the header and library path to configure command

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -380,9 +380,9 @@ and ``configure`` Python versions >= 3.7::
 
 or ``configure`` Python versions < 3.7::
 
-    $ CPPFLAGS="-I$(brew --prefix openssl)/include" \
-      LDFLAGS="-L$(brew --prefix openssl)/lib" \
-      ./configure --with-pydebug
+    $ export CPPFLAGS="-I$(brew --prefix openssl)/include"
+    $ export LDFLAGS="-L$(brew --prefix openssl)/lib"
+    $ ./configure --with-pydebug
 
 and ``make``::
 
@@ -394,9 +394,9 @@ or **MacPorts**::
 
 and ``configure``::
 
-    $ CPPFLAGS="-I/opt/local/include" \
-      LDFLAGS="-L/opt/local/lib" \
-      ./configure --with-pydebug
+    $ export CPPFLAGS="-I/opt/local/include"
+    $ export LDFLAGS="-L/opt/local/lib"
+    $ ./configure --with-pydebug
 
 and ``make``::
 


### PR DESCRIPTION
Using shell variable to pass header and library path to configure command does not works
so change to use environment variables