### PR TITLE
fixed capitalization on PCbuild\build.bat

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -258,9 +258,9 @@ are downloaded:
 
 .. code-block:: dosbatch
 
-   PCBuild\build.bat
+   PCbuild\build.bat
 
-After this build succeeds, you can open the ``PCBuild\pcbuild.sln`` solution in
+After this build succeeds, you can open the ``PCbuild\pcbuild.sln`` solution in
 Visual Studio to continue development.
 
 See the `readme`_ for more details on what other software is necessary and how


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

On Windows, the build instructions prompt the user to run `PCBuild\build.bat`. The correct path is `PCbuild\build.bad` if a user copies the path from the copy block in the docs, it won't find the file correctly.