### PR TITLE
suggest edit of sources.list to enable deb-src's

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -318,6 +318,10 @@ Take Ubuntu Bionic for example::
 
    deb-src http://archive.ubuntu.com/ubuntu/ bionic main
 
+Alternatively, uncomment lines with deb-src using an editor, i.e.::
+
+   sudo nano /etc/apt/sources.list
+
 For other distributions, like Debian, change the URL and names to correspond
 with the specific distribution.
 

--- a/setup.rst
+++ b/setup.rst
@@ -318,7 +318,7 @@ Take Ubuntu Bionic for example::
 
    deb-src http://archive.ubuntu.com/ubuntu/ bionic main
 
-Alternatively, uncomment lines with deb-src using an editor, i.e.::
+Alternatively, uncomment lines with ``deb-src`` using an editor, e.g.::
 
    sudo nano /etc/apt/sources.list
 


### PR DESCRIPTION
When using WSL with Ubuntu, it was not obvious how to get the relevant deb-src to avoid error "E: You must put some 'deb-src' URIs in your sources.list".
The file already contained the urls which can be uncommented to continue the process of installing dependencies.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->