### PR TITLE
Remove reference to unused Zulip chat

### DIFF
--- a/getting-started/getting-help.rst
+++ b/getting-started/getting-help.rst
@@ -73,23 +73,6 @@ whereas ``#python`` is for questions concerning development *with* Python.
 
 .. _Libera.Chat: https://libera.chat/
 
-Zulip
------
-
-An alternative to IRC is our own `Zulip`_ instance.  There are different streams
-for asking help with core development, as well as core developers' office
-hour stream. It is preferred that you ask questions here first or schedule
-an office hour, before posting to python-dev mailing list or filing bugs.
-
-.. warning::
-
-  This is no longer actively monitored by core devs.
-  Consider asking your questions in the relevant
-  :ref:`Discourse <communication-discourse>` category instead.
-
-.. _Zulip: https://python.zulipchat.com
-
-
 Core Mentorship
 ---------------
 
@@ -121,15 +104,6 @@ during office hours.
 +==================+===============================+================================================+
 | Zachary Ware     | See details link              | Schedule at https://calendly.com/zware         |
 +------------------+-------------------------------+------------------------------------------------+
-| Mariatta Wijaya  | Thursdays 7PM - 8PM Pacific   | In `Python's Zulip Chat`_, Core > Office       |
-|                  | (Vancouver, Canada Timezone)  | Hour stream. A reminder will be posted to both |
-|                  |                               | Zulip and `Mariatta's twitter`_ account        |
-|                  |                               | 24 hours before the start.                     |
-+------------------+-------------------------------+------------------------------------------------+
-
-.. _Python's Zulip Chat: https://python.zulipchat.com/login/#narrow/stream/116503-core/topic/Office.20Hour
-.. _Mariatta's twitter: https://twitter.com/mariatta
-
 
 File a Bug
 ----------


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

For the second point of https://github.com/python/core-workflow/issues/457.

Zulip is no longer used and there's very little activity:

![image](https://user-images.githubusercontent.com/1324225/206199178-b61f2877-aa3d-4867-b7c6-36bbe0dcc88a.png)

The little activity that remains is unanswered questions, such as:

![image](https://user-images.githubusercontent.com/1324225/206199375-8368742f-49d2-422e-b817-7edff0210d5b.png)

There are better places to ask for help, let's remove Zulip references from the devguide.

Ping also @Mariatta as it referred to your Office Hour, but I see there was no activity for a few years so I think we're fine to remove it, unless you'd like to replace it with something else.