### PR TITLE
Removed unused reference.

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -261,4 +261,3 @@ Full Table of Contents
 .. _IronPython: https://ironpython.net/
 .. _Stackless: https://github.com/stackless-dev/stackless/wiki/
 .. _Issue tracker: https://github.com/python/cpython/issues
-.. _open pull requests: https://github.com/python/cpython/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Aopen%20label%3A%22awaiting%20review%22


### PR DESCRIPTION
This link got removed in 7ab47a07ff686afa43621c130304fd42bce75f14 and it's not longer needed.