### PR TITLE
Update `venv` and `clean` make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,23 @@
 
 # You can set these variables from the command line.
 PYTHON        = python3
-SPHINXOPTS    =
-SPHINXBUILD   = ./venv/bin/sphinx-build
-PAPER         =
+VENVDIR       = ./venv
 BUILDDIR      = _build
+SPHINXOPTS    =
+SPHINXBUILD   = $(VENVDIR)/bin/sphinx-build
+PAPER         =
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp \
+.PHONY: help venv clean html dirhtml singlehtml pickle json htmlhelp qthelp \
         devhelp epub latex latexpdf text man changes linkcheck doctest htmlview check
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  venv       to create a venv with necessary tools"
 	@echo "  html       to make standalone HTML files"
 	@echo "  htmlview   to open the index page built by the html target in your browser"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
@@ -41,9 +43,15 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 venv:
-	$(PYTHON) -m venv venv
-	./venv/bin/python3 -m pip install --upgrade pip
-	./venv/bin/python3 -m pip install -r requirements.txt
+	@if [ -d $(VENVDIR) ] ; then \
+		echo "venv already exists."; \
+		echo "To recreate it, remove it first with \`make clean-venv'."; \
+	else \
+		$(PYTHON) -m venv $(VENVDIR); \
+		$(VENVDIR)/bin/python3 -m pip install --upgrade pip; \
+		$(VENVDIR)/bin/python3 -m pip install -r requirements.txt; \
+		echo "The venv has been created in the $(VENVDIR) directory"; \
+	fi
 
 html: venv
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ help:
 	@echo "  venv       to create a venv with necessary tools"
 	@echo "  html       to make standalone HTML files"
 	@echo "  htmlview   to open the index page built by the html target in your browser"
+	@echo "  clean      to remove the venv and build files"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
 	@echo "  pickle     to make pickle files"
@@ -39,8 +40,11 @@ help:
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 	@echo "  check      to run a check for frequent markup errors"
 
-clean:
+clean: clean-venv
 	-rm -rf $(BUILDDIR)/*
+
+clean-venv:
+	rm -rf $(VENVDIR)
 
 venv:
 	@if [ -d $(VENVDIR) ] ; then \


### PR DESCRIPTION
This PR:
* Updates the `venv` target
* Adds a `clean-venv` target
* Updates the `clean` target to call `clean-venv` too

These are copied from [`cpython/Doc/Makefile`](https://github.com/hugovk/cpython/blob/1ed8d035f1edfaec34016b9f8d615df9e9fe9414/Doc/Makefile#L150-L159) with minor changes.

See #854.