### PR TITLE
Remove outdated Mercurial sections

### DIFF
--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -318,6 +318,49 @@ When it happens, you need to resolve conflict.  See these articles about resolvi
 - `About merge conflicts <https://help.github.com/en/articles/about-merge-conflicts>`_
 - `Resolving a merge conflict using the command line <https://help.github.com/en/articles/resolving-a-merge-conflict-using-the-command-line>`_
 
+.. _git_from_patch:
+
+Applying a Patch to Git
+-----------------------
+
+Scenario:
+
+- A patch exists but there is no pull request for it.
+
+Solution:
+
+1. Download the patch locally.
+
+2. Apply the patch::
+
+       git apply /path/to/patch.diff
+
+   If there are errors, update to a revision from when the patch was
+   created and then try the ``git apply`` again:
+
+   .. code-block:: bash
+
+       git checkout $(git rev-list -n 1 --before="yyyy-mm-dd hh:mm:ss" main)
+       git apply /path/to/patch.diff
+
+   If the patch still won't apply, then a patch tool will not be able to
+   apply the patch and it will need to be re-implemented manually.
+
+3. If the apply was successful, create a new branch and switch to it.
+
+4. Stage and commit the changes.
+
+5. If the patch was applied to an old revision, it needs to be updated and
+   merge conflicts need to be resolved::
+
+       git rebase main
+       git mergetool
+
+   For very old changes, ``git merge --no-ff`` may be easier than a rebase,
+   with regards to resolving conflicts.
+
+6. Push the changes and open a pull request.
+
 .. _git_pr:
 
 Downloading Other's Patches

--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -318,46 +318,6 @@ When it happens, you need to resolve conflict.  See these articles about resolvi
 - `About merge conflicts <https://help.github.com/en/articles/about-merge-conflicts>`_
 - `Resolving a merge conflict using the command line <https://help.github.com/en/articles/resolving-a-merge-conflict-using-the-command-line>`_
 
-.. _git_from_mercurial:
-
-Applying a Patch from Mercurial to Git
---------------------------------------
-
-Scenario:
-
-- A Mercurial patch exists but there is no pull request for it.
-
-Solution:
-
-1. Download the patch locally.
-
-2. Apply the patch::
-
-       git apply /path/to/issueNNNN-git.patch
-
-   If there are errors, update to a revision from when the patch was
-   created and then try the ``git apply`` again:
-
-   .. code-block:: bash
-
-       git checkout $(git rev-list -n 1 --before="yyyy-mm-dd hh:mm:ss" main)
-       git apply /path/to/issueNNNN-git.patch
-
-   If the patch still won't apply, then a patch tool will not be able to
-   apply the patch and it will need to be re-implemented manually.
-
-3. If the apply was successful, create a new branch and switch to it.
-
-4. Stage and commit the changes.
-
-5. If the patch was applied to an old revision, it needs to be updated and
-   merge conflicts need to be resolved::
-
-       git rebase main
-       git mergetool
-
-6. Push the changes and open a pull request.
-
 .. _git_pr:
 
 Downloading Other's Patches

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -394,8 +394,6 @@ Author Name <email_address> ." to the pull request description and commit messag
 See `the GitHub article <https://help.github.com/articles/creating-a-commit-with-multiple-authors/>`_
 on how to properly add the co-author info.
 
-See also :ref:`Applying a Patch from Mercurial to Git <git_from_mercurial>`.
-
 Reviewing
 ---------
 

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -394,6 +394,8 @@ Author Name <email_address> ." to the pull request description and commit messag
 See `the GitHub article <https://help.github.com/articles/creating-a-commit-with-multiple-authors/>`_
 on how to properly add the co-author info.
 
+See also :ref:`Applying a Patch to Git <git_from_patch>`.
+
 Reviewing
 ---------
 

--- a/triaging.rst
+++ b/triaging.rst
@@ -505,7 +505,9 @@ with the "open" status.
 
 Mercurial Repository
 ''''''''''''''''''''
-This field is not used anymore.
+Deprecated: HTTP link to a Mercurial repository that contains a patch for the issue.
+
+New repository links should not be added to new or existing issues.
 
 Generating Special Links in a Comment
 -------------------------------------

--- a/triaging.rst
+++ b/triaging.rst
@@ -505,13 +505,7 @@ with the "open" status.
 
 Mercurial Repository
 ''''''''''''''''''''
-HTTP link to a Mercurial repository that contains a patch for the issue.
-A :guilabel:`Create Patch` button will appear that computes a diff for the
-head revision of the remote branch and attaches it to the issue.  The button
-supports only CPython_ patches.
-
-If you don't indicate a remote branch, ``default`` is used.  You can
-indicate a remote branch by adding ``#BRANCH`` to the end of the URL.
+This field is not used anymore.
 
 Generating Special Links in a Comment
 -------------------------------------


### PR DESCRIPTION
Keep _Mercurial Repository_ in _Triaging_, since BPO links to it.

Resolves #796 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->