### PR TITLE
Use double backticks for code in RST

### DIFF
--- a/gh-faq.rst
+++ b/gh-faq.rst
@@ -2,7 +2,7 @@ GitHub issues for BPO users
 ===========================
 
 Here are some frequently asked quesions about how to do things in
-Github issues that you used to be able to do on `bpo`_.
+GitHub issues that you used to be able to do on `bpo`_.
 
 Before you ask your own question, make sure you read :doc:`tracker`
 and :doc:`triaging` (specifically including :doc:`gh-labels`) as those
@@ -11,7 +11,7 @@ pages include a lot of introductory material.
 How to format my comments nicely?
 ---------------------------------
 
-There is a wonderful `beginner guide to writing and formatting on Github
+There is a wonderful `beginner guide to writing and formatting on GitHub
 <https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github>`_.
 Highly recommended.
 
@@ -29,13 +29,13 @@ If you still insist on pasting it in your comment, do it like this::
 How to attach files to an issue?
 --------------------------------
 
-Drag them into the comment field, wait until the file uploads, and Github
+Drag them into the comment field, wait until the file uploads, and GitHub
 will automatically put a link to your file in your comment text.
 
 How to link to file paths in the repository when writing comments?
 ------------------------------------------------------------------
 
-Use Markdown links. If you link to the default Github path, the file
+Use Markdown links. If you link to the default GitHub path, the file
 will link to the latest current version on the given branch.
 
 You can get a permanent link to a given revision of a given file by
@@ -44,7 +44,7 @@ You can get a permanent link to a given revision of a given file by
 How to do advanced searches?
 ----------------------------
 
-Use the `Github search syntax`_ or the interactive `advanced search`_ form
+Use the `GitHub search syntax`_ or the interactive `advanced search`_ form
 that generates search queries for you.
 
 Where is the "nosy list"?
@@ -73,23 +73,23 @@ Add a checkbox list like this in the issue description::
     - [ ] https://github.com/octo-org/octo-repo/issues/740
     - [ ] Add delight to the experience when all tasks are complete :tada:
 
-then those will become sub-tasks on the given issue. Moreover, Github will
+then those will become sub-tasks on the given issue. Moreover, GitHub will
 automatically mark a task as complete if the other referenced issue is
-closed. More details in the `official Github documentation
+closed. More details in the `official GitHub documentation
 <https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists>`_.
 
 What on Earth is a "mannequin"?
 -------------------------------
 
-For issues migrated to Github from `bpo`_ where the authors or commenters
-are not core developers, we opted not to link to their Github accounts
-directly. Users not in the `python organization on Github
+For issues migrated to GitHub from `bpo`_ where the authors or commenters
+are not core developers, we opted not to link to their GitHub accounts
+directly. Users not in the `python organization on GitHub
 <https://github.com/orgs/python/people>`_ might not like comments to
-appear under their name from an automated import.  Others never linked Github on
+appear under their name from an automated import.  Others never linked GitHub on
 `bpo`_ in the first place so linking their account, if any, would be impossible.
 
 In those cases a "mannequin" account is present to help follow the conversation
-that happened in the issue. In case the user did share their Github account
+that happened in the issue. In case the user did share their GitHub account
 name in their `bpo`_ profile, we use that. Otherwise, their classic `bpo`_
 username is used instead.
 
@@ -106,7 +106,7 @@ Based on historical data we found those not being used very often.
 How to find a random issue?
 ---------------------------
 
-This is not supported by Github.
+This is not supported by GitHub.
 
 Where are regression labels?
 ----------------------------
@@ -116,5 +116,5 @@ particularly useful outside of the change log.
 
 
 .. _bpo: https://bugs.python.org/
-.. _Github search syntax: https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax
+.. _GitHub search syntax: https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax
 .. _advanced search: https://github.com/search/advanced

--- a/gh-labels.rst
+++ b/gh-labels.rst
@@ -1,9 +1,9 @@
 .. _github-labels:
 
