### PR TITLE
Release cycle chart: show suggestion if JavaScript disabled

### DIFF
--- a/versions.rst
+++ b/versions.rst
@@ -55,3 +55,16 @@ See also the :ref:`devcycle` page for more information about branches.
 By default, the end-of-life is scheduled 5 years after the first release,
 but can be adjusted by the release manager of each branch.  All Python 2
 versions have reached end-of-life.
+
+.. raw:: html
+
+    <noscript>
+        <style>
+            #python-release-cycle:after {
+                content: "Enable JavaScript to see the release cycle chart.";
+            }
+            .mermaid {
+                display: none;
+            }
+        </style>
+    </noscript>


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Follow on from https://github.com/python/devguide/pull/988.

Visit https://devguide.python.org/versions/.

---

# Before: with JavaScript enabled

<img width="785" alt="image" src="https://user-images.githubusercontent.com/1324225/205752201-6258da80-e4c7-41f6-b292-e54182aabd61.png">

---

# Before: with JavaScript disabled

<img width="791" alt="image" src="https://user-images.githubusercontent.com/1324225/205752323-060ac36b-8ac8-4069-acfe-b42776c36b87.png">

---

# After: with JavaScript disabled


Instead, hide chart code and advise the user to enable JS if they wish to see the chart:

<img width="770" alt="image" src="https://user-images.githubusercontent.com/1324225/205752460-ec175e1d-d106-445f-8337-98f4de19b5be.png">

Uses the advice at https://florianbrinkmann.com/en/css-rules-when-javascript-is-disabled-4536/

---

# Demo

https://cpython-devguide--997.org.readthedocs.build/versions/
