### PR TITLE
Update Python GitHub Org owners

### DIFF
--- a/devcycle.rst
+++ b/devcycle.rst
@@ -260,7 +260,7 @@ This role is paramount to the security of the Python Language, Community, and
 Infrastructure.
 
 The Executive Director of the Python Software Foundation delegates authority on
-GitHub Organization Owner Status to Ee W. Durbin III - Python Software
+GitHub Organization Owner Status to Ee Durbin - Python Software
 Foundation Director of Infrastructure. Common reasons for this role are:
 Infrastructure Staff Membership, Python Software Foundation General Counsel,
 and Python Software Foundation Staff as fallback.
@@ -285,9 +285,13 @@ Current Owners
 +----------------------+--------------------------------+-----------------+
 | Ewa Jodlowska        | PSF Executive Director         | ejodlowska      |
 +----------------------+--------------------------------+-----------------+
-| Ee W. Durbin III     | PSF Director of Infrastructure | ewdurbin        |
+| Ee Durbin            | PSF Director of Infrastructure | ewdurbin        |
 +----------------------+--------------------------------+-----------------+
 | Van Lindberg         | PSF General Counsel            | VanL            |
++----------------------+--------------------------------+-----------------+
+| Ezio Melotti         | roundup -> github migration    | ezio-melotti    |
++----------------------+--------------------------------+-----------------+
+| Łukasz Langa         | CPython Developr in Residence  | ambv            |
 +----------------------+--------------------------------+-----------------+
 
 Repository Administrator Role Policy


### PR DESCRIPTION
@ezio-melotti was added to be able to develop and test tooling for bpo -> GitHub Issues migration.

Proposes adding @ambv as an org owner. As Developer in Residence this adds one other person with committed time who is closer to CPython day-to-day to help manage membership of the python org, since currently only Owners can perform those invites (for triage team additions, etc).