### PR TITLE
FIX: Broken inline literal.

### DIFF
--- a/testing/run-write-tests.rst
+++ b/testing/run-write-tests.rst
@@ -56,7 +56,7 @@ But, there are several important notes:
 
 1. This way of running tests exists only
    for local developer needs and is discouraged for anything else
-2. Some modules do not support it at all. One example is``test_importlib``.
+2. Some modules do not support it at all. One example is ``test_importlib``.
    In other words: if some module does not have ``unittest.main()``, then
    most likely it does not support direct invocation.
 


### PR DESCRIPTION
It's currently not rendered due to this missing space:

![Capture d’écran du 2022-10-06 15-00-46](https://user-images.githubusercontent.com/239510/194319327-ff6794cc-d622-4125-8995-acd77e05fe2c.png)

Yes this will be automatically caught by the next release of sphinxlint.