### PR TITLE
bpo-44727: Avoid `enum` in the stable ABI

### DIFF
--- a/c-api.rst
+++ b/c-api.rst
@@ -124,6 +124,13 @@ Guidelines for changing the Limited API
   - If possible, avoid macros. This makes the Limited API more usable in
     languages that don't use the C preprocessor.
 
+- Think twice when using ``enum``.
+
+  - If a new identifier is added to an ``enum`` in the future, passing it to
+    older extensions can lead to issues (unspecified/undefined behavior in
+    C++; possible size change in C).
+    It is safer to use ``int`` for types and ``#define`` for naming values.
+
 - Please start a public discussion before expanding the Limited API
 
 - The Limited API and must follow standard C, not just features of currently


### PR DESCRIPTION
Adding a new enumerator to a C enum can change the size of the type,
which would break the ABI.
This is not often a problem in practice, but the rules around when it
is a problem and when it isn't are complicated enough that I believe
enum should not be used in the stable ABI (possibly with well-reasoned
exceptions)

AFAICS, the rules are:
- In C++, an incompatible change to an enum is one that changes the
  size of the *smallest bit field large enough to hold all enumerators*.
  Values outside the range cause undefined/unspecified behavior.
- In C, it looks like enums that fit in `char` are safe.

Also, the compiler-defined size of enums will make it more cumbersome
to formally define an ABI for non-C languages.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->