### PR TITLE
Update name to macOS

### DIFF
--- a/advanced-tools/clang.rst
+++ b/advanced-tools/clang.rst
@@ -110,7 +110,7 @@ After ``make install`` executes, the compilers will be installed in
     libclang_rt.lsan-x86_64.a   libclang_rt.ubsan_cxx-x86_64.a
     libclang_rt.msan-x86_64.a   libclang_rt.ubsan-x86_64.a
 
-On Mac OS X, the libraries are installed in
+On macOS, the libraries are installed in
 ``/usr/local/lib/clang/3.3/lib/darwin/``:
 
 .. code-block:: console

--- a/core-developers/experts.rst
+++ b/core-developers/experts.rst
@@ -299,7 +299,7 @@ Cygwin                jlt63^, stutzbach^
 FreeBSD
 HP-UX
 Linux
-Mac OS X              ronaldoussoren, ned-deily
+macOS                 ronaldoussoren, ned-deily
 NetBSD1
 OS2/EMX               aimacintyre^
 Solaris/OpenIndiana   jcea

--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -241,7 +241,7 @@ should do to help ensure that your pull request is accepted.
 ``patchcheck`` is a simple automated patch checklist that guides a developer
 through the common patch generation checks. To run ``patchcheck``:
 
-   On *UNIX* (including Mac OS X)::
+   On *UNIX* (including macOS)::
 
       make patchcheck
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -209,7 +209,7 @@ If you decide to :ref:`build-dependencies`, you will need to re-run both
 Once CPython is done building you will then have a working build
 that can be run in-place; ``./python`` on most machines (and what is used in
 all examples), ``./python.exe`` wherever a case-insensitive filesystem is used
-(e.g. on OS X by default), in order to avoid conflicts with the ``Python``
+(e.g. on macOS by default), in order to avoid conflicts with the ``Python``
 directory. There is normally no need to install your built copy
 of Python! The interpreter will realize where it is being run from
 and thus use the files found in the working copy.  If you are worried
@@ -326,7 +326,7 @@ Install dependencies
 ====================
 
 This section explains how to install additional extensions (e.g. ``zlib``)
-on :ref:`Linux <deps-on-linux>` and :ref:`macOs/OS X <macOS>`.  On Windows,
+on :ref:`Linux <deps-on-linux>` and :ref:`macOS`.  On Windows,
 extensions are already included and built automatically.
 
 .. _deps-on-linux:
@@ -385,7 +385,7 @@ their dependencies::
          lzma lzma-dev tk-dev uuid-dev zlib1g-dev
 
 
-.. _MacOS:
+.. _macOS:
 
 macOS and OS X
 --------------
@@ -610,7 +610,7 @@ every rule.
      The part of the standard library implemented in pure Python.
 
 ``Mac``
-     Mac-specific code (e.g., using IDLE as an OS X application).
+     Mac-specific code (e.g., using IDLE as a macOS application).
 
 ``Misc``
      Things that do not belong elsewhere. Typically this is varying kinds of

--- a/index.rst
+++ b/index.rst
@@ -27,7 +27,7 @@ instructions please see the :ref:`setup guide <setup>`.
       git clone https://github.com/<your_username>/cpython
       cd cpython
 
-3. Build Python, on UNIX and Mac OS use::
+3. Build Python, on UNIX and macOS use::
 
       ./configure --with-pydebug && make -j
 
@@ -40,13 +40,13 @@ instructions please see the :ref:`setup guide <setup>`.
    See also :ref:`more detailed instructions <compiling>`,
    :ref:`how to install and build dependencies <build-dependencies>`,
    and the platform-specific pages for :ref:`UNIX <unix-compiling>`,
-   :ref:`Mac OS <MacOS>`, and :ref:`Windows <windows-compiling>`.
+   :ref:`macOS`, and :ref:`Windows <windows-compiling>`.
 
 4. :ref:`Run the tests <runtests>`::
 
       ./python -m test -j3
 
-   On :ref:`most <mac-python.exe>` Mac OS X systems, replace :file:`./python`
+   On :ref:`most <mac-python.exe>` macOS systems, replace :file:`./python`
    with :file:`./python.exe`.  On Windows, use :file:`python.bat`.
 
 5. Create a new branch where your work for the issue will go, e.g.::
@@ -190,7 +190,7 @@ Key Resources
 * Source code
     * `Browse online <https://github.com/python/cpython/>`_
     * `Snapshot of the *main* branch <https://github.com/python/cpython/archive/main.zip>`_
-    * `Daily OS X installer <https://buildbot.python.org/daily-dmg/>`_
+    * `Daily macOS installer <https://buildbot.python.org/daily-dmg/>`_
 * PEPs_ (Python Enhancement Proposals)
 * :ref:`help`
 * :ref:`developers`

--- a/testing/coverage.rst
+++ b/testing/coverage.rst
@@ -93,7 +93,7 @@ On Unix run::
     source ../cpython-venv/bin/activate
     pip install coverage
 
-On :ref:`most <mac-python.exe>` Mac OS X systems run::
+On :ref:`most <mac-python.exe>` macOS systems run::
 
     ./python.exe -m venv ../cpython-venv
     source ../cpython-venv/bin/activate

--- a/testing/run-write-tests.rst
+++ b/testing/run-write-tests.rst
@@ -22,7 +22,7 @@ from the root directory of your checkout (after you have
     ./python -m test
 
 You may need to change this command as follows throughout this section.
-On :ref:`most <mac-python.exe>` Mac OS X systems, replace :file:`./python`
+On :ref:`most <mac-python.exe>` macOS systems, replace :file:`./python`
 with :file:`./python.exe`.  On Windows, use :file:`python.bat`.  If using
 Python 2.7, replace ``test`` with ``test.regrtest``.
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Apple's operating system has been called [macOS since 2016](https://en.wikipedia.org/wiki/MacOS#Release_history). Before that it was OS X, and before that it was Mac OS X.

In most cases we're referring to the recent versions, so let's use the current name.

---

We have [one section](https://devguide.python.org/getting-started/setup-building/#macos) specifically with two sets of instructions:

* older set: Mac OS X (versions 10.0-10.7) and OS X 10.8
* newer set: OS X 10.9-10.11 and macOS (versions 10.12+)

It's good to differentiate the names here. But whilst we're reviewing this, are the instructions for the older set still useful?

* Mac OS X versions 10.0-10.7 were released between 2001-2012
* OS X 10.8 was released between 2012-2015

Similarly, do we still need to mention OS X 10.9+ in the newer set?

* OS X versions 10.9-10.11 were released between 2013-2018

Mac OS X and OS X are all long out of support.

---

Finally, I noticed the link from https://devguide.python.org/#key-resources to the daily installer goes to https://buildbot.python.org/daily-dmg/, but it's an empty directory listing.

Should there be an installer there or shall we remove the link?

---

cc @ronaldoussoren @ned-deily