### PR TITLE
Add a quick reference for rst markup.

### DIFF
--- a/documentation/markup.rst
+++ b/documentation/markup.rst
@@ -16,22 +16,22 @@ Quick Reference
 This table summarizes which markup should be used for some commonly used
 elements:
 
-===================== =========================================== ====================
-Element               Markup                                      See also
-===================== =========================================== ====================
-arguments/parameters  ``*arg*``                                   :ref:`inline-markup`
-vars/literals/code    ````var````, ````42````, ````len(s) - 1```` :ref:`inline-markup`
-True/False/None       ````True````, ````False````, ````None````   :ref:`inline-markup`
-functions             ``:func:`sorted```                          :ref:`roles`
-func definitions      ``.. function:: func(args)``                :ref:`directives`
-reference labels      ``.. _label-name:``                         :ref:`doc-ref-role`
-internal ref          ``:ref:`label-name```                       :ref:`doc-ref-role`
-external links        ```Link text <https://target>`_``           :ref:`hyperlinks`
-roles w/ custom text  ``:role:`custom text <target>```            :ref:`roles`
-roles w/o link        ``:role:`!target```                         :ref:`roles`
-roles w/o first part  ``:role:`~hidden.hidden.visible```          :ref:`roles`
-comments              ``.. a comment``                            :ref:`comments`
-===================== =========================================== ====================
+======================= =========================================== ====================
+Element                 Markup                                      See also
+======================= =========================================== ====================
+arguments/parameters    ``*arg*``                                   :ref:`inline-markup`
+variables/literals/code ````foo````, ````42````, ````len(s) - 1```` :ref:`inline-markup`
+True/False/None         ````True````, ````False````, ````None````   :ref:`inline-markup`
+functions definitions   ``.. function:: print(*args)``              :ref:`directives`
+functions references    ``:func:`print```                           :ref:`roles`
+reference labels        ``.. _label-name:``                         :ref:`doc-ref-role`
+internal references     ``:ref:`label-name```                       :ref:`doc-ref-role`
+external links          ```Link text <https://example.com>`_``      :ref:`hyperlinks`
+roles w/ custom text    ``:role:`custom text <target>```            :ref:`roles`
+roles w/ only last part ``:role:`~hidden.hidden.visible```          :ref:`roles`
+roles w/o link          ``:role:`!target```                         :ref:`roles`
+comments                ``.. a comment``                            :ref:`comments`
+======================= =========================================== ====================
 
 
 .. _rst-primer:
@@ -263,10 +263,8 @@ You can also explicitly number the footnotes for better context.
 Comments
 --------
 
-Every explicit markup block which isn't a valid markup construct (like the
-footnotes above) is regarded as a comment.
-
-Comments are generally preceeded by ``..``::
+Every explicit markup block (starting with :literal:`.. \ `) which isn't a
+:ref:`valid markup construct <directives>` is regarded as a comment::
 
    .. This is a comment
 
@@ -678,8 +676,12 @@ Roles
 As said before, Sphinx uses interpreted text roles to insert semantic markup in
 documents.
 
-Names of local variables, such as function/method arguments, are an exception,
-they should be marked simply with ``*var*``.
+There are a couple of cases where roles can be omitted in favor of
+simpler markup:
+
+* Function and method arguments can be marked with ``*arg*``.
+* ``True``, ``False``, ``None``, and variables can be marked with
+  :literal:`\`\`...```.
 
 For all other roles, you have to write ``:rolename:`content```.
 

--- a/documentation/markup.rst
+++ b/documentation/markup.rst
@@ -671,11 +671,11 @@ include files should be placed in the ``Doc/includes`` subdirectory.
 Roles
 -----
 
-As :ref:`previously mentioned <inline-markup>`,  Sphinx uses
+As :ref:`previously mentioned <inline-markup>`, Sphinx uses
 interpreted text roles of the form ``:rolename:`content```
 to insert semantic markup in documents.
 
