### PR TITLE
Replacing "each country" by " eachtranslation"

### DIFF
--- a/documenting.rst
+++ b/documenting.rst
@@ -1769,7 +1769,7 @@ Here's what's we're using:
 How a coordinator is elected?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-There is no election, each country have to sort this out.  Here are some suggestions.
+There is no election, each translation have to sort this out.  Here are some suggestions.
 
 -  Coordinator requests are to be public on doc-sig mailing list.
 -  If the given language have a native core dev, the core dev have its


### PR DESCRIPTION
# Replacing "each country" by " each translation"

While it is easy to understand what was meant by "country", this is inaccurate. While I believe most people know why, I'll still be explicit here. Some countries have multiple languages, each having their translation (e.g. Canada with English and French) and some languages are spoken in many countries, and the regional variation are small enough that there will probably never be multiple translation. (While Canadian French and France French are so different that it's sometime hard for French native to understand French Canadian speaking, I doubt anybody will want to create a ca-fr translation, given that the technical language will probably be almost the same)

While not a typo, I assume the issue is so small that it can be considered as a typo. But if required, I'll go open a bpo
