### PR TITLE
Update links for new issue tracker

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,7 +22,7 @@ comments they leave and their "Details" links, respectively. The key points of
 our workflow that are not covered by a bot or status check are:
 
 - All discussions that are not directly related to the code in the pull request
-  should happen on [bugs.python.org](https://bugs.python.org/)
+  should happen on the [issue tracker](https://devguide.python.org/tracker/)
 - Upon your first non-trivial pull request (which includes documentation changes),
   feel free to add yourself to [`Misc/ACKS`](https://github.com/python/cpython/blob/main/Misc/ACKS)
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 > Note: This repo is for the Python devguide. If you are requesting an
 enhancementfor the Python language or CPython interpreter,
 then the CPython issue tracker is better
-suited for this report: https://devguide.python.org/tracker/
+suited for this report: https://github.com/python/cpython/issues
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 > Note: This repo is for the Python devguide. If you are requesting an
 enhancementfor the Python language or CPython interpreter,
 then the CPython issue tracker is better
-suited for this report: https://bugs.python.org
+suited for this report: https://devguide.python.org/tracker/
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,7 +10,7 @@ assignees: ''
 > Note: This repo is for the Python devguide. If you are requesting an
 enhancement for the Python language or CPython interpreter,
 then the CPython issue tracker is better
-suited for this report: https://bugs.python.org
+suited for this report: https://devguide.python.org/tracker/
 
 **Describe the enhancement or feature you'd like**
 A clear and concise description of what you want to happen.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,7 +10,7 @@ assignees: ''
 > Note: This repo is for the Python devguide. If you are requesting an
 enhancement for the Python language or CPython interpreter,
 then the CPython issue tracker is better
-suited for this report: https://devguide.python.org/tracker/
+suited for this report: https://github.com/python/cpython/issues
 
 **Describe the enhancement or feature you'd like**
 A clear and concise description of what you want to happen.

--- a/committing.rst
+++ b/committing.rst
@@ -14,8 +14,8 @@ Assessing a pull request
 Before you can accept a pull request, you need to make sure that it is ready
 to enter the public source tree. Ask yourself the following questions:
 
-* **Are there ongoing discussions at** ``bugs.python.org`` **(b.p.o.)?**
-   Read the linked b.p.o. issue. If there are ongoing discussions, then
+* **Are there ongoing discussions at the issue tracker?**
+   Read the linked issue. If there are ongoing discussions, then
    we need to have a resolution there before we can merge the pull request.
 
 * **Was the pull request first made against the appropriate branch?**

--- a/gh-faq.rst
+++ b/gh-faq.rst
@@ -1,7 +1,7 @@
 GitHub issues for BPO users
 ===========================
 
-Here are some frequently asked quesions about how to do things in
+Here are some frequently asked questions about how to do things in
 GitHub issues that you used to be able to do on `bpo`_.
 
 Before you ask your own question, make sure you read :doc:`tracker`

--- a/index.rst
+++ b/index.rst
@@ -54,8 +54,8 @@ instructions please see the :ref:`setup guide <setup>`.
       git checkout -b fix-issue-12345 main
 
    If an issue does not already exist, please `create it
-   <https://devguide.python.org/tracker/>`_.  Trivial issues (e.g. typo fixes) do not
-   require any issue to be created.
+   <https://github.com/python/cpython/issues>`_.  Trivial issues (e.g. typo fixes) do
+   not require any issue to be created.
 
 6. Once you fixed the issue, run the tests, run ``make patchcheck``, and if
    everything is ok, commit.

--- a/index.rst
+++ b/index.rst
@@ -54,7 +54,7 @@ instructions please see the :ref:`setup guide <setup>`.
       git checkout -b fix-issue-12345 main
 
    If an issue does not already exist, please `create it
-   <https://bugs.python.org/>`_.  Trivial issues (e.g. typo fixes) do not
+   <https://devguide.python.org/tracker/>`_.  Trivial issues (e.g. typo fixes) do not
    require any issue to be created.
 
 6. Once you fixed the issue, run the tests, run ``make patchcheck``, and if

--- a/triaging.rst
+++ b/triaging.rst
@@ -362,7 +362,7 @@ Checklist for Triaging
 .. _Tools/demo: https://github.com/python/cpython/tree/main/Tools/demo/
 .. _Developer's guide: https://github.com/python/devguide/
 .. _GSoC: https://summerofcode.withgoogle.com/
-.. _issue tracker: https://bugs.python.org
+.. _issue tracker: https://devguide.python.org/tracker/
 .. _GitHub pull requests: https://github.com/python/cpython/pulls
 .. _Python source code repositories: https://github.com/python/cpython/
 .. _Reporting security issues in Python: https://www.python.org/dev/security/


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Update old references to bugs.python.org to the new GitHub issue tracker.

Rather than linking directly to https://github.com/python/cpython/issues, I used https://devguide.python.org/tracker/ which has important info like to search for duplicates first.