### PR TITLE
Update to canonical PEP URLs

### DIFF
--- a/c-api.rst
+++ b/c-api.rst
@@ -58,9 +58,7 @@ definition in ``Include/internal/`` (or directly in a ``.c`` file):
 * “Provisional” API, included in a Python release to test real-world usage
   of new API. Such names should be renamed when stabilized; preferably with
   a macro aliasing the old name to the new one.
-  See `"Finalizing the API" in PEP 590`_ for an example.
-
-.. _"Finalizing the API" in PEP 590: https://www.python.org/dev/peps/pep-0590/#finalizing-the-api
+  See :pep:`"Finalizing the API" in PEP 590 <590#finalizing-the-api>` for an example.
 
 
 .. _public-capi:

--- a/extensions.rst
+++ b/extensions.rst
@@ -11,5 +11,5 @@ Read the following references:
 
 * https://docs.python.org/dev/c-api/
 * https://docs.python.org/dev/extending/
-* https://www.python.org/dev/peps/pep-0399/
+* :pep:`399`
 * https://pythonextensionpatterns.readthedocs.io/en/latest/

--- a/index.rst
+++ b/index.rst
@@ -333,7 +333,7 @@ Full Table of Contents
 
 .. _Buildbot status: https://www.python.org/dev/buildbot/
 .. _Misc directory: https://github.com/python/cpython/tree/main/Misc
-.. _PEPs: https://www.python.org/dev/peps/
+.. _PEPs: https://peps.python.org/
 .. _python.org maintenance: https://pythondotorg.readthedocs.io/
 .. _Python: https://www.python.org/
 .. _Core Python Mentorship: https://www.python.org/dev/core-mentorship/

--- a/langchanges.rst
+++ b/langchanges.rst
@@ -28,10 +28,8 @@ your proposed change (which helps communicate the usefulness of your change to
 others). For further guidance, see :ref:`suggesting-changes`.
 
 Your proposed change also needs to be *Pythonic*. While only the Steering
-Council can truly classify something as Pythonic, you can read the `Zen of
-Python`_ for guidance.
-
-.. _Zen of Python: https://www.python.org/dev/peps/pep-0020/
+Council can truly classify something as Pythonic, you can read the
+:pep:`Zen of Python <20>` for guidance.
 
 
 .. index:: PEP process
@@ -79,7 +77,7 @@ task.
 
 If the idea is reasonable, someone will suggest posting it as a feature
 request on the `issue tracker`_, or, for larger changes, writing it up as
-a `draft PEP`_.
+a :pep:`draft PEP <1>`.
 
 Sometimes core developers will differ in opinion, or merely be collectively
 unconvinced. When there isn't an obvious victor then the
@@ -90,7 +88,6 @@ For some examples on language changes that were accepted please read
 
 .. _python-ideas: https://mail.python.org/mailman3/lists/python-ideas.python.org/
 .. _issue tracker: https://bugs.python.org
-.. _PEP Index: https://www.python.org/dev/peps/
-.. _draft PEP: https://www.python.org/dev/peps/pep-0001/
+.. _PEP Index: https://peps.python.org/
 .. _Status Quo Wins a Stalemate: https://www.curiousefficiency.org/posts/2011/02/status-quo-wins-stalemate.html
 .. _Justifying Python Language Changes: https://www.curiousefficiency.org/posts/2011/02/justifying-python-language-changes.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Sphinx==4.4.0
+Sphinx==4.5.0
 furo<2022.3.5
 sphinx_copybutton>=0.3.3

--- a/stdlibchanges.rst
+++ b/stdlibchanges.rst
@@ -147,4 +147,4 @@ means that the core developers end up agreeing in general to accepting
 your PEP) then the module will be added to the stdlib once the creators of the
 module sign :ref:`contributor agreements <contributor_agreement>`.
 
-.. _PEP index: https://www.python.org/dev/peps/
+.. _PEP index: https://peps.python.org/

--- a/triaging.rst
+++ b/triaging.rst
@@ -387,7 +387,7 @@ Various informational flags about the issue. Multiple values are possible.
 |               | difference from the "security" issue type is that this is  |
 |               | a definite security problem that has to be dealt with.     |
 +---------------+------------------------------------------------------------+
-| PEP 3121      | The issue is related to PEP `PEP 3121`_.                   |
+| PEP 3121      | The issue is related to :pep:`3121`.                       |
 |               | Extension Module Initialization and Finalization.          |
 +---------------+------------------------------------------------------------+
 | newcomer      | Issue suitable for newcomer/first time contributors.       |
@@ -630,4 +630,3 @@ Checklist for Triaging
 .. _python-ideas: https://mail.python.org/mailman3/lists/python-ideas.python.org
 .. _release schedule: https://devguide.python.org/#status-of-python-branches
 .. _PSF Code of Conduct: https://www.python.org/psf/conduct/
-.. _PEP 3121: https://www.python.org/dev/peps/pep-3121/


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

With the recent implementation of [PEP 676](https://peps.python.org/pep-0676/) the canonical URL for PEPs has changed from, for example:

https://www.python.org/dev/peps/pep-0008/

to:

https://peps.python.org/pep-0008/

Redirects are in place so the old links still work, but let's update to use the new canonical form.

See also:

* [bpo-47126](https://bugs.python.org/issue47126) / https://github.com/python/cpython/pull/32124
* https://github.com/sphinx-doc/sphinx/pull/10267