### PR TITLE
Remove dummy thread modules from Experts Index

### DIFF
--- a/core-developers/experts.rst
+++ b/core-developers/experts.rst
@@ -52,7 +52,6 @@ Module                Maintainers
 ====================  =============================================
 __future__
 __main__              gvanrossum, ncoghlan
-_dummy_thread         brettcannon
 _thread
 _testbuffer
 abc
@@ -104,7 +103,6 @@ difflib               tim-one (inactive)
 dis                   1st1
 distutils             merwok, dstufft
 doctest               tim-one (inactive)
-dummy_threading       brettcannon
 email                 warsaw, bitdancer*, maxking
 encodings             malemburg
 ensurepip             ncoghlan, dstufft, pradyunsg


### PR DESCRIPTION
`_dummy_thread` and `dummy_threading` modules are removed in https://github.com/python/cpython/pull/14143 so keep Experts Index in sync.