### PR TITLE
Fix gdbm build on macos

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -390,16 +390,22 @@ with **Homebrew**::
 
 For Python 3.10 and newer::
 
-    $ PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig" \
-      ./configure --with-pydebug --with-openssl=$(brew --prefix openssl@1.1)
+    $ CFLAGS="-I$(brew --prefix gdbm)/include -I$(brew --prefix xz)/include" \
+      LDFLAGS="-L$(brew --prefix gdbm)/lib -I$(brew --prefix xz)/lib" \
+      PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig" \
+      ./configure --with-pydebug \
+                  --with-openssl=$(brew --prefix openssl)
+
 
 For Python versions 3.9 through 3.7::
 
-    $ export PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig"
-    $ ./configure --with-pydebug \
-                  --with-openssl=$(brew --prefix openssl@1.1) \
-                  --with-tcltk-libs="$(pkg-config --libs tcl tk)" \
-                  --with-tcltk-includes="$(pkg-config --cflags tcl tk)"
+    $ CFLAGS="-I$(brew --prefix gdbm)/include -I$(brew --prefix xz)/include" \
+      LDFLAGS="-L$(brew --prefix gdbm)/lib -L$(brew --prefix xz)/lib" \
+      PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig" \
+      ./configure --with-pydebug \
+              --with-openssl=$(brew --prefix openssl@1.1) \
+              --with-tcltk-libs="$(pkg-config --libs tcl tk)" \
+              --with-tcltk-includes="$(pkg-config --cflags tcl tk)"
 
 and ``make``::
 


### PR DESCRIPTION
This PR fixes #817. 

It uses homebrew's gdbm and xz.