### PR TITLE
Update expected release date of 3.11

### DIFF
--- a/versions.rst
+++ b/versions.rst
@@ -19,7 +19,7 @@ Dates shown in *italic* are scheduled and can be adjusted.
 Branch Schedule   Status   First release End-of-life  Release manager
 ====== ========== ======== ============= ============ =====================
 main   :pep:`693` features *2023-10-03*  *2028-10*    Thomas Wouters
-3.11   :pep:`664` bugfix   *2022-10-03*  *2027-10*    Pablo Galindo Salgado
+3.11   :pep:`664` bugfix   *2022-10-24*  *2027-10*    Pablo Galindo Salgado
 3.10   :pep:`619` bugfix   2021-10-04    *2026-10*    Pablo Galindo Salgado
 3.9    :pep:`596` security 2020-10-05    *2025-10*    Łukasz Langa
 3.8    :pep:`569` security 2019-10-14    *2024-10*    Łukasz Langa


### PR DESCRIPTION
As per https://www.python.org/downloads/release/python-3110rc2/ - I was looking up EOL dates, but it was a bit jarring to see 3.11 listed as already released 😅 