### PR TITLE
Explain that the contributors should base changes against `main`

### DIFF
--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -86,7 +86,7 @@ You should have already :ref:`set up your system <setup>`,
      git checkout -b <branch-name> upstream/main
 
   .. note::
-     Almost all changes to Python, including bug fixes, should first be 
+     Almost all changes to Python, including bug fixes, should first be
      made against the ``main`` branch. See :ref:`here <good-prs>` for
      more details.
 

--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -29,7 +29,8 @@ Here is a quick overview of how you can contribute to CPython:
 
 #. `Create an issue`_ that describes your change [*]_
 
-#. :ref:`Create a new branch in Git <pullrequest-steps>`
+#. :ref:`Create a new branch in Git <pullrequest-steps>` from the
+   ``main`` branch
 
 #. Work on changes (e.g. fix a bug or add a new feature)
 
@@ -79,9 +80,15 @@ You should have already :ref:`set up your system <setup>`,
 
      git fetch upstream
 
-* Create a new branch in your local clone::
+* Create a new branch in your local clone from the ``main`` branch
+  in the upstream repository::
 
      git checkout -b <branch-name> upstream/main
+
+  * NOTE: Don't work on old branches of Python. Even if you're working on
+    a fix for a bug you discovered in an older version of Python, we
+    want to fix it in ``main`` first and then
+    :ref:`port your fix back <branch-merge>` later.
 
 * Make changes to the code, and use ``git status`` and ``git diff`` to see them.
 
@@ -180,7 +187,14 @@ Making Good PRs
 When creating a pull request for submission, there are several things that you
 should do to help ensure that your pull request is accepted.
 
-First, make sure to follow Python's style guidelines. For Python code you
+First, make your change against the right version of Python. Even if you're
+fixing a bug, your fix needs to go to the ``main`` branch first. After the
+fix is merged, it will be :ref:`ported back <branch-merge>` to older
+maintenance releases as well. That way we ensure all affected versions are
+handled. Unless you're sure that your change does not apply to ``main``,
+don't base your fixes on old versions of Python.
+
+Second, make sure to follow Python's style guidelines. For Python code you
 should follow :PEP:`8`, and for C code you should follow :PEP:`7`. If you have
 one or two discrepancies those can be fixed by the core developer who merges
 your pull request. But if you have systematic deviations from the style guides
@@ -191,7 +205,7 @@ your pull request will be put on hold until you fix the formatting issues.
    hand, fixes for typos and grammar errors in documents and docstrings are
    welcome.
 
-Second, be aware of backwards-compatibility considerations. While the core
+Third, be aware of backwards-compatibility considerations. While the core
 developer who eventually handles your pull request will make the final call on
 whether something is acceptable, thinking about backwards-compatibility early
 will help prevent having your pull request rejected on these grounds. Put
@@ -204,15 +218,15 @@ default values which maintain the existing behavior.) If in doubt, have a look
 at :PEP:`387` or :ref:`discuss <communication>` the issue with experienced
 developers.
 
-Third, make sure you have proper tests to verify your pull request works as
+Fourth, make sure you have proper tests to verify your pull request works as
 expected. Pull requests will not be accepted without the proper tests!
 
-Fourth, make sure the entire test suite :ref:`runs <runtests>` **without
+Fifth, make sure the entire test suite :ref:`runs <runtests>` **without
 failure** because of your changes.  It is not sufficient to only run whichever
 test seems impacted by your changes, because there might be interferences
 unknown to you between your changes and some other part of the interpreter.
 
-Fifth, proper :ref:`documentation <documenting>`
+Sixth, proper :ref:`documentation <documenting>`
 additions/changes should be included.
 
 

--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -85,10 +85,10 @@ You should have already :ref:`set up your system <setup>`,
 
      git checkout -b <branch-name> upstream/main
 
-  * NOTE: Don't work on old branches of Python. Even if you're working on
-    a fix for a bug you discovered in an older version of Python, we
-    want to fix it in ``main`` first and then
-    :ref:`port your fix back <branch-merge>` later.
+  .. note::
+     Almost all changes to Python, including bug fixes, should first be 
+     made against the ``main`` branch. See :ref:`here <good-prs>` for
+     more details.
 
 * Make changes to the code, and use ``git status`` and ``git diff`` to see them.
 
@@ -187,47 +187,50 @@ Making Good PRs
 When creating a pull request for submission, there are several things that you
 should do to help ensure that your pull request is accepted.
 
