### PR TITLE
Refine 'gaining commit privileges'.

### DIFF
--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -45,7 +45,7 @@ are granted through these steps:
    - A request for account details as required by
      `🔒 python/voters <https://github.com/python/voters>`_
    - A request for the committer's preferred address for subscription to
-     ``python-committers@``
+     the `python-committers mailing list`_
    - A reminder about the `Code of Conduct`_ and guidance on reporting issues
      to the PSF Conduct WG
 

--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -29,11 +29,11 @@ After a candidate has demonstrated consistent contributions, commit privileges
 are granted through these steps:
 
 1. A core developer (submitter, usually the mentor) starts a poll in the
-   `Committers category`_ on the `Python Discourse`_.
+   `Committers category`_ on the `Python Discourse`_ and cross-post to
+   the `python-committers mailing list`_.
 
    - Open for 7 days
    - Results shown upon close
-   - Cross-post the announcement to the `python-committers mailing list`_
 
 2. If the candidate receives at least two-thirds positive votes when the poll closes
    (as per :pep:`13`), the submitter emails the `steering council

--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -39,6 +39,7 @@ are granted through these steps:
    (as per :pep:`13`), the submitter emails the `steering council
    <mailto:steering-council@python.org>`_ with the candidate's email address
    requesting that the council either accept or reject the proposed membership.
+
 #. Assuming the steering council does not object, a member of the council or delegate
    (approver) will email the candidate:
 
@@ -50,6 +51,7 @@ are granted through these steps:
      to the PSF Conduct WG
 
 #. Once the candidate has provided the pertinent details, the approver will:
+
    - enable various new privileges;
    - add the new committer's details to
      `🔒 python/voters <https://github.com/python/voters>`_;

--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -28,18 +28,18 @@ Gaining Commit Privileges
 After a candidate has demonstrated consistent contributions, commit privileges
 are granted through these steps:
 
-1. A core developer (submitter, usually the mentor) starts a poll in the
+#. A core developer (submitter, usually the mentor) starts a poll in the
    `Committers category`_ on the `Python Discourse`_ and cross-post to
    the `python-committers mailing list`_.
 
    - Open for 7 days
    - Results shown upon close
 
-2. If the candidate receives at least two-thirds positive votes when the poll closes
+#. If the candidate receives at least two-thirds positive votes when the poll closes
    (as per :pep:`13`), the submitter emails the `steering council
    <mailto:steering-council@python.org>`_ with the candidate's email address
    requesting that the council either accept or reject the proposed membership.
-3. Assuming the steering council does not object, a member of the council or delegate
+#. Assuming the steering council does not object, a member of the council or delegate
    (approver) will email the candidate:
 
    - A request for account details as required by
@@ -49,7 +49,7 @@ are granted through these steps:
    - A reminder about the `Code of Conduct`_ and guidance on reporting issues
      to the PSF Conduct WG
 
-4. Once the candidate has provided the pertinent details, the approver will:
+#. Once the candidate has provided the pertinent details, the approver will:
    - enable various new privileges;
    - add the new committer's details to
      `🔒 python/voters <https://github.com/python/voters>`_;

--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -35,12 +35,10 @@ are granted through these steps:
    - Results shown upon close
    - Cross-post the announcement to the `python-committers mailing list`_
 
-2. After the poll has closed, the submitter confirms the membership per
-   :pep:`13` (2/3 of the vote).
-3. The submitter then emails the
-   `steering council <mailto:steering-council@python.org>`_ with the
-   candidate's email address requesting that the council either accept or reject the proposed
-   membership.
+2. If the candidate receives at least two-thirds positive votes when the poll closes
+   (as per :pep:`13`), the submitter emails the `steering council
+   <mailto:steering-council@python.org>`_ with the candidate's email address
+   requesting that the council either accept or reject the proposed membership.
 4. Assuming the steering council does not object, a member of the council or delegate
    (approver) will email the candidate:
 

--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -49,13 +49,13 @@ are granted through these steps:
    - A reminder about the `Code of Conduct`_ and guidance on reporting issues
      to the PSF Conduct WG
 
-5. Once the candidate has provided the pertinent details, the approver will enable
-   various new privileges.
-6. The approver will add the new committer's details to
-   `🔒 python/voters <https://github.com/python/voters>`_.
-7. The approver will update the devguide to publicly list the new committer's team
-   membership at :ref:`developers`.
-8. The approver sends an announcement email to the Committers Discourse category.
+4. Once the candidate has provided the pertinent details, the approver will:
+   - enable various new privileges;
+   - add the new committer's details to
+     `🔒 python/voters <https://github.com/python/voters>`_;
+   - update the devguide to publicly list the new committer's team membership
+     at :ref:`developers`;
+   - send an announcement email to the Committers Discourse category.
 
 .. _Code of Conduct: https://www.python.org/psf/conduct/
 .. _Committers category: https://discuss.python.org/c/committers/5

--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -29,14 +29,14 @@ After a candidate has demonstrated consistent contributions, commit privileges
 are granted through these steps:
 
 #. A core developer (submitter, usually the mentor) starts a poll in the
