### PR TITLE
Move 'moved to' link to the end

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -89,12 +89,6 @@ contributing to Python:
 * PEPs_ (Python Enhancement Proposals)
 * :ref:`gitbootcamp`
 
-Status of Python branches
--------------------------
-
-Moved to :ref:`versions`
-
-
 .. _contributing:
 
 Contributing
@@ -228,6 +222,11 @@ which includes all infrastructure used in the development of Python itself
 (e.g. mailing lists, issue trackers, GitHub, etc.).
 In general this means everyone is expected to be open, considerate, and
 respectful of others no matter what their position is within the project.
+
+Status of Python branches
+-------------------------
+
+Moved to :ref:`versions`
 
 .. _contents:
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

These "Moved to [another-page#another-anchor]" links are a convenience to avoid linkrot:

<img width="781" alt="image" src="https://user-images.githubusercontent.com/1324225/209578239-6bb01622-4baf-4c93-ae7a-b8060b63e2cf.png">

---

Like at https://devguide.python.org/documentation/start-documenting/#style-guide, let's put them at end of the page.

So when reading through a page, the reader is not disturbed by a notice that some content has moved.

---

Before: https://devguide.python.org/#status-of-python-branches

After: https://cpython-devguide--1015.org.readthedocs.build/#status-of-python-branches