### PR TITLE
Fix a ref markup syntax in markup.rst

### DIFF
--- a/documentation/markup.rst
+++ b/documentation/markup.rst
@@ -220,7 +220,7 @@ A directive is a generic block of explicit markup.  Besides roles, it is one of
 the extension mechanisms of reST, and Sphinx makes heavy use of it.
 
 Basically, a directive consists of a name, arguments, options and content. (Keep
-this terminology in mind, it is used in `:ref:`the next section
+this terminology in mind, it is used in :ref:`the next section
 <Additional Markup Constructs>` describing custom
 directives.)  Looking at this example,
 

--- a/documentation/markup.rst
+++ b/documentation/markup.rst
@@ -221,7 +221,7 @@ the extension mechanisms of reST, and Sphinx makes heavy use of it.
 
 Basically, a directive consists of a name, arguments, options and content. (Keep
 this terminology in mind, it is used in :ref:`the next section
-<Additional Markup Constructs>` describing custom
+<additional-markup-constructs>` describing custom
 directives.)  Looking at this example,
 
 ::
@@ -287,6 +287,7 @@ There are some problems one commonly runs into while authoring reST documents:
   separated from the surrounding text by non-word characters, you have to use
   an escaped space to get around that.
 
+.. _additional-markup-constructs:
 
 Additional Markup Constructs
 ============================


### PR DESCRIPTION
Extra backtick is causing a ref to show as emphasys instead of the expected link to a target.

A screenshot from [Directives](https://devguide.python.org/documentation/markup/#directives):

<img src="https://user-images.githubusercontent.com/1571783/209576014-07d331bf-4345-4310-8166-5a14dcbc65d2.png" width="70%" height="70%" />
