### PR TITLE
Updating brew install command to avoid pkg-config warning

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -385,7 +385,7 @@ for the header and library files to your ``configure`` command.  For example,
 
 with **Homebrew**::
 
-    $ brew install pkg-config openssl@1.1 xz gdbm
+    $ brew install pkg-config openssl xz gdbm
 
 and ``configure`` Python versions >= 3.7::
 

--- a/setup.rst
+++ b/setup.rst
@@ -385,7 +385,7 @@ for the header and library files to your ``configure`` command.  For example,
 
 with **Homebrew**::
 
-    $ brew install openssl xz gdbm
+    $ brew install pkg-config openssl xz gdbm
 
 and ``configure`` Python versions >= 3.7::
 

--- a/setup.rst
+++ b/setup.rst
@@ -385,7 +385,7 @@ for the header and library files to your ``configure`` command.  For example,
 
 with **Homebrew**::
 
-    $ brew install pkg-config openssl xz gdbm
+    $ brew install pkg-config openssl@1.1 xz gdbm
 
 and ``configure`` Python versions >= 3.7::
 


### PR DESCRIPTION
I am using Mac OS Catalina 10.15.7.
To avoid getting the following warning : 
`configure: WARNING: pkg-config is missing. Some dependencies may not be detected correctly.`
`brew install pkg-config` needs to be run.

Issue number: https://github.com/python/cpython/issues/93658
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->