### PR TITLE
rename default branch to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   pull_request:
   push:
-    branches: master
+    branches: main
 
 jobs:
   test:

--- a/runtests.rst
+++ b/runtests.rst
@@ -132,4 +132,4 @@ Benchmarking is useful to test that a change does not degrade performance.
 `The Python Benchmark Suite <https://github.com/python/pyperformance>`_
 has a collection of benchmarks for all Python implementations. Documentation
 about running the benchmarks is in the `README.txt
-<https://github.com/python/pyperformance/blob/master/README.rst>`_ of the repo.
+<https://github.com/python/pyperformance/blob/main/README.rst>`_ of the repo.

--- a/setup.rst
+++ b/setup.rst
@@ -13,7 +13,7 @@ directory structure of the CPython source code.
 
 Alternatively, if you have `Docker <https://www.docker.com/>`_ installed you
 might want to use `our official images
-<https://gitlab.com/python-devs/ci-images/blob/master/README.md>`_.  These
+<https://gitlab.com/python-devs/ci-images/blob/main/README.md>`_.  These
 contain the latest releases of several Python versions, along with git head,
 and are provided for development and testing purposes only.
 

--- a/tools/templates/customsourcelink.html
+++ b/tools/templates/customsourcelink.html
@@ -3,7 +3,7 @@
     <h3>{{ _('This Page') }}</h3>
     <ul class="this-page-menu">
       <li>
-        <a href="https://github.com/python/devguide/blob/master/{{ sourcename|replace('.rst.txt', '.rst') }}"
+        <a href="https://github.com/python/devguide/blob/main/{{ sourcename|replace('.rst.txt', '.rst') }}"
             rel="nofollow">{{ _('Show Source') }}
         </a>
       </li>


### PR DESCRIPTION
also covers a handful of external references who have similarly made this change