### PR TITLE
Change the coordinator of the zh-tw translations

### DIFF
--- a/documenting.rst
+++ b/documenting.rst
@@ -1641,9 +1641,9 @@ in production, other are work in progress:
 +-----------------+-------------------------------+----------------------------+
 | Spanish (es)    | Raúl Cumplido                 | `GitHub <github_es_>`_     |
 +-----------------+-------------------------------+----------------------------+
-| Traditional     | 廖偉涵 Adrian Liaw            | `GitHub <github_zh_tw_>`_  |
-| Chinese         |                               | `Transifex <tx_zh_tw_>`_   |
-| (zh-tw)         |                               | `Doc <doc_zh_tw_>`_        |
+| Traditional     | `王威翔 Matt Wang             | `GitHub <github_zh_tw_>`_  |
+| Chinese         | <bpo_mattwang44_>`_,          | `Transifex <tx_zh_tw_>`_   |
+| (zh-tw)         | Josix Wang                    | `Doc <doc_zh_tw_>`_        |
 +-----------------+-------------------------------+----------------------------+
 | Turkish (tr)    |                               | `GitHub <github_tr_>`_     |
 +-----------------+-------------------------------+----------------------------+
@@ -1655,6 +1655,7 @@ in production, other are work in progress:
 .. _bpo_mdk: https://bugs.python.org/user23063
 .. _bpo_oonid: https://bugs.python.org/user32660
 .. _bpo_zhsj: https://bugs.python.org/user24811
+.. _bpo_mattwang44: https://bugs.python.org/user39654
 .. _chat_pt_br: https://t.me/pybr_i18n
 .. _doc_ja: https://docs.python.org/ja/
 .. _doc_ko: https://docs.python.org/ko/

--- a/experts.rst
+++ b/experts.rst
@@ -368,6 +368,6 @@ Korean         flowdas
 Bengali India  kushal.das
 Hungarian      gbtami
 Portuguese     rougeth
-Chinese (TW)   adrianliaw
+Chinese (TW)   mattwang44, josix
 Chinese (CN)   zhsj
 =============  ============


### PR DESCRIPTION
There will be two coordinators for the Traditional Chinese (zh-tw) translations, Matt Wang (@mattwang44) and Josix Wang (@josix).  Please wait until written confirmations from Matt and Josix here before merging.