### PR TITLE
Remove sentence mooted by GitHub Issues transition

### DIFF
--- a/testing/coverage.rst
+++ b/testing/coverage.rst
@@ -259,9 +259,7 @@ times.
 Filing the Issue
 ================
 Once you have increased coverage, you need to create an issue on the
-`issue tracker`_ and submit a :ref:`pull request <pullrequest>`. On the
-issue set the "Components" to "Test" and "Versions" to the version of Python you
-worked on (i.e., the in-development version).
+`issue tracker`_ and submit a :ref:`pull request <pullrequest>`.
 
 
 Measuring coverage of C code with gcov and lcov


### PR DESCRIPTION
This PR removes a sentence that no longer applies on account of the GitHub Issues transition. Issue authors can't apply labels, and the "tests" label is added automatically.