-First, make your change against the right version of Python. Even if you're
-fixing a bug, your fix needs to go to the ``main`` branch first. After the
-fix is merged, it will be :ref:`ported back <branch-merge>` to older
-maintenance releases as well. That way we ensure all affected versions are
-handled. Unless you're sure that your change does not apply to ``main``,
-don't base your fixes on old versions of Python.
+#. **Make your change against the right version of Python.** In general all
+   changes are made against the ``main`` branch first. This includes bug fixes.
+   After the change is merged there, it will be :ref:`ported back <branch-merge>`
+   to older :ref:`maintenance releases <branchstatus>` as well. That way we
+   ensure all affected versions are handled. Therefore, basing a new change
+   directly on a maintenance branch is only used in specific circumstances,
+   for instance when that change does not apply to ``main`` or the change
+   requires a different approach in an older Python version compared to
+   ``main``.
 
-Second, make sure to follow Python's style guidelines. For Python code you
-should follow :PEP:`8`, and for C code you should follow :PEP:`7`. If you have
-one or two discrepancies those can be fixed by the core developer who merges
-your pull request. But if you have systematic deviations from the style guides
-your pull request will be put on hold until you fix the formatting issues.
+#. **Make sure to follow Python's style guidelines.** For Python code you
+   should follow :PEP:`8`, and for C code you should follow :PEP:`7`. If you have
+   one or two discrepancies those can be fixed by the core developer who merges
+   your pull request. But if you have systematic deviations from the style guides
+   your pull request will be put on hold until you fix the formatting issues.
 
-.. note::
-   Pull requests with only code formatting changes are usually rejected. On the other
-   hand, fixes for typos and grammar errors in documents and docstrings are
-   welcome.
+   .. note::
+      Pull requests with only code formatting changes are usually rejected. On
+      the other hand, fixes for typos and grammar errors in documents and
+      docstrings are welcome.
 
-Third, be aware of backwards-compatibility considerations. While the core
-developer who eventually handles your pull request will make the final call on
-whether something is acceptable, thinking about backwards-compatibility early
-will help prevent having your pull request rejected on these grounds. Put
-yourself in the shoes of someone whose code will be broken by the change(s)
-introduced by the pull request. It is quite likely that any change made will
-break someone's code, so you need to have a good reason to make a change as
-you will be forcing someone to update their code. (This obviously does not
-apply to new classes or functions; new arguments should be optional and have
-default values which maintain the existing behavior.) If in doubt, have a look
-at :PEP:`387` or :ref:`discuss <communication>` the issue with experienced
-developers.
+#. **Be aware of backwards-compatibility considerations.** While the core
+   developer who eventually handles your pull request will make the final call on
+   whether something is acceptable, thinking about backwards-compatibility early
+   will help prevent having your pull request rejected on these grounds. Put
+   yourself in the shoes of someone whose code will be broken by the change(s)
+   introduced by the pull request. It is quite likely that any change made will
+   break someone's code, so you need to have a good reason to make a change as
+   you will be forcing someone to update their code. (This obviously does not
+   apply to new classes or functions; new arguments should be optional and have
+   default values which maintain the existing behavior.) If in doubt, have a look
+   at :PEP:`387` or :ref:`discuss <communication>` the issue with experienced
+   developers.
 
-Fourth, make sure you have proper tests to verify your pull request works as
-expected. Pull requests will not be accepted without the proper tests!
+#. **Make sure you have proper tests** to verify your pull request works as
+   expected. Pull requests will not be accepted without the proper tests!
 
-Fifth, make sure the entire test suite :ref:`runs <runtests>` **without
-failure** because of your changes.  It is not sufficient to only run whichever
-test seems impacted by your changes, because there might be interferences
-unknown to you between your changes and some other part of the interpreter.
+#. **Make sure all tests pass.** The entire test suite needs to
+   :ref:`run <runtests>` **without failure** because of your changes.
+   It is not sufficient to only run whichever test seems impacted by your
+   changes, because there might be interferences unknown to you between your
+   changes and some other part of the interpreter.
 
-Sixth, proper :ref:`documentation <documenting>`
-additions/changes should be included.
+#. Proper :ref:`documentation <documenting>` additions/changes should be included.
 
 
 .. _patchcheck:


### PR DESCRIPTION
This isn't a particularly common issue but every now and then somebody will waste their time by preparing a change against a maintenance branch instead of working with `main` from the get-go.

This change serves as a reminder to contributors to think about the `main` branch first.

Key changes:
<img width="916" alt="Screen Shot 2022-11-10 at 17 30 43" src="https://user-images.githubusercontent.com/55281/201152828-fc77d3ba-1fef-4c39-8ded-be8134afc95b.png">

<img width="915" alt="Screen Shot 2022-11-10 at 17 30 57" src="https://user-images.githubusercontent.com/55281/201152922-fc3ca74b-1009-4079-9ec5-eefa0cccf6ec.png">
