### PR TITLE
Remove deceased expert and line linking to now-obsolete PEPs with special rules

### DIFF
--- a/experts.rst
+++ b/experts.rst
@@ -50,7 +50,7 @@ __future__
 __main__              gvanrossum, ncoghlan
 _dummy_thread         brett.cannon
 _thread
-_testbuffer           
+_testbuffer
 abc
 aifc                  r.david.murray
 argparse              rhettinger*
@@ -141,7 +141,7 @@ itertools             rhettinger*
 json                  bob.ippolito (inactive), ezio.melotti, rhettinger
 keyword
 lib2to3               benjamin.peterson
-libmpdec              
+libmpdec
 linecache
 locale                lemburg
 logging               vinay.sajip
@@ -187,7 +187,7 @@ pydoc
 queue                 rhettinger*
 quopri
 random                rhettinger, mark.dickinson
-re                    effbot (inactive), ezio.melotti, serhiy.storchaka
+re                    ezio.melotti, serhiy.storchaka
 readline              twouters
 reprlib
 resource              twouters
@@ -254,13 +254,13 @@ wave
 weakref               fdrake
 webbrowser
 winreg                stutzbach
-winsound              effbot (inactive)
+winsound
 wsgiref               pje
 xdrlib
 xml.dom
 xml.dom.minidom
 xml.dom.pulldom
-xml.etree             effbot (inactive), eli.bendersky*, scoder
+xml.etree             eli.bendersky*, scoder
 xml.parsers.expat
 xml.sax
 xml.sax.handler
@@ -335,7 +335,7 @@ io                  benjamin.peterson, stutzbach
 locale              lemburg
 mathematics         mark.dickinson, lemburg, stutzbach, rhettinger
 memory management   tim.peters, lemburg, twouters
-memoryview          
+memoryview
 networking          giampaolo.rodola,
 object model        benjamin.peterson, twouters
 packaging           tarek, lemburg, alexis, eric.araujo, dstufft, paul.moore

--- a/experts.rst
+++ b/experts.rst
@@ -37,9 +37,6 @@ The existence of this list is not meant to indicate that these people
 by non-committers to find responsible parties, and by committers who do
 not feel qualified to make a decision in a particular context.
 
-See also :PEP:`291` and :PEP:`360` for information about certain modules
-with special rules.
-
 
 Stdlib
 ------


### PR DESCRIPTION
As discussed on python/peps#2270 , looks like [Fredrik "effbot" Lundh](https://mail.python.org/archives/list/python-dev@python.org/thread/36Q5QBILL3QIFIA3KHNGFBNJQKXKN7SD/), who has passed away, is still listed here.

Also, the list still mentions and links to [PEP 291](https://www.python.org/dev/peps/pep-0291/) and [PEP 360](https://www.python.org/dev/peps/pep-0360/), stating they contain special rules for some modules. PEP 291 is thoroughly obsolete, being explicitly limited to Python 2, while PEP 360 has not been updated in many years and with any new additions being explicitly prohibited, it presumably never will be, and all the projects currently listed are maintained in the stdlib and no longer active upstream for at least the past decade or more. This was a source of confusion, so given this sentence no longer applies to any developed CPython version, it should presumably be removed.

@gvanrossum @brettcannon 