### PR TITLE
Fix some markup (including 2 false-positives).

### DIFF
--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -151,8 +151,8 @@ reading experience.
 Instead, these security concerns should be gathered into a dedicated
 "Security Considerations" section within the module's documentation, and
 cross-referenced from the documentation of affected interfaces with a note
-similar to ``"Please refer to the :ref:`security-considerations` section
-for important information on how to avoid common mistakes."``.
+similar to :samp:`"Please refer to the :ref:\`{security-considerations}\`
+section for important information on how to avoid common mistakes."`.
 
 Similarly, if there is a common error that affects many interfaces in a
 module (e.g. OS level pipe buffers filling up and stalling child processes),

--- a/internals/parser.rst
+++ b/internals/parser.rst
@@ -833,9 +833,9 @@ Testing
 
 There are three files that contain tests for the grammar and the parser:
 
-* `Lib/test/test_grammar.py`.
-* `Lib/test/test_syntax.py`.
-* `Lib/test/test_exceptions.py`.
+* ``Lib/test/test_grammar.py``.
+* ``Lib/test/test_syntax.py``.
+* ``Lib/test/test_exceptions.py``.
 
 Check the contents of these files to know which is the best place to place new tests depending
 on the nature of the new feature you are adding.

--- a/testing/coverage.rst
+++ b/testing/coverage.rst
@@ -258,8 +258,9 @@ times.
 
 Filing the Issue
 ================
-Once you have increased coverage, you need to create an issue on the
-`issue tracker`_ and submit a :ref:`pull request <pullrequest>`.
+Once you have increased coverage,
+you need to create an issue on the `issue tracker`_ and
+submit a :ref:`pull request <pullrequest>`.
 
 
 Measuring coverage of C code with gcov and lcov


### PR DESCRIPTION
This PR fixes  markup errors exposed by `sphinx-lint` `0.6.3`, even though two of them are actually false positives:
```
# Ignore the tools and venv dirs and check that the default role is not used.
./venv/bin/sphinx-lint -i tools -i ./venv --enable default-role
testing/coverage.rst:262: default role used (hint: for inline literals, use double backticks) (default-role)
documentation/style-guide.rst:154: default role used (hint: for inline literals, use double backticks) (default-role)
internals/parser.rst:836: default role used (hint: for inline literals, use double backticks) (default-role)
internals/parser.rst:837: default role used (hint: for inline literals, use double backticks) (default-role)
internals/parser.rst:838: default role used (hint: for inline literals, use double backticks) (default-role)
```
See also:
* #956 
* https://github.com/sphinx-contrib/sphinx-lint/issues/46#issuecomment-1270602699

(cc @JulienPalard, @hugovk, @CAM-Gerlach)