### PR TITLE
GitHub Actions updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: main
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Dependencies
         run: python3 -m pip install -U pip -r requirements.txt
       - name: Build Docs
-        run: sphinx-build -n -W -q -b html -d _build/doctrees . _build/html
+        run: sphinx-build --color -n -W -b html -d _build/doctrees . _build/html
       - name: Link Check
-        run: sphinx-build -b linkcheck -d _build/doctrees . _build/linkcheck
+        run: sphinx-build --color -b linkcheck -d _build/doctrees . _build/linkcheck
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
       - name: Install Dependencies
         run: python3 -m pip install -U pip -r requirements.txt
       - name: Build Docs


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

# Simplify caching

Follow on from https://github.com/python/devguide/pull/783#pullrequestreview-842402521.

https://github.com/actions/setup-python now has pip caching built in so let's remove the whole `actions/cache` step here. It uses `requirements.txt` as the key by default.

Docs: https://github.com/actions/setup-python#caching-packages-dependencies

# Enable build button

Also, add `workflow_dispatch`, which adds a button to the GitHub Actions UI to let you trigger builds. This is something Travis CI has built in, and is fairly new to GHA and needs enabling.

Docs: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

# Add colour

Finally, GitHub Actions isn't a tty so tools such as sphinx-build that autodetect don't show the output in colour. So let's add `--color` to turn it on, especially useful for the link check. And let's show the docs build output too, useful for debugging failures (and now in colour!).

![image](https://user-images.githubusercontent.com/1324225/151550825-8001f260-0e3f-4bf7-81a5-beda95fffc1d.png)

