### PR TITLE
Do not recommend to gh- prefix in commit message

### DIFF
--- a/gitbootcamp.rst
+++ b/gitbootcamp.rst
@@ -200,7 +200,7 @@ Staging and Committing Files
 
    .. code-block:: bash
 
-      git commit -m "gh-XXXX: This is the commit message."
+      git commit -m "This is the commit message."
 
 Reverting Changes
 -----------------

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -268,7 +268,7 @@ and for each pull request there may be several commits.  In particular:
 
 Commit messages should follow the following structure::
 
-   gh-42: Make the spam module more spammy (GH-NNNN)
+   Make the spam module more spammy
 
    The spam module sporadically came up short on spam. This change
    raises the amount of spam in the module by making it more spammy.
@@ -346,7 +346,7 @@ Now you want to
 <https://help.github.com/articles/creating-a-pull-request-from-a-fork/>`_.
 If this is a pull request in response to a pre-existing issue on the
 `issue tracker`_, please make sure to reference the issue number using
-``gh-NNNN`` in the pull request title or message.
+``gh-NNNNN: `` in the pull request title.
 
 If this is a pull request for an unreported issue (assuming you already
 performed a search on the issue tracker for a pre-existing issue), create a

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -346,7 +346,7 @@ Now you want to
 <https://help.github.com/articles/creating-a-pull-request-from-a-fork/>`_.
 If this is a pull request in response to a pre-existing issue on the
 `issue tracker`_, please make sure to reference the issue number using
-``gh-NNNNN: `` in the pull request title.
+``gh-NNNNN: `` in the pull request title and ``#NNNNN`` in the description.
 
 If this is a pull request for an unreported issue (assuming you already
 performed a search on the issue tracker for a pre-existing issue), create a


### PR DESCRIPTION
If we add `gh-` prefix to each commits, many spammy notification send to the issue.
See this ecample:

![image](https://user-images.githubusercontent.com/199592/163696859-e88025f8-64d6-41a5-8c23-552e455b1955.png)

We should recommend `gh-` prefix only in pull request title (and merge commit title).