### PR TITLE
gh-872: fix a typo and reword a sentence in the translating docs.

### DIFF
--- a/documenting.rst
+++ b/documenting.rst
@@ -1717,9 +1717,9 @@ The important steps look like this:
   way if you like; it's up to you.
 - Ensure we update this page to reflect your work and progress, either via a
   PR or by asking on the `translation mailing list <translation_ml_>`_.
-- When ``tutorial/``, ``bugs.py`` and ``library/functions``
-  are complete, ask on the `translation mailing list <translation_ml_>`_ for your language to be added in the
-  language picker on docs.python.org.
+- When ``bugs.html``, ``tutorial``, and ``library/functions`` are 100%
+  completed, ask on the `translation mailing list <translation_ml_>`_ for
+  your language to be added in the language picker on docs.python.org.
 
 
 PEP 545 summary:


### PR DESCRIPTION
This fixes a typo reported in GH-872 by rewording a sentence according to [PEP 545](https://peps.python.org/pep-0545/#add-translation-to-the-language-switcher).