### PR TITLE
Update documenting.rst

### DIFF
--- a/documenting.rst
+++ b/documenting.rst
@@ -1647,7 +1647,8 @@ in production, other are work in progress:
 | Chinese         | <bpo_mattwang44_>`_,          | `Transifex <tx_zh_tw_>`_   |
 | (zh-tw)         | Josix Wang                    | `Doc <doc_zh_tw_>`_        |
 +-----------------+-------------------------------+----------------------------+
-| Turkish (tr)    |                               | `GitHub <github_tr_>`_     |
+| Turkish (tr)    | `Ege Akman (egeakman)         | `GitHub <github_tr_>`_     |
+|                 | <email_egeakman_>`_           |                            |
 +-----------------+-------------------------------+----------------------------+
 
 .. _article_pt_br: http://rgth.co/blog/python-ptbr-cenario-atual
@@ -1659,6 +1660,7 @@ in production, other are work in progress:
 .. _bpo_osdotsystem: https://bugs.python.org/user28057
 .. _bpo_zhsj: https://bugs.python.org/user24811
 .. _bpo_mattwang44: https://bugs.python.org/user39654
+.. _email_egeakman: mailto:egeakmanegeakman@hotmail.com
 .. _chat_pt_br: https://t.me/pybr_i18n
 .. _doc_ja: https://docs.python.org/ja/
 .. _doc_ko: https://docs.python.org/ko/
@@ -1676,7 +1678,7 @@ in production, other are work in progress:
 .. _github_ko: https://github.com/python/python-docs-ko
 .. _github_pl: https://github.com/python/python-docs-pl
 .. _github_pt_br: https://github.com/python/python-docs-pt-br
-.. _github_tr: https://github.com/alaeddingurel/python-docs-tr
+.. _github_tr: https://github.com/python-docs-tr/python-docs-tr
 .. _github_zh_cn: https://github.com/python/python-docs-zh-cn
 .. _github_zh_tw: https://github.com/python/python-docs-zh-tw
 .. _list_hu: https://mail.python.org/pipermail/python-hu


### PR DESCRIPTION
Looks like https://github.com/alaeddingurel/python-docs-tr is not maintained anymore. So replaced with the [active translation](https://github.com/python-docs-tr/python-docs-tr).