### PR TITLE
Fixes #717: Example for Running a single test case fails

### DIFF
--- a/runtests.rst
+++ b/runtests.rst
@@ -48,7 +48,7 @@ verbose mode (using ``-v``), so that individual failures are detailed::
 To run a single test case, use the ``unittest`` module, providing the import
 path to the test case::
 
-   ./python -m unittest -v test.test_abc.TestABC
+   ./python -m unittest -v test.test_abc.TestABC_Py
 
 If you have a multi-core or multi-CPU machine, you can enable parallel testing
 using several Python processes so as to speed up things::


### PR DESCRIPTION
Cause of the bug:
- The class seems to be reloaded using a different name at the bottom of `https://github.com/python/cpython/blob/main/Lib/test/test_abc.py`

Fix:
- Modify class name in guide.