### PR TITLE
Docs for Python 2.x are no longer built daily

### DIFF
--- a/docquality.rst
+++ b/docquality.rst
@@ -32,8 +32,8 @@ and validates that your new markup is correct.
 
 You can view the documentation built from :ref:`in-development <indevbranch>`
 and :ref:`maintenance <maintbranch>` branches at https://docs.python.org/dev/.
-The in-development and most recent 3.x (as well as 2.x) maintenance
-branches are rebuilt once per day.
+The in-development and most recent 3.x maintenance branches are rebuilt once per
+day.
 
 If you would like to be more involved with documentation, consider subscribing
 to the `docs@python.org <https://mail.python.org/mailman/listinfo/docs>`_

--- a/docquality.rst
+++ b/docquality.rst
@@ -32,8 +32,7 @@ and validates that your new markup is correct.
 
 You can view the documentation built from :ref:`in-development <indevbranch>`
 and :ref:`maintenance <maintbranch>` branches at https://docs.python.org/dev/.
-The in-development and most recent 3.x maintenance branches are rebuilt once per
-day.
+The in-development and recent maintenance branches are rebuilt once per day.
 
 If you would like to be more involved with documentation, consider subscribing
 to the `docs@python.org <https://mail.python.org/mailman/listinfo/docs>`_


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Delete "(as well as 2.x)" from:

> The in-development and most recent 3.x **(as well as 2.x)** maintenance
branches are rebuilt once per day.

The footer of https://docs.python.org/2/ and https://docs.python.org/2.7/ say "Last updated on Jun 19, 2020."
