### PR TITLE
gh-853: Update Document Discourse.

### DIFF
--- a/communication.rst
+++ b/communication.rst
@@ -100,61 +100,61 @@ We have our own `Discourse`_ forum for both developers and users. This forum
 complements the `python-dev`_, `python-ideas`_, `python-help`_, and
 `python-list`_ mailing lists.
 
-This forum has many different categories and most core development discussions 
-take place in the open forum categories for `PEPs`_ and `Core Development`_. 
+This forum has many different categories and most core development discussions
+take place in the open forum categories for `PEPs`_ and `Core Development`_.
 (These are the Discourse equivalents to the python-dev mailing list)
-Most categories are open for all users to read and post with the exception of 
+Most categories are open for all users to read and post with the exception of
 Committers and Core Development categories.
 
 
 **Committers category**
 
-The `Committers`_ category is an "argument clinic" for Python committers with 
-the commit bit on `CPython <https://github.com/python/cpython>`_ and related 
-projects. 
-It is open for all users to read but posting is restricted to core developers. 
-It is often used for announcements and notifications. It is also a common venue 
-for the core developer promotion votes (This category is equivalent to the 
+The `Committers`_ category is an "argument clinic" for Python committers with
+the commit bit on `CPython <https://github.com/python/cpython>`_ and related
+projects.
+It is open for all users to read but posting is restricted to core developers.
+It is often used for announcements and notifications. It is also a common venue
+for the core developer promotion votes (This category is equivalent to the
 python-committers mailing list).
 
 **Core Development category**
 
-The `Core Development`_ category on Discourse is a private category visible to 
-core developers only. This category is used to share administrative information, 
-as well as individual information inputs among all core developers in an 
-enclosed environment where information will not be permanently archived on the 
+The `Core Development`_ category on Discourse is a private category visible to
+core developers only. This category is used to share administrative information,
+as well as individual information inputs among all core developers in an
+enclosed environment where information will not be permanently archived on the
 internet (e.g. logistics for in-person core development sprints).
 
 Getting Started
 ''''''''''''''''
-To start a topic or participate in any discussions in the forum, sign up and 
-create an account using an email address or Github account. You can do so by 
+To start a topic or participate in any discussions in the forum, sign up and
+create an account using an email address or Github account. You can do so by
 clicking the "Sign Up" button on the top right hand corner of the `Discourse`_
 main page.
 
 
 Quick Start
 ''''''''''''
-The Python Discourse `Quick Start <https://discuss.python.org/t/python-discourse-quick-start/116>`_ 
-compiled by `Carol Willing <https://discuss.python.org/u/willingc/>`_ gives you 
+The Python Discourse `Quick Start <https://discuss.python.org/t/python-discourse-quick-start/116>`_
+compiled by `Carol Willing <https://discuss.python.org/u/willingc/>`_ gives you
 a quick overview on how to kick off Python Discourse.
 
 Tutorials for New Users
 ''''''''''''''''''''''''
-New users can get familiarise with the forum by going through Discobot tutorials. 
-These tutorials can be activated by replying to a welcome message from "discourse 
-Greetings!" received under Notifications and Messages in your user account. 
+New users can get familiarise with the forum by going through Discobot tutorials.
+These tutorials can be activated by replying to a welcome message from "discourse
+Greetings!" received under Notifications and Messages in your user account.
 
 * Click on your personal account found on the top right hand corner of the page.
-* The dropdown menu will show 4 different glyphs namely Notifications 🔔, Bookmark, 
+* The dropdown menu will show 4 different glyphs namely Notifications 🔔, Bookmark,
   Messages ✉️ and Preferences.
 * Select either Notifications or Messages.
-* Open the "Greetings!" message sent by discobot. 
-* Ensure that you read through the `Python Code of Conduct <https://discuss.python.org/faq>`_. 
-  We are to be open, considerate and respectful to all users in the community.  
-* Click on the bookmark glyph found on the bottom right corner of the message beside 
+* Open the "Greetings!" message sent by discobot.
+* Ensure that you read through the `Python Code of Conduct <https://discuss.python.org/faq>`_.
+  We are to be open, considerate and respectful to all users in the community.
+* Click on the bookmark glyph found on the bottom right corner of the message beside
   the reply button.
-* Discobot will then reply and guide you through a simple tutorial on how to use 
+* Discobot will then reply and guide you through a simple tutorial on how to use
   Discourse.
 
 .. note:: You will receive a certified badge if you follow through the entire new user tutorial.
@@ -163,55 +163,55 @@ Greetings!" received under Notifications and Messages in your user account.
 Reading topics
 '''''''''''''''
 Click a topic title and read down the list of replies in chronological order,
-following links or previewing replies and quotes as you go. Use your mouse to 
-scroll the screen, or use the timeline scroll bar on the right which also shows 
-you how far through the conversation you’ve read. On smaller screens, select the 
+following links or previewing replies and quotes as you go. Use your mouse to
+scroll the screen, or use the timeline scroll bar on the right which also shows
+you how far through the conversation you’ve read. On smaller screens, select the
 bottom progress bar to expand it.
 
 Related topics
 '''''''''''''''
-Sometimes conversations are clearer if topics are split, where posts are moved 
-to a more appropriate topic, or two related topics are merged. If a post is 
+Sometimes conversations are clearer if topics are split, where posts are moved
+to a more appropriate topic, or two related topics are merged. If a post is
 it has been moved to, and the person who posted it will also be notified.
 
 Following categories (Category notifications)
 ''''''''''''''''''''''''''''''''''''''''''''''
-Notification level can also be set per category. To change any of these 
-defaults, you can either go to your user preferences, or visit the category 
+Notification level can also be set per category. To change any of these
+defaults, you can either go to your user preferences, or visit the category
 page, and use the notification button 🔔 above the topic list,
 on the top right hand corner of the category page beside the “+ New Topic” button.
 
-Clicking on the Notification control 🔔 will show a drop-down panel with 5 
-different options : Watching, Tracking, Watching First Post, Normal and Muted. 
-All categories are set by default in Normal mode where you will only be notified 
-if someone mentions your @name or replies to you. 
+Clicking on the Notification control 🔔 will show a drop-down panel with 5
+different options : Watching, Tracking, Watching First Post, Normal and Muted.
+All categories are set by default in Normal mode where you will only be notified
+if someone mentions your @name or replies to you.
 
 **Customising notifications on user preference**
-You can customise or make adjustments to all your notifications according to 
-categories, users and tags under Preferences of your account. 
+You can customise or make adjustments to all your notifications according to
+categories, users and tags under Preferences of your account.
 (https://discuss.python.org/u/username/preferences/categories)
-Accessing this page allows you to view all your saved notifications in bird’s 
+Accessing this page allows you to view all your saved notifications in bird’s
 eye view and makes it easier for you to make changes and adjustments.
 
 Following individual threads (Topic notifications)
 ''''''''''''''''''''''''''''''''''''''''''''''''''
-To follow any individual topics or threads, you can adjust your notification 
-through the notification button at the bottom of each topic. If the topic is 
-long, you can also do so at the end of the timeline found on the right of the 
+To follow any individual topics or threads, you can adjust your notification
+through the notification button at the bottom of each topic. If the topic is
+long, you can also do so at the end of the timeline found on the right of the
 topic beside the reply button.
-Select “Watching” and you will be notified when there is any new updated reply 
-from that particular thread. 
+Select “Watching” and you will be notified when there is any new updated reply
+from that particular thread.
 
 Enabling mailing list mode
 ''''''''''''''''''''''''''
-In mailing list mode, you will receive one email per post, as happens with 
-traditional mailing lists. This is desirable if you prefer to interact via email, 
-without visiting the forum website. 
-To activate the mailing list mode, go to preferences >emails, check on "enable 
-mailing list mode" and save changes. 
-(https://discuss.python.org/u/username/preferences/emails) 
+In mailing list mode, you will receive one email per post, as happens with
+traditional mailing lists. This is desirable if you prefer to interact via email,
+without visiting the forum website.
+To activate the mailing list mode, go to preferences >emails, check on "enable
+mailing list mode" and save changes.
+(https://discuss.python.org/u/username/preferences/emails)
 
-.. note:: This setting overrides the activity summary. Muted topics and 
+.. note:: This setting overrides the activity summary. Muted topics and
   categories will not be included in these emails
 
 .. _Discourse: https://discuss.python.org/

--- a/communication.rst
+++ b/communication.rst
@@ -141,7 +141,7 @@ Reading topics
 Click a topic title and read down the list of replies in chronological order,
 following links or previewing replies and quotes as you go. Use your mouse to
 scroll the screen, or use the timeline scroll bar on the right which also shows
-you how far through the conversation you’ve read. On smaller screens, select the
+you how far through the conversation you've read. On smaller screens, select the
 bottom progress bar to expand it.
 
 

--- a/communication.rst
+++ b/communication.rst
@@ -92,55 +92,37 @@ RSS feed readers.
 .. _web gateway: https://mail.python.org/archives/
 
 
-Discourse
------------
-**(discuss.python.org web forum)**
+Discourse (discuss.python.org web forum)
+----------------------------------------
 
 We have our own `Discourse`_ forum for both developers and users. This forum
 complements the `python-dev`_, `python-ideas`_, `python-help`_, and
 `python-list`_ mailing lists.
 
-This forum has many different categories and most core development discussions
-take place in the open forum categories for `PEPs`_ and `Core Development`_.
-(These are the Discourse equivalents to the python-dev mailing list)
-Most categories are open for all users to read and post with the exception of
-Committers and Core Development categories.
-
-
-**Committers category**
+This forum has different categories and most core development discussions
+take place in the open forum categories for `PEPs`_ and `Core Development`_
+(These are the Discourse equivalents to the python-dev mailing list).
+All categories are open for users to read and post with the exception of
+the Committers category.
 
 The `Committers`_ category is an "argument clinic" for Python committers with
 the commit bit on `CPython <https://github.com/python/cpython>`_ and related
-projects.
-It is open for all users to read but posting is restricted to core developers.
-It is often used for announcements and notifications. It is also a common venue
-for the core developer promotion votes (This category is equivalent to the
-python-committers mailing list).
+projects. It is open for all users to read but posting is restricted to core
+developers. It is often used for announcements and notifications. It is also
+a common venue for the core developer promotion votes (This category is
+equivalent to the python-committers mailing list)
 
-**Core Development category**
-
-The `Core Development`_ category on Discourse is a private category visible to
-core developers only. This category is used to share administrative information,
-as well as individual information inputs among all core developers in an
-enclosed environment where information will not be permanently archived on the
-internet (e.g. logistics for in-person core development sprints).
-
-Getting Started
-''''''''''''''''
+Tutorials for new users
+'''''''''''''''''''''''
 To start a topic or participate in any discussions in the forum, sign up and
 create an account using an email address or GitHub account. You can do so by
 clicking the "Sign Up" button on the top right hand corner of the `Discourse`_
 main page.
 
-
-Quick Start
-''''''''''''
 The Python Discourse `Quick Start <https://discuss.python.org/t/python-discourse-quick-start/116>`_
 compiled by `Carol Willing <https://discuss.python.org/u/willingc/>`_ gives you
 a quick overview on how to kick off Python Discourse.
 
-Tutorials for New Users
-''''''''''''''''''''''''
 New users can get familiarise with the forum by going through Discobot tutorials.
 These tutorials can be activated by replying to a welcome message from "discourse
 Greetings!" received under Notifications and Messages in your user account.
@@ -168,14 +150,12 @@ scroll the screen, or use the timeline scroll bar on the right which also shows
 you how far through the conversation you’ve read. On smaller screens, select the
 bottom progress bar to expand it.
 
-Related topics
-'''''''''''''''
-Sometimes conversations are clearer if topics are split, where posts are moved
-to a more appropriate topic, or two related topics are merged. If a post is
-it has been moved to, and the person who posted it will also be notified.
+
+Notifications
+'''''''''''''
 
 Following categories (Category notifications)
-''''''''''''''''''''''''''''''''''''''''''''''
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Notifications can be set for individual categories and topics. To change any of these
 defaults, you can either go to your user preferences, or visit the category
 page, and use the notification button 🔔 above the topic list,
@@ -186,21 +166,23 @@ different options : Watching, Tracking, Watching First Post, Normal and Muted.
 All categories are set by default in Normal mode where you will only be notified
 if someone mentions your @name or replies to you.
 
-**Customising notifications on user preference**
+Following individual threads (Topic notifications)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+To follow any individual topics or threads, you can adjust your notifications
+through the notification button 🔔 found on the right of the topic at the end
+of the timeline. You can also do so at the bottom of each topic.
+Select “Watching” and you will be notified when there is any new updated reply
+from that particular thread.
+
+Customising notifications on user preference
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 You can customise or make adjustments to all your notifications according to
 categories, users and tags under Preferences of your account.
 (https://discuss.python.org/my/preferences/categories)
 Accessing this page allows you to view all your saved notifications in bird’s
 eye view and makes it easier for you to make changes and adjustments.
 
-Following individual threads (Topic notifications)
-''''''''''''''''''''''''''''''''''''''''''''''''''
-To follow any individual topics or threads, you can adjust your notification
-through the notification button at the bottom of each topic. If the topic is
-long, you can also do so at the end of the timeline found on the right of the
-topic beside the reply button.
-Select “Watching” and you will be notified when there is any new updated reply
-from that particular thread.
+
 
 Enabling mailing list mode
 ''''''''''''''''''''''''''

--- a/communication.rst
+++ b/communication.rst
@@ -133,6 +133,11 @@ Greetings!" received under Notifications and Messages in your user account.
 
 Ensure that you read through the `Python Code of Conduct <https://discuss.python.org/faq>`_.
 We are to be open, considerate and respectful to all users in the community.
+You can report messages that don't respect the CoC by clicking on the three
+dots under the message and then on the ⚐ icon.  You can also mention the
+`@staff <https://discuss.python.org/groups/staff>`_,
+`@moderators <https://discuss.python.org/groups/moderators>`_, or
+`@admins <https://discuss.python.org/groups/admins>`_ groups in a message.
 
 
 

--- a/communication.rst
+++ b/communication.rst
@@ -171,12 +171,10 @@ from that particular thread.
 
 Customising notifications on user preference
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-You can customise or make adjustments to all your notifications according to
-categories, users and tags under Preferences of your account.
+To get a bird's eye view of all your customised notifications, you can
+go to Preferences of your account. This allows you to make adjustments
+according to categories, users and tags.
 (https://discuss.python.org/my/preferences/categories)
-Accessing this page allows you to view all your saved notifications in bird’s
-eye view and makes it easier for you to make changes and adjustments.
-
 
 
 Enabling mailing list mode

--- a/communication.rst
+++ b/communication.rst
@@ -176,7 +176,7 @@ it has been moved to, and the person who posted it will also be notified.
 
 Following categories (Category notifications)
 ''''''''''''''''''''''''''''''''''''''''''''''
-Notification level can also be set per category. To change any of these
+Notifications can be set for individual categories and topics. To change any of these
 defaults, you can either go to your user preferences, or visit the category
 page, and use the notification button 🔔 above the topic list,
 on the top right hand corner of the category page beside the “+ New Topic” button.

--- a/communication.rst
+++ b/communication.rst
@@ -123,7 +123,7 @@ The Python Discourse `Quick Start <https://discuss.python.org/t/python-discourse
 compiled by `Carol Willing <https://discuss.python.org/u/willingc/>`_ gives you
 a quick overview on how to kick off Python Discourse.
 
-New users can get familiarise with the forum by going through Discobot tutorials.
+We recommend new users getting familiarised with the forum by going through Discobot tutorials.
 These tutorials can be activated by replying to a welcome message from "discourse
 Greetings!" received under Notifications and Messages in your user account.
 
@@ -131,7 +131,7 @@ Greetings!" received under Notifications and Messages in your user account.
 * The dropdown menu will show four different icons: 🔔 (Notifications),
   🔖 (Bookmarks), ✉️ (Messages), and 👤 (Preferences).
 * Select either Notifications or Messages.
-* Open the "Greetings!" message sent by discobot.
+* Open the "Greetings!" message sent by Discobot to start the tutorial.
 * Ensure that you read through the `Python Code of Conduct <https://discuss.python.org/faq>`_.
   We are to be open, considerate and respectful to all users in the community.
 * Click on the bookmark glyph found on the bottom right corner of the message beside

--- a/communication.rst
+++ b/communication.rst
@@ -153,7 +153,7 @@ Following categories (Category notifications)
 Notifications can be set for individual categories and topics. To change any of these
 defaults, you can either go to your user preferences, or visit the category
 page, and use the notification button 🔔 above the topic list,
-on the top right hand corner of the category page beside the “+ New Topic” button.
+on the top right hand corner of the category page beside the "+ New Topic" button.
 
 Clicking on the Notification control 🔔 will show a drop-down panel with 5
 different options: Watching, Tracking, Watching First Post, Normal, and Muted.

--- a/communication.rst
+++ b/communication.rst
@@ -189,7 +189,7 @@ if someone mentions your @name or replies to you.
 **Customising notifications on user preference**
 You can customise or make adjustments to all your notifications according to
 categories, users and tags under Preferences of your account.
-(https://discuss.python.org/u/username/preferences/categories)
+(https://discuss.python.org/my/preferences/categories)
 Accessing this page allows you to view all your saved notifications in bird’s
 eye view and makes it easier for you to make changes and adjustments.
 

--- a/communication.rst
+++ b/communication.rst
@@ -169,19 +169,10 @@ from that particular thread.
 
 Customising notifications on user preference
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-<<<<<<< HEAD
 To get a bird's eye view of all your customised notifications, you can
 go to Preferences of your account. This allows you to make adjustments
 according to categories, users and tags.
 (https://discuss.python.org/my/preferences/categories)
-=======
-You can customise or make adjustments to all your notifications according to
-`categories, users, and tags under Preferences of your account
-<https://discuss.python.org/my/preferences/notifications>`_.
-Accessing this page allows you to view all your saved notifications in bird’s
-eye view and makes it easier for you to make changes and adjustments.
-
->>>>>>> 378742081fb47fa3fd78c6791592dea65c4a12e1
 
 
 Enabling mailing list mode

--- a/communication.rst
+++ b/communication.rst
@@ -211,9 +211,6 @@ To activate the mailing list mode, go to the `email preferences
 <https://discuss.python.org/my/preferences/emails>`_, check "Enable
 mailing list mode" and save changes.
 
-.. note:: This setting overrides the activity summary. Muted topics and
-  categories will not be included in these emails
-
 .. _Discourse: https://discuss.python.org/
 .. _PEPs: https://discuss.python.org/c/peps/
 .. _Core Development: https://discuss.python.org/c/core-dev/

--- a/communication.rst
+++ b/communication.rst
@@ -165,7 +165,7 @@ Following individual threads (Topic notifications)
 To follow any individual topics or threads, you can adjust your notifications
 through the notification button 🔔 found on the right of the topic at the end
 of the timeline. You can also do so at the bottom of each topic.
-Select “Watching” and you will be notified when there is any new updated reply
+Select "Watching" and you will be notified when there is any new updated reply
 from that particular thread.
 
 Customising notifications on user preference

--- a/communication.rst
+++ b/communication.rst
@@ -176,7 +176,7 @@ from that particular thread.
 Customising notifications on user preference
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 To get a bird's eye view of all your customised notifications, you can
-go to `Preferences of your account <https://discuss.python.org/my/preferences/categories>`_. 
+go to `Preferences of your account <https://discuss.python.org/my/preferences/categories>`_.
 This allows you to make adjustments according to categories, users, and tags.
 
 Enabling mailing list mode

--- a/communication.rst
+++ b/communication.rst
@@ -171,9 +171,8 @@ from that particular thread.
 Customising notifications on user preference
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 To get a bird's eye view of all your customised notifications, you can
-go to Preferences of your account. This allows you to make adjustments
-according to categories, users and tags.
-(https://discuss.python.org/my/preferences/categories)
+go to `Preferences of your account <https://discuss.python.org/my/preferences/categories>`_. 
+This allows you to make adjustments according to categories, users, and tags.
 
 Enabling mailing list mode
 ''''''''''''''''''''''''''

--- a/communication.rst
+++ b/communication.rst
@@ -106,7 +106,7 @@ All categories are open for users to read and post with the exception of
 the Committers category, where posting is restricted to the `CPython
 <https://github.com/python/cpython>`_ core developers.
 
-The Committers category is often used for announcements and notifications.
+The `Committers`_ category is often used for announcements and notifications.
 It is also a common venue for the core developer promotion votes (this
 category is equivalent to the python-committers mailing list).
 

--- a/communication.rst
+++ b/communication.rst
@@ -103,10 +103,10 @@ This forum has different categories and most core development discussions
 take place in the open forum categories for `PEPs`_ and `Core Development`_
 (these are the Discourse equivalents to the python-dev mailing list).
 All categories are open for users to read and post with the exception of
-the Committers category, where posting is restricted to the `CPython
+the `Committers`_ category, where posting is restricted to the `CPython
 <https://github.com/python/cpython>`_ core developers.
 
-The `Committers`_ category is often used for announcements and notifications.
+The Committers category is often used for announcements and notifications.
 It is also a common venue for the core developer promotion votes (this
 category is equivalent to the python-committers mailing list).
 

--- a/communication.rst
+++ b/communication.rst
@@ -174,7 +174,6 @@ go to Preferences of your account. This allows you to make adjustments
 according to categories, users and tags.
 (https://discuss.python.org/my/preferences/categories)
 
-
 Enabling mailing list mode
 ''''''''''''''''''''''''''
 In mailing list mode, you will receive one email per post, as happens with

--- a/communication.rst
+++ b/communication.rst
@@ -207,9 +207,9 @@ Enabling mailing list mode
 In mailing list mode, you will receive one email per post, as happens with
 traditional mailing lists. This is desirable if you prefer to interact via email,
 without visiting the forum website.
-To activate the mailing list mode, go to preferences >emails, check on "enable
+To activate the mailing list mode, go to the `email preferences
+<https://discuss.python.org/my/preferences/emails>`_, check "Enable
 mailing list mode" and save changes.
-(https://discuss.python.org/u/username/preferences/emails)
 
 .. note:: This setting overrides the activity summary. Muted topics and
   categories will not be included in these emails

--- a/communication.rst
+++ b/communication.rst
@@ -92,28 +92,127 @@ RSS feed readers.
 .. _web gateway: https://mail.python.org/archives/
 
 
-Discourse (discuss.python.org web forum)
-----------------------------------------
+Discourse
+-----------
+**(discuss.python.org web forum)**
 
 We have our own `Discourse`_ forum for both developers and users. This forum
 complements the `python-dev`_, `python-ideas`_, `python-help`_, and
 `python-list`_ mailing lists.
 
-Most core development discussions take place in the open forum categories for
-`PEPs`_ and `Core Development`_. (These are the Discourse equivalents to the
-python-dev mailing list)
+This forum has many different categories and most core development discussions 
+take place in the open forum categories for `PEPs`_ and `Core Development`_. 
+(These are the Discourse equivalents to the python-dev mailing list)
+Most categories are open for all users to read and post with the exception of 
+Committers and Core Development categories.
 
-The `Committers`_ category restricts posting to core developers only, and is
-used more for announcements and notifications, rather than for discussions. It
-is also the venue for core developer promotion votes. (This category is the
-equivalent of the python-committers mailing list)
 
-There is a final, rarely used, core development category on Discourse that is
-only visible to core developers. This can be used to share administrative
-information with all core developers in a non-public forum (e.g. logistics for
-in person core development sprints), as well as for individual core developers
-to share info that they'd like other core devs to be aware of, but would prefer
-not to have permanently archived on the internet.
+**Committers category**
+
+The `Committers`_ category is an "argument clinic" for Python committers with 
+the commit bit on `CPython <https://github.com/python/cpython>`_ and related 
+projects. 
+It is open for all users to read but posting is restricted to core developers. 
+It is often used for announcements and notifications. It is also a common venue 
+for the core developer promotion votes (This category is equivalent to the 
+python-committers mailing list).
+
+**Core Development category**
+
+The `Core Development`_ category on Discourse is a private category visible to 
+core developers only. This category is used to share administrative information, 
+as well as individual information inputs among all core developers in an 
+enclosed environment where information will not be permanently archived on the 
+internet (e.g. logistics for in-person core development sprints).
+
+Getting Started
+''''''''''''''''
+To start a topic or participate in any discussions in the forum, sign up and 
+create an account using an email address or Github account. You can do so by 
+clicking the "Sign Up" button on the top right hand corner of the `Discourse`_
+main page.
+
+
+Quick Start
+''''''''''''
+The Python Discourse `Quick Start <https://discuss.python.org/t/python-discourse-quick-start/116>`_ 
+compiled by `Carol Willing <https://discuss.python.org/u/willingc/>`_ gives you 
+a quick overview on how to kick off Python Discourse.
+
+Tutorials for New Users
+''''''''''''''''''''''''
+New users can get familiarise with the forum by going through Discobot tutorials. 
+These tutorials can be activated by replying to a welcome message from "discourse 
+Greetings!" received under Notifications and Messages in your user account. 
+
+* Click on your personal account found on the top right hand corner of the page.
+* The dropdown menu will show 4 different glyphs namely Notifications 🔔, Bookmark, 
+  Messages ✉️ and Preferences.
+* Select either Notifications or Messages.
+* Open the "Greetings!" message sent by discobot. 
+* Ensure that you read through the `Python Code of Conduct <https://discuss.python.org/faq>`_. 
+  We are to be open, considerate and respectful to all users in the community.  
+* Click on the bookmark glyph found on the bottom right corner of the message beside 
+  the reply button.
+* Discobot will then reply and guide you through a simple tutorial on how to use 
+  Discourse.
+
+.. note:: You will receive a certified badge if you follow through the entire new user tutorial.
+
+
+Reading topics
+'''''''''''''''
+Click a topic title and read down the list of replies in chronological order,
+following links or previewing replies and quotes as you go. Use your mouse to 
+scroll the screen, or use the timeline scroll bar on the right which also shows 
+you how far through the conversation you’ve read. On smaller screens, select the 
+bottom progress bar to expand it.
+
+Related topics
+'''''''''''''''
+Sometimes conversations are clearer if topics are split, where posts are moved 
+to a more appropriate topic, or two related topics are merged. If a post is 
+it has been moved to, and the person who posted it will also be notified.
+
+Following categories (Category notifications)
+''''''''''''''''''''''''''''''''''''''''''''''
+Notification level can also be set per category. To change any of these 
+defaults, you can either go to your user preferences, or visit the category 
+page, and use the notification button 🔔 above the topic list,
+on the top right hand corner of the category page beside the “+ New Topic” button.
+
+Clicking on the Notification control 🔔 will show a drop-down panel with 5 
+different options : Watching, Tracking, Watching First Post, Normal and Muted. 
+All categories are set by default in Normal mode where you will only be notified 
+if someone mentions your @name or replies to you. 
+
+**Customising notifications on user preference**
+You can customise or make adjustments to all your notifications according to 
+categories, users and tags under Preferences of your account. 
+(https://discuss.python.org/u/username/preferences/categories)
+Accessing this page allows you to view all your saved notifications in bird’s 
+eye view and makes it easier for you to make changes and adjustments.
+
+Following individual threads (Topic notifications)
+''''''''''''''''''''''''''''''''''''''''''''''''''
+To follow any individual topics or threads, you can adjust your notification 
+through the notification button at the bottom of each topic. If the topic is 
+long, you can also do so at the end of the timeline found on the right of the 
+topic beside the reply button.
+Select “Watching” and you will be notified when there is any new updated reply 
+from that particular thread. 
+
+Enabling mailing list mode
+''''''''''''''''''''''''''
+In mailing list mode, you will receive one email per post, as happens with 
+traditional mailing lists. This is desirable if you prefer to interact via email, 
+without visiting the forum website. 
+To activate the mailing list mode, go to preferences >emails, check on "enable 
+mailing list mode" and save changes. 
+(https://discuss.python.org/u/username/preferences/emails) 
+
+.. note:: This setting overrides the activity summary. Muted topics and 
+  categories will not be included in these emails
 
 .. _Discourse: https://discuss.python.org/
 .. _PEPs: https://discuss.python.org/c/peps/

--- a/communication.rst
+++ b/communication.rst
@@ -128,7 +128,7 @@ internet (e.g. logistics for in-person core development sprints).
 Getting Started
 ''''''''''''''''
 To start a topic or participate in any discussions in the forum, sign up and
-create an account using an email address or Github account. You can do so by
+create an account using an email address or GitHub account. You can do so by
 clicking the "Sign Up" button on the top right hand corner of the `Discourse`_
 main page.
 

--- a/communication.rst
+++ b/communication.rst
@@ -146,8 +146,8 @@ These tutorials can be activated by replying to a welcome message from "discours
 Greetings!" received under Notifications and Messages in your user account.
 
 * Click on your personal account found on the top right hand corner of the page.
-* The dropdown menu will show 4 different glyphs namely Notifications 🔔, Bookmark,
-  Messages ✉️ and Preferences.
+* The dropdown menu will show four different icons: 🔔 (Notifications),
+  🔖 (Bookmarks), ✉️ (Messages), and 👤 (Preferences).
 * Select either Notifications or Messages.
 * Open the "Greetings!" message sent by discobot.
 * Ensure that you read through the `Python Code of Conduct <https://discuss.python.org/faq>`_.

--- a/communication.rst
+++ b/communication.rst
@@ -130,8 +130,9 @@ Greetings!" received under Notifications and Messages in your user account.
   🔖 (Bookmarks), ✉️ (Messages), and 👤 (Preferences).
 * Select either Notifications or Messages.
 * Open the "Greetings!" message sent by Discobot to start the tutorial.
-* Ensure that you read through the `Python Code of Conduct <https://discuss.python.org/faq>`_.
-  We are to be open, considerate and respectful to all users in the community.
+
+Ensure that you read through the `Python Code of Conduct <https://discuss.python.org/faq>`_.
+We are to be open, considerate and respectful to all users in the community.
 
 
 

--- a/conf.py
+++ b/conf.py
@@ -232,6 +232,10 @@ linkcheck_ignore = [
     'https://github.com/python/voters/',
     # The python-core team link is private, redirects to login
     'https://github.com/orgs/python/teams/python-core',
+    # The Discourse groups are private unless you are logged in
+    'https://discuss.python.org/groups/staff',
+    'https://discuss.python.org/groups/moderators',
+    'https://discuss.python.org/groups/admins',
 ]
 
 # Use our custom CSS stylesheet to differentiate us from the official python

--- a/help.rst
+++ b/help.rst
@@ -15,19 +15,19 @@ question.
 Discourse
 ---------
 
-Python has a hosted `Discourse`_ instance. This forum has many different 
-categories and most core development discussions take place in the open forum 
-categories for `PEPs`_ and `Core Development`_ . 
-Most categories are open for all users to read and post with the exception of 
+Python has a hosted `Discourse`_ instance. This forum has many different
+categories and most core development discussions take place in the open forum
+categories for `PEPs`_ and `Core Development`_ .
+Most categories are open for all users to read and post with the exception of
 Committers and Core Development categories. Be sure to visit the related Core
 categories, such as
 `Core Development <https://discuss.python.org/c/core-dev/23>`_ and
 `Core Workflow <https://discuss.python.org/c/core-workflow/8>`_.
 
-.. seealso:: 
+.. seealso::
   `Discourse <https://devguide.python.org/communication/#discourse-discuss-python-org-web-forum>`_
   on how to get started.
-  
+
 
 .. _PEPs: https://discuss.python.org/c/peps/
 

--- a/help.rst
+++ b/help.rst
@@ -15,12 +15,21 @@ question.
 Discourse
 ---------
 
-Python has a hosted `Discourse`_ instance. Be sure to visit the related Core
+Python has a hosted `Discourse`_ instance. This forum has many different 
+categories and most core development discussions take place in the open forum 
+categories for `PEPs`_ and `Core Development`_ . 
+Most categories are open for all users to read and post with the exception of 
+Committers and Core Development categories. Be sure to visit the related Core
 categories, such as
 `Core Development <https://discuss.python.org/c/core-dev/23>`_ and
 `Core Workflow <https://discuss.python.org/c/core-workflow/8>`_.
 
-.. _Discourse: https://discuss.python.org/
+.. seealso:: 
+  `Discourse <https://devguide.python.org/communication/#discourse-discuss-python-org-web-forum>`_
+  on how to get started.
+  
+
+.. _PEPs: https://discuss.python.org/c/peps/
 
 Mailing Lists
 -------------


### PR DESCRIPTION
Fixing issue #853 updating documentation about usage of Discourse. 
Added info includes:

- brief overview of categories in discourse
- getting started
- tutorials for new users
- how to read topics and threads
- following and adding notifications in both categories and topics
- enabling mailing list mode
