### PR TITLE
gh-870 Added Closing PR section for close reasons

### DIFF
--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -490,6 +490,14 @@ versions of Python as a bugfix if the core developer doing the merge believes
 it is warranted.
 
 
+Closing PR
+----------
+
+On 2022-05-19, `the GitHub issues release an update <https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/>`_:
+issue closed reasons. When closing PR, the core developer may opt to close as
+``complete`` or ``not-planned``.
+
+
 Crediting
 ---------
 

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -489,14 +489,8 @@ with the next major release of Python. It may also be backported to older
 versions of Python as a bugfix if the core developer doing the merge believes
 it is warranted.
 
-
-Closing PR
-----------
-
-On 2022-05-19, `the GitHub issues release an update <https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/>`_:
-issue closed reasons. When closing PR, the core developer may opt to close as
-``complete`` or ``not-planned``.
-
+Your pull request can be closed with reason: either as ``complete`` or
+``not-planned``.
 
 Crediting
 ---------

--- a/pullrequest.rst
+++ b/pullrequest.rst
@@ -489,8 +489,6 @@ with the next major release of Python. It may also be backported to older
 versions of Python as a bugfix if the core developer doing the merge believes
 it is warranted.
 
-Your pull request can be closed with reason: either as ``complete`` or
-``not-planned``.
 
 Crediting
 ---------

--- a/tracker.rst
+++ b/tracker.rst
@@ -110,7 +110,8 @@ after a consensus has been reached amongst the core developers is unlikely to
 win any converts.
 
 As a reminder, issues closed by a core developer have already been carefully
-considered. Please do not reopen a closed issue.
+considered. Please do not reopen a closed issue. An issue can be closed with
+reason either as ``complete`` or ``not planned``.
 
 .. _helptriage:
 


### PR DESCRIPTION
where now we can opt to close as complete or not-planned.

GH issue: https://github.com/python/devguide/issues/870
GH blog:
https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->