### PR TITLE
Fix brew prefix passed to configure for openssl@1.1

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -391,13 +391,13 @@ with **Homebrew**::
 For Python 3.10 and newer::
 
     $ PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig" \
-      ./configure --with-pydebug --with-openssl=$(brew --prefix openssl)
+      ./configure --with-pydebug --with-openssl=$(brew --prefix openssl@1.1)
 
 For Python versions 3.9 through 3.7::
 
     $ export PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig"
     $ ./configure --with-pydebug \
-                  --with-openssl=$(brew --prefix openssl) \
+                  --with-openssl=$(brew --prefix openssl@1.1) \
                   --with-tcltk-libs="$(pkg-config --libs tcl tk)" \
                   --with-tcltk-includes="$(pkg-config --cflags tcl tk)"
 


### PR DESCRIPTION
The brew install command was updated in #892, but the corresponding commands were not.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->