-In the CPython documentation, there are a few common cases
+In the CPython documentation, there are a couple common cases
 where simpler markup should be used:
 
 * ``*arg*`` (rendered as *arg*) for function and method arguments.

--- a/documentation/markup.rst
+++ b/documentation/markup.rst
@@ -69,8 +69,6 @@ The standard reST inline markup is quite simple: use
 * two asterisks: ``**text**`` for strong emphasis (boldface), and
 * backquotes: ````text```` for code samples, variables, and literals.
 
-Italic is also used for function and method arguments (``*arg*``).
-
 If asterisks or backquotes appear in running text and could be confused with
 inline markup delimiters, they have to be escaped with a backslash.
 
@@ -673,17 +671,15 @@ include files should be placed in the ``Doc/includes`` subdirectory.
 Roles
 -----
 
-As said before, Sphinx uses interpreted text roles to insert semantic markup in
-documents.
+As :ref:`previously mentioned <inline-markup>`,  Sphinx uses
+interpreted text roles of the form ``:rolename:`content```
+to insert semantic markup in documents.
 
-There are a couple of cases where roles can be omitted in favor of
-simpler markup:
+In the CPython documentation, there are a few common cases
+where simpler markup should be used:
 
-* Function and method arguments can be marked with ``*arg*``.
-* ``True``, ``False``, ``None``, and variables can be marked with
-  :literal:`\`\`...```.
-
-For all other roles, you have to write ``:rolename:`content```.
+* ``*arg*`` (rendered as *arg*) for function and method arguments.
+* ````True````/````False````/````None```` for ``True``/``False``/``None``.
 
 There are some additional facilities that make cross-referencing roles more
 versatile:

--- a/documentation/markup.rst
+++ b/documentation/markup.rst
@@ -10,6 +10,29 @@ This document describes the custom reStructuredText markup introduced by Sphinx
 to support Python documentation and how it should be used.
 
 
+Quick Reference
+===============
+
+This table summarizes which markup should be used for some commonly used
+elements:
+
+================ ========================================= ====================
+Element          Markup                                    See also
+================ ========================================= ====================
+arguments        ``*arg*``                                 :ref:`inline-markup`
+variables        ````var````                               :ref:`inline-markup`
+literals         ````0````, ````[]````                     :ref:`inline-markup`
+True/False/None  ````True````, ````False````, ````None```` :ref:`inline-markup`
+code snippets    ````print('hello world')````              :ref:`inline-markup`
+functions        ``:func:`sorted```                        :ref:`roles`
+func definitions ``.. function:: func(args)``              :ref:`directives`
+reference labels ``.. _label-name:``                       :ref:`doc-ref-role`
+internal ref     ``:ref:`label-name```                     :ref:`doc-ref-role`
+external links   ```Link text <https://target>`_``         :ref:`hyperlinks`
+comments         ``.. a comment``                          :ref:`comments`
+================ ========================================= ====================
+
+
 .. _rst-primer:
 
 reStructuredText Primer
@@ -34,6 +57,7 @@ chunks of text separated by one or more blank lines.  As in Python, indentation
 is significant in reST, so all lines of the same paragraph must be left-aligned
 to the same level of indentation.
 
+.. _inline-markup:
 
 Inline markup
 -------------
@@ -42,7 +66,9 @@ The standard reST inline markup is quite simple: use
 
 * one asterisk: ``*text*`` for emphasis (italics),
 * two asterisks: ``**text**`` for strong emphasis (boldface), and
-* backquotes: ````text```` for code samples.
+* backquotes: ````text```` for code samples, variables, and literals.
+
+Italic is also used for function and method arguments (``*arg*``).
 
 If asterisks or backquotes appear in running text and could be confused with
 inline markup delimiters, they have to be escaped with a backslash.
