### PR TITLE
Delete `.hgignore`

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -1,6 +1,0 @@
-syntax: glob
-
-*.swp
-*~
-_build
-venv


### PR DESCRIPTION
Docs: https://www.mercurial-scm.org/wiki/.hgignore

Since mercurial is no longer used, I don't see why we would need it.
It seems unused and a bit outdated (last update was 6 years ago).

Maybe I am missing something? 🙂 
