### PR TITLE
Updating brew install command to build _tkinter

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -387,12 +387,12 @@ with **Homebrew**::
 
     $ brew install pkg-config openssl xz gdbm tcl-tk
 
-For Python 3.11 and newer::
+For Python 3.10 and newer::
 
     $ PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig" \
       ./configure --with-pydebug --with-openssl=$(brew --prefix openssl)
 
-For Python versions 3.10 through 3.7::
+For Python versions 3.9 through 3.7::
 
     $ export PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig"
     $ ./configure --with-pydebug \

--- a/setup.rst
+++ b/setup.rst
@@ -389,7 +389,7 @@ with **Homebrew**::
 
 and ``configure`` Python versions >= 3.7::
 
-    PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig" 
+    PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig"
     ./configure --with-pydebug --with-openssl=$(brew --prefix openssl)
 
 or ``configure`` Python versions < 3.7::

--- a/setup.rst
+++ b/setup.rst
@@ -387,16 +387,27 @@ with **Homebrew**::
 
     $ brew install pkg-config openssl xz gdbm tcl-tk
 
-and ``configure`` Python versions >= 3.7::
+For Python 3.11 and newer::
 
-    PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig"
-    ./configure --with-pydebug --with-openssl=$(brew --prefix openssl)
+    $ PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig" \
+      ./configure --with-pydebug --with-openssl=$(brew --prefix openssl)
 
-or ``configure`` Python versions < 3.7::
+For Python versions 3.10 through 3.7::
 
+    $ export PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig"
+    $ ./configure --with-pydebug \
+                  --with-openssl=$(brew --prefix openssl) \
+                  --with-tcltk-libs="$(pkg-config --libs tcl tk)" \
+                  --with-tcltk-includes="$(pkg-config --cflags tcl tk)"
+
+For Python versions 3.6 and older::
+
+    $ export PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig"
     $ CPPFLAGS="-I$(brew --prefix openssl)/include" \
       LDFLAGS="-L$(brew --prefix openssl)/lib" \
-      ./configure --with-pydebug
+      ./configure --with-pydebug \
+                  --with-tcltk-libs="$(pkg-config --libs tcl tk)" \
+                  --with-tcltk-includes="$(pkg-config --cflags tcl tk)"
 
 and ``make``::
 

--- a/setup.rst
+++ b/setup.rst
@@ -385,7 +385,7 @@ for the header and library files to your ``configure`` command.  For example,
 
 with **Homebrew**::
 
-    $ brew install openssl xz gdbm tcl-tk
+    $ brew install pkg-config openssl xz gdbm tcl-tk
 
 and ``configure`` Python versions >= 3.7::
 

--- a/setup.rst
+++ b/setup.rst
@@ -385,10 +385,11 @@ for the header and library files to your ``configure`` command.  For example,
 
 with **Homebrew**::
 
-    $ brew install openssl xz gdbm
+    $ brew install openssl xz gdbm tcl-tk
 
 and ``configure`` Python versions >= 3.7::
 
+    PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig" 
     ./configure --with-pydebug --with-openssl=$(brew --prefix openssl)
 
 or ``configure`` Python versions < 3.7::

--- a/setup.rst
+++ b/setup.rst
@@ -400,15 +400,6 @@ For Python versions 3.9 through 3.7::
                   --with-tcltk-libs="$(pkg-config --libs tcl tk)" \
                   --with-tcltk-includes="$(pkg-config --cflags tcl tk)"
 
-For Python versions 3.6 and older::
-
-    $ export PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig"
-    $ CPPFLAGS="-I$(brew --prefix openssl)/include" \
-      LDFLAGS="-L$(brew --prefix openssl)/lib" \
-      ./configure --with-pydebug \
-                  --with-tcltk-libs="$(pkg-config --libs tcl tk)" \
-                  --with-tcltk-includes="$(pkg-config --cflags tcl tk)"
-
 and ``make``::
 
     $ make -s -j2


### PR DESCRIPTION
I am using Mac OS Catalina 10.15.7.
This is to avoid getting the following message:
> The necessary bits to build these optional modules were not found:
> _tkinter

The solution was provided by @erlend-aasland.
Issue number: https://github.com/python/cpython/issues/93659
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->