### PR TITLE
Triagers cannot rename PRs

### DIFF
--- a/triaging.rst
+++ b/triaging.rst
@@ -26,7 +26,6 @@ needed, to other repos such as devguide and core-workflow.
 Responsibilities include:
 
 * PR/issue management
-    - Renaming PRs
     - Reviewing PRs
     - Assisting contributors
     - Notifying appropriate core developers


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
Fixes https://github.com/python/core-workflow/issues/418.