### PR TITLE
Remove outdated ` Py_VA_COPY` Coverity false positive

### DIFF
--- a/coverity.rst
+++ b/coverity.rst
@@ -80,18 +80,6 @@ False positives
   ``path_t.nullable`` is explicitly enabled. CID 719648
 
 
-Intentionally
--------------
-
-``Py_VA_COPY()``
-  Python is written in C89 (ANSI C), therefore it can't use C99 features such
-  as ``va_copy()``. Python's own variant ``Py_VA_COPY()`` uses ``memcpy()``
-  to make a copy of a ``va_list`` variable. Coverity detects two issues in
-  this approach: "Passing argument "lva" of type "va_list" and sizeof(va_list)
-  to function memcpy() is suspicious." CID 486405 and "Uninitialized pointer
-  read" CID 486630.
-
-
 Modeling
 ========
 


### PR DESCRIPTION
After https://github.com/python/cpython/commit/0c21214f3e583d541227df2239de377e796b55fa removed `Py_VA_COPY` usage from the codebase leaving `#define Py_VA_COPY va_copy` behind, the *[Coverity Scan → Known limitations → Intentionally → Py_VA_COPY](https://devguide.python.org/coverity/#intentionally)* section became obsolete and can be removed.