### PR TITLE
Fix`actions/cache` in `ci.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
       - uses: actions/setup-python@v2


### PR DESCRIPTION
There were two problems:
1. `actions/cache` was outdated, currently the active version is `@2`: https://github.com/actions/cache/releases
2. For some reason it was using `pyproject.toml` as a caching key, but this file does not exist. I've changed it to be https://github.com/python/devguide/blob/main/requirements.txt

Question: other repos have `dependabot.yml` job to update GitHub Actions. Do you need one? I can send another PR if it is going to be useful.