### PR TITLE
Setup and Building: update code blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
           cache: pip

--- a/conf.py
+++ b/conf.py
@@ -97,3 +97,7 @@ intersphinx_mapping = {
 }
 
 todo_include_todos = True
+
+# Strip the dollar prompt when copying code
+# https://sphinx-copybutton.readthedocs.io/en/latest/use.html#strip-and-configure-input-prompts-for-code-cells
+copybutton_prompt_text = "$"

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -150,11 +150,9 @@ If you want to install these optional dependencies, consult the
 If you don't need to install them, the basic steps for building Python
 for development is to configure it and then compile it.
 
-Configuration is typically:
+Configuration is typically::
 
-.. code-block:: bash
-
-   ./configure --with-pydebug
+   $ ./configure --with-pydebug
 
 More flags are available to ``configure``, but this is the minimum you should
 do to get a pydebug build of CPython.
@@ -163,11 +161,9 @@ do to get a pydebug build of CPython.
    You might need to run ``make clean`` before or after re-running ``configure``
    in a particular build directory.
 
-Once ``configure`` is done, you can then compile CPython with:
+Once ``configure`` is done, you can then compile CPython with::
 
-.. code-block:: bash
-
-   make -s -j2
+   $ make -s -j2
 
 This will build CPython with only warnings and errors being printed to
 stderr and utilize up to 2 CPU cores. If you are using a multi-core machine
@@ -465,11 +461,9 @@ Python's ``configure.ac`` script typically requires a specific version of
 Autoconf.  At the moment, this reads: ``AC_PREREQ(2.69)``. It also requires
 to have the ``autoconf-archive`` and ``pkg-config`` utilities installed in
 the system and the ``pkg.m4`` macro file located in the appropriate ``alocal``
-location. You can easily check if this is correctly configured by running:
+location. You can easily check if this is correctly configured by running::
 
-.. code-block:: bash
-
-   ls $(aclocal --print-ac-dir) | grep pkg.m4
+   $ ls $(aclocal --print-ac-dir) | grep pkg.m4
 
 If the system copy of Autoconf does not match this version, you will need to
 install your own copy of Autoconf.
@@ -501,9 +495,7 @@ Make target. Note that for doing this you need to regenerate the ABI file in
 the same environment that the GitHub CI uses to check for it. This is because
 different platforms may include some platform-specific details that make the
 check fail even if the Python ABI is the same. The easier way to regenerate
-the ABI file using the same platform as the CI uses is by using docker:
-
-.. code-block:: bash
+the ABI file using the same platform as the CI uses is by using Docker::
 
    # In the CPython root:
    $ docker run -v$(pwd):/src:Z -w /src --rm -it ubuntu:22.04 \


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

# With output

For blocks showing commands, where there's output shown, it's best to show a `$` prompt and use `console` formatting, so they're shown with formatting:

```console
$ git remote -v
origin  git@github.com:<your-username>/cpython.git (fetch)
origin  git@github.com:<your-username>/cpython.git (push)
upstream        git@github.com:python/cpython.git (fetch)
upstream        git@github.com:python/cpython.git (push)
```

(These PR message examples are shown in Markdown because GitHub, but a similar thing applies to RST in the devguide.)

# No output

If there's no output shown, instead of `console` formatting and a prompt, it's better to use `bash` without a prompt.

Here's an example with `console` and prompts:

```console
$ # In the CPython root:
$ docker run -v$(pwd):/src:Z -w /src --rm -it ubuntu:22.04 \
     bash /src/.github/workflows/regen-abidump.sh
```

And `bash` with no prompts:

```bash
# In the CPython root:
docker run -v$(pwd):/src:Z -w /src --rm -it ubuntu:22.04 \
     bash /src/.github/workflows/regen-abidump.sh
```

# Why?

The biggest usability gain is when clicking the copy button at the right side of the code block: it doesn't include the `$`, so you can follow the guide more easily without having to carefully avoid pasting and running a `$` in your terminal.

# Details

* Because there's only one using `console` and ~21 using `bash`, flip the default to `. highlight:: bash`.

* Also -- unrelated but minor -- bump a GitHub Actions version, can drop this if desired.

# Preview

* Now: https://devguide.python.org/getting-started/setup-building/

* PR: https://cpython-devguide--947.org.readthedocs.build/getting-started/setup-building/