-Github Labels
+GitHub Labels
 =============
 
-We're using labels on Github to categorize issues and pull requests.
+We're using labels on GitHub to categorize issues and pull requests.
 Many labels are shared for both use cases, while some are dedicated
 only to one. Below is a possibly inexhaustive list, but it should get
 you going. For a full list, see `here <https://github.com/python/cpython/issues/labels>`_.

--- a/gh-labels.rst
+++ b/gh-labels.rst
@@ -18,7 +18,7 @@ type-behavior
 
 type-documentation
     Used for issues/PRs that exclusively involve changes to
-    the documentation. Documentation includes `*.rst` files, docstrings,
+    the documentation. Documentation includes ``*.rst`` files, docstrings,
     and code comments.
 
 type-enhancement

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -314,7 +314,7 @@ Here are the steps needed in order to sign the CLA:
 2. When ``cpython-cla-bot`` comments on your pull request that commit
    authors are required to sign a Contributor License Agreement, click
    on the button in the comment to sign it. It's enough to log in through
-   Github. The process is automatic.
+   GitHub. The process is automatic.
 
 3. After signing, the comment by ``cpython-cla-bot`` will update to
    indicate that "all commit authors signed the Contributor License

--- a/triaging.rst
+++ b/triaging.rst
@@ -73,7 +73,7 @@ Python triage team. Triagers will be responsible to handle not just issues, but
 also pull requests, and even managing backports. A Python triager has access to
 more repositories than just CPython.
 
-Any existing active contributor to the Python repository on Github can
+Any existing active contributor to the Python repository on GitHub can
 transition into becoming a Python triager. They can request this to any core
 developer, and the core developer can pass the request to the `Python
 organization admin
@@ -151,7 +151,7 @@ specific type, please do not set a type.
 
 Stage
 '''''
-A needed next action to advance the issue.  The *stage* on Github issues is
+A needed next action to advance the issue.  The *stage* on GitHub issues is
 determined by presence of a linked PR and whether the issue is still open
 or closed. It is the PR that holds code review-related labels.
 
@@ -230,7 +230,7 @@ Nosy List
 '''''''''
 A list of people who may be interested in an issue.
 
-This used to be a feature of the old issue tracker. On Github issues the
+This used to be a feature of the old issue tracker. On GitHub issues the
 same effect is achieved by tagging people in a comment using ``@username``.
 
 It is acceptable to tag someone to if you think the issue should be brought to
@@ -264,16 +264,16 @@ comment. Long story short, if you add this::
     - [ ] https://github.com/octo-org/octo-repo/issues/740
     - [ ] Add delight to the experience when all tasks are complete :tada:
 
-then those will become sub-tasks on the given issue. Moreover, Github will
+then those will become sub-tasks on the given issue. Moreover, GitHub will
 automatically mark a task as complete if the other referenced issue is
 closed.
 
-More details in the `official Github documentation
+More details in the `official GitHub documentation
 <https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists>`_.
 
 Superseder
 ''''''''''
-The issue is a duplicate of the listed issue(s). To make Github mark
+The issue is a duplicate of the listed issue(s). To make GitHub mark
 an issue as duplicate, write "Duplicate of #xxxx" in a comment.
 
 Status
@@ -302,7 +302,7 @@ a link to relevant web pages.
 | Comment abbreviation                                        | Description                                           |
 +=============================================================+=======================================================+
 | ``#<number>``,                                              | Links to the tracker issue or PR ``<number>`` (they   |
-| ``GH-<number>``                                             | share the same sequence of integers on Github).       |
+| ``GH-<number>``                                             | share the same sequence of integers on GitHub).       |
 +-------------------------------------------------------------+-------------------------------------------------------+
 | ``BPO-<number>``                                            | Links to the old bug tracker at bugs.python.org.      |
 +-------------------------------------------------------------+-------------------------------------------------------+


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Single backticks are for Markdown.

And Github -> GitHub.