### PR TITLE
Fix copying of multiline snippets

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -107,3 +107,5 @@ todo_include_todos = True
 # Strip the dollar prompt when copying code
 # https://sphinx-copybutton.readthedocs.io/en/latest/use.html#strip-and-configure-input-prompts-for-code-cells
 copybutton_prompt_text = "$"
+# https://sphinx-copybutton.readthedocs.io/en/latest/use.html#honor-line-continuation-characters-when-copying-multline-snippets
+copybutton_line_continuation_character = "\\"


### PR DESCRIPTION
For instance, the macOS build command