### PR TITLE
Add padlock emoji to denote voters repo is private

### DIFF
--- a/coredev.rst
+++ b/coredev.rst
@@ -78,7 +78,7 @@ The steps to gaining commit privileges are:
    email you asking for:
 
    - Account details as required by
-     https://github.com/python/voters/
+     🔒 https://github.com/python/voters/
    - Your preferred email address to
      subscribe to python-committers with
    - A reminder about the `Code of Conduct`_ and to report issues to the PSF
@@ -86,12 +86,12 @@ The steps to gaining commit privileges are:
 
 6. Once you have provided the pertinent details, your various new privileges
    will be turned on
-7. Your details will be added to https://github.com/python/voters/
+7. Your details will be added to 🔒 https://github.com/python/voters/
 8. They will update the devguide to publicly list your team membership at
    :ref:`developers`
 9. An announcement email by the steering council member handling your new
    membership will be sent to python-committers
-   
+
 .. _Code of Conduct: https://www.python.org/psf/conduct/
 
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

GitHub uses a padlock to indicate private repos.

Add a padlock emoji 🔒 next to the private https://github.com/python/voters/ name.

If you don't have access, GitHub shows a 404 when clicking, making it appear like a broken link: https://github.com/python/devguide/issues/681#issuecomment-1016952381
