### PR TITLE
Change label to shortened form

### DIFF
--- a/gh-labels.rst
+++ b/gh-labels.rst
@@ -64,7 +64,7 @@ Component
 library
     Used for issues involving Python modules in the ``Lib/`` dir.
 
-documentation
+docs
     Used for issues involving documentation in the ``Doc/`` dir.
 
 interpreter-core


### PR DESCRIPTION
[devguide page](https://devguide.python.org/gh-labels/#component) has it as 'documentation', while [cpython repo labels](https://github.com/python/cpython/labels/) have it as 'docs'