### PR TITLE
cpy-file: Go direct to the GitHub page and avoid a redirect

### DIFF
--- a/_extensions/custom_roles.py
+++ b/_extensions/custom_roles.py
@@ -11,7 +11,7 @@ def setup(app):
     # role to link to cpython files
     app.add_role(
         "cpy-file",
-        autolink("https://github.com/python/cpython/blob/main/{}"),
+        autolink("https://github.com/python/cpython/tree/main/{}"),
     )
     # role to link to cpython labels
     app.add_role(


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

# Steps to reproduce

1. Visit https://devguide.python.org/internals/parser/
2. Find and click one of the links that use the `:cpy-file:` role, for example:

> The generator is located at [`Tools/peg_generator/pegen`](https://github.com/python/cpython/blob/main/Tools/peg_generator/pegen).

# Actual result

Takes you to:

`https://github.com/python/cpython/blob/main/Tools/peg_generator/pegen`

And then redirects to:

`https://github.com/python/cpython/tree/main/Tools/peg_generator/pegen`

# Expected result

Go straight to:

`https://github.com/python/cpython/tree/main/Tools/peg_generator/pegen`

# Notes

This is a recent GitHub change.

One redirect isn't a big deal, but we might as well save a couple of hundred milliseconds and be direct.
