### PR TITLE
Fix typo (`python.bat`->`build.bat`)

### DIFF
--- a/parser.rst
+++ b/parser.rst
@@ -873,7 +873,7 @@ Verbose mode
 ~~~~~~~~~~~~
 
 When Python is compiled in debug mode (by adding ``--with-pydebug`` when running the configure step in Linux or by
-adding ``-d`` when calling the :file:`PCbuild/python.bat` script in Windows), it is possible to activate a **very** verbose
+adding ``-d`` when calling the :file:`PCbuild/build.bat` script in Windows), it is possible to activate a **very** verbose
 mode in the generated parser. This is very useful to debug the generated parser and to understand how it works, but it
 can be a bit hard to understand at first.
 


### PR DESCRIPTION
The script it should be referencing is https://github.com/python/cpython/blob/main/PCbuild/build.bat, as https://github.com/python/cpython/blob/main/PCbuild/python.bat doesn't exist.