### PR TITLE
Pin sphinx-lint to fix the CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Sphinx==5.2.3
 furo>=2022.6.4
 sphinx_copybutton>=0.3.3
-sphinx-lint<1
+sphinx-lint==0.6.1
 sphinxext-rediraffe


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Between PR https://github.com/python/devguide/pull/954 being opened ([CI passed](https://github.com/python/devguide/actions/runs/3197379860)) and merged 25 minutes later ([CI failed](https://github.com/python/devguide/actions/runs/3197545797)), a [new release of sphinx-lint](https://pypi.org/project/sphinx-lint/0.6.2/) came out with differing checks.

Let's pin it to get the CI green, and I'll open an issue to upgrade and fix the issues.