@@ -132,6 +158,7 @@ The handling of the ``::`` marker is smart:
 That way, the second sentence in the above example's first paragraph would be
 rendered as "The next paragraph is a code sample:".
 
+.. _hyperlinks:
 
 Hyperlinks
 ----------
@@ -185,6 +212,7 @@ indentation.  (There needs to be a blank line between explicit markup and normal
 paragraphs.  This may all sound a bit complicated, but it is intuitive enough
 when you write it.)
 
+.. _directives:
 
 Directives
 ----------
@@ -229,12 +257,17 @@ body at the bottom of the document after a "Footnotes" rubric heading, like so::
 
 You can also explicitly number the footnotes for better context.
 
+.. _comments:
 
 Comments
 --------
 
 Every explicit markup block which isn't a valid markup construct (like the
 footnotes above) is regarded as a comment.
+
+Comments are generally preceeded by ``..``::
+
+   .. This is a comment
 
 
 Source encoding
@@ -636,9 +669,10 @@ The file name is relative to the current file's path.  Documentation-specific
 include files should be placed in the ``Doc/includes`` subdirectory.
 
 .. _rest-inline-markup:
+.. _roles:
 
-Inline markup
--------------
+Roles
+-----
 
 As said before, Sphinx uses interpreted text roles to insert semantic markup in
 documents.

--- a/documentation/markup.rst
+++ b/documentation/markup.rst
@@ -16,21 +16,22 @@ Quick Reference
 This table summarizes which markup should be used for some commonly used
 elements:
 
-================ ========================================= ====================
-Element          Markup                                    See also
-================ ========================================= ====================
-arguments        ``*arg*``                                 :ref:`inline-markup`
-variables        ````var````                               :ref:`inline-markup`
-literals         ````0````, ````[]````                     :ref:`inline-markup`
-True/False/None  ````True````, ````False````, ````None```` :ref:`inline-markup`
-code snippets    ````print('hello world')````              :ref:`inline-markup`
-functions        ``:func:`sorted```                        :ref:`roles`
-func definitions ``.. function:: func(args)``              :ref:`directives`
-reference labels ``.. _label-name:``                       :ref:`doc-ref-role`
-internal ref     ``:ref:`label-name```                     :ref:`doc-ref-role`
-external links   ```Link text <https://target>`_``         :ref:`hyperlinks`
-comments         ``.. a comment``                          :ref:`comments`
-================ ========================================= ====================
+===================== =========================================== ====================
+Element               Markup                                      See also
+===================== =========================================== ====================
+arguments/parameters  ``*arg*``                                   :ref:`inline-markup`
+vars/literals/code    ````var````, ````42````, ````len(s) - 1```` :ref:`inline-markup`
+True/False/None       ````True````, ````False````, ````None````   :ref:`inline-markup`
+functions             ``:func:`sorted```                          :ref:`roles`
+func definitions      ``.. function:: func(args)``                :ref:`directives`
+reference labels      ``.. _label-name:``                         :ref:`doc-ref-role`
+internal ref          ``:ref:`label-name```                       :ref:`doc-ref-role`
+external links        ```Link text <https://target>`_``           :ref:`hyperlinks`
+roles w/ custom text  ``:role:`custom text <target>```            :ref:`roles`
+roles w/o link        ``:role:`!target```                         :ref:`roles`
+roles w/o first part  ``:role:`~hidden.hidden.visible```          :ref:`roles`
+comments              ``.. a comment``                            :ref:`comments`
+===================== =========================================== ====================
 
 
 .. _rst-primer:


### PR DESCRIPTION
This PR adds a quick reference table at the top of the rst reference page.  The goal of this table is to show some commonly used markup and to include links to the relevant sections.  I also added some internal references and changed a title.

This was proposed a decade ago on IRC, and then captured in https://github.com/python/cpython/issues/58426#issuecomment-1093572689 [^1]

[^1]: note that the issue itself (now transferred to #14) is probably obsolete, and this proposal doesn't aim to solve that.