### PR TITLE
Fix a broken link

### DIFF
--- a/advanced-tools/gdb.rst
+++ b/advanced-tools/gdb.rst
@@ -357,7 +357,7 @@ this approach is less helpful when debugging the runtime virtual
 machine, since the main interpreter loop function,
 ``_PyEval_EvalFrameDefault``, is well over 4,000 lines long as of Python 3.12.
 Fortunately, among the `many ways to set breakpoints
-<https://sourceware.org/gdb/onlinedocs/gdb/Specify-Location.html>`_,
+<https://sourceware.org/gdb/onlinedocs/gdb/Location-Specifications.html>`_,
 you can break at C labels, such as those generated for computed gotos.
 If you are debugging an interpreter compiled with computed goto support
 (generally true, certainly when using GCC), each instruction will be


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

For https://github.com/python/devguide/issues/681.

```console
$ make linkcheck | grep broken
(developer-workflow/grammar: line   40) broken    https://github.com/python/cpython/blob/main/Include/Python-ast.h - 404 Client Error: Not Found for url: https://github.com/python/cpython/blob/main/Include/Python-ast.h
(internals/compiler: line  516) broken    https://github.com/python/cpython/blob/main/Include/code.h - 404 Client Error: Not Found for url: https://github.com/python/cpython/blob/main/Include/code.h
(developer-workflow/grammar: line   33) broken    https://github.com/python/cpython/blob/main/Include/token.h - 404 Client Error: Not Found for url: https://github.com/python/cpython/blob/main/Include/token.h
(internals/compiler: line  488) broken    https://github.com/python/cpython/blob/main/Python/peephole.c - 404 Client Error: Not Found for url: https://github.com/python/cpython/blob/main/Python/peephole.c
(internals/compiler: line  586) broken    https://github.com/python/cpython/blob/main/Python/wordcode_helpers.h - 404 Client Error: Not Found for url: https://github.com/python/cpython/blob/main/Python/wordcode_helpers.h
(advanced-tools/gdb: line  355) broken    https://sourceware.org/gdb/onlinedocs/gdb/Specify-Location.html - 404 Client Error: Not Found for url: https://sourceware.org/gdb/onlinedocs/gdb/Specify-Location.html
make: *** [linkcheck] Error 1
```

The first five are covered by https://github.com/python/devguide/issues/1003.

This PR fixes the last one.

Old page:

https://web.archive.org/web/20220616003657/https://sourceware.org/gdb/onlinedocs/gdb/Specify-Location.html

New page:

https://sourceware.org/gdb/onlinedocs/gdb/Location-Specifications.html