### PR TITLE
Building _hashlib and _ssl modules

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -401,6 +401,13 @@ and ``make``::
 
     $ make -s -j2
 
+.. note:: 
+   If the _hashlib and _ssl modules do not build, specifying the openssl version can resolve the issue. As indicated earlier, you might need to run ``make clean`` before or after re-running ``configure``.
+
+For example::
+
+   $ brew install openssl@3
+
 or **MacPorts**::
 
     $ sudo port install pkgconfig openssl xz gdbm

--- a/setup.rst
+++ b/setup.rst
@@ -385,7 +385,7 @@ for the header and library files to your ``configure`` command.  For example,
 
 with **Homebrew**::
 
-    $ brew install openssl xz gdbm
+    $ brew install openssl@1.1 xz gdbm
 
 and ``configure`` Python versions >= 3.7::
 
@@ -400,13 +400,6 @@ or ``configure`` Python versions < 3.7::
 and ``make``::
 
     $ make -s -j2
-
-.. note:: 
-   If the _hashlib and _ssl modules do not build, specifying the openssl version can resolve the issue. As indicated earlier, you might need to run ``make clean`` before or after re-running ``configure``.
-
-For example::
-
-   $ brew install openssl@1.1
 
 or **MacPorts**::
 

--- a/setup.rst
+++ b/setup.rst
@@ -406,7 +406,7 @@ and ``make``::
 
 For example::
 
-   $ brew install openssl@3
+   $ brew install openssl@1.1
 
 or **MacPorts**::
 

--- a/setup.rst
+++ b/setup.rst
@@ -385,7 +385,7 @@ for the header and library files to your ``configure`` command.  For example,
 
 with **Homebrew**::
 
-    $ brew install openssl@1.1 xz gdbm
+    $ brew install pkg-config openssl@1.1 xz gdbm
 
 and ``configure`` Python versions >= 3.7::
 


### PR DESCRIPTION
I am using Mac OS Catalina 10.15.7.

To avoid getting the following messages : 

> The necessary bits to build these optional modules were not found:
> _hashlib              _ssl   

as well as:

> Could not build the ssl module!
> Python requires a OpenSSL 1.1.1 or newer

Based on the comments below, the solution is to indicate the OpenSSL version in the brew command: `brew install openssl@1.1` and make a note to update this line with `brew install openssl@3` when OpenSSL 3 is supported.

Initial (and outdated descritption below):
<details>
Running `brew install openssl@3` allowed the  _hashlib _ssl modules to build, but as suggested in a comment by @ezio-melotti it seemed strange that the version needed to be specified. 

I am therefore updating the documentation by leaving the suggested command line as `brew install openssl` rather than `brew install openssl@3 ` but I am adding a note saying that if user gets the message 

> Could not build the ssl module!
> Python requires a OpenSSL 1.1.1 or newer 

they can try specifying the version of OpenSSL by using `brew install openssl@3`.
</details>

Issue number: https://github.com/python/cpython/issues/93695

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->