-   `Committers category`_ on the `Python Discourse`_ and cross-post to
+   `Committers category`_ on the `Python Discourse`_ and cross-posts it to
    the `python-committers mailing list`_.
 
    - Open for 7 days
    - Results shown upon close
 
 #. If the candidate receives at least two-thirds positive votes when the poll closes
-   (as per :pep:`13`), the submitter emails the `steering council
+   (as per :pep:`13`), the submitter `emails the steering council
    <mailto:steering-council@python.org>`_ with the candidate's email address
    requesting that the council either accept or reject the proposed membership.
 
@@ -52,7 +52,7 @@ are granted through these steps:
 
 #. Once the candidate has provided the pertinent details, the approver will:
 
-   - enable various new privileges;
+   - enable the various new privileges;
    - add the new committer's details to
      `🔒 python/voters <https://github.com/python/voters>`_;
    - update the devguide to publicly list the new committer's team membership

--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -25,37 +25,39 @@ an official offer. How core developers come to that agreement are outlined in
 Gaining Commit Privileges
 =========================
 
-The steps to gaining commit privileges are:
+After a candidate has demonstrated consistent contributions, commit privileges
+are granted through these steps:
 
-1. A core developer starts a poll in the
-   `Committers category`_ on the `Python Discourse`_ (``discuss.python.org``)
+1. A core developer (submitter, usually the mentor) starts a poll in the
+   `Committers category`_ on the `Python Discourse`_ (``discuss.python.org``).
 
    - Open for 7 days
    - Results shown upon close
+   - Cross-post the announcement to the `python-committers mailing list`_
 
-2. The poll is announced on the `python-committers mailing list`_
-3. Wait for the poll to close and see if the results confirm your membership
-   as per the voting results required by :pep:`13`
-4. The person who nominated you emails the steering council with your email
-   address and a request that the council either accept or reject the proposed
-   membership
-5. Assuming the steering council does not object, a member of the council will
-   email you asking for:
+2. After the poll has closed, the submitter confirms the membership per
+   :pep:`13` (2/3 of the vote).
+3. The submitter then emails the
+   `steering council <mailto:steering-council@python.org>`_ with the
+   candidate's email address requesting that the council either accept or reject the proposed
+   membership.
+4. Assuming the steering council does not object, a member of the council or delegate
+   (approver) will email the candidate:
 
-   - Account details as required by
-     🔒 https://github.com/python/voters/
-   - Your preferred email address to
-     subscribe to the python-committers mailing list with
-   - A reminder about the `Code of Conduct`_ and to report issues to the PSF
-     Conduct WG
+   - A request for account details as required by
+     `🔒 python/voters <https://github.com/python/voters>`_
+   - A request for the committer's preferred address for subscription to
+     ``python-committers@``
+   - A reminder about the `Code of Conduct`_ and guidance on reporting issues
+     to the PSF Conduct WG
 
-6. Once you have provided the pertinent details, your various new privileges
-   will be turned on
-7. Your details will be added to 🔒 https://github.com/python/voters/
-8. They will update the devguide to publicly list your team membership at
-   :ref:`developers`
-9. An announcement email by the steering council member handling your new
-   membership will be sent to the Committers Discourse category
+5. Once the candidate has provided the pertinent details, the approver will enable
+   various new privileges.
+6. The approver will add the new committer's details to
+   `🔒 python/voters <https://github.com/python/voters>`_.
+7. The approver will update the devguide to publicly list the new committer's team
+   membership at :ref:`developers`.
+8. The approver sends an announcement email to the Committers Discourse category.
 
 .. _Code of Conduct: https://www.python.org/psf/conduct/
 .. _Committers category: https://discuss.python.org/c/committers/5

--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -29,7 +29,7 @@ After a candidate has demonstrated consistent contributions, commit privileges
 are granted through these steps:
 
 1. A core developer (submitter, usually the mentor) starts a poll in the
-   `Committers category`_ on the `Python Discourse`_ (``discuss.python.org``).
+   `Committers category`_ on the `Python Discourse`_.
 
    - Open for 7 days
    - Results shown upon close

--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -39,7 +39,7 @@ are granted through these steps:
    (as per :pep:`13`), the submitter emails the `steering council
    <mailto:steering-council@python.org>`_ with the candidate's email address
    requesting that the council either accept or reject the proposed membership.
-4. Assuming the steering council does not object, a member of the council or delegate
+3. Assuming the steering council does not object, a member of the council or delegate
    (approver) will email the candidate:
 
    - A request for account details as required by


### PR DESCRIPTION
During my recent experience nominating someone for commit privileges, I ran into some friction attempting to follow the guidance. This change addresses that friction.

- Allow the audience to be anybody (not just an individual seeking commit privileges). Avoids use of second-person language.
- Provide guidance for all involved.
- Refer to the various actors directly, avoiding passive language. Use 'candidate', 'submitter', and 'approver' to represent the key actors.
- Move the "cross-post" action into step 1 to indicate better the temporal positition of the action.
- Summarize the confirmation criterion (2/3 vote) rather than make the reader go to the PEP, which basically indicates 2/3 vote.
- Include the steering council email, because the submitter may not know it.
- Normalize the initial approver actions. Previously, council was directed to be "asking for ... a reminder about the Code of Conduct and to report issues to the PSF WG". Now it's two requests and a reminder.
- Hyperlink "python/voters" instead of the full URL.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
