### PR TITLE
Update `patchcheck` description

### DIFF
--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -254,10 +254,9 @@ through the common patch generation checks. To run ``patchcheck``:
 The automated patch checklist runs through:
 
 * Are there any whitespace problems in Python files?
-  (using ``Tools/scripts/reindent.py``)
+  (using ``Tools/patchcheck/reindent.py``)
 * Are there any whitespace problems in C files?
 * Are there any whitespace problems in the documentation?
-  (using ``Tools/scripts/reindent-rst.py``)
 * Has the documentation been updated?
 * Has the test suite been updated?
 * Has an entry under ``Misc/NEWS.d/next`` been added?

--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -254,7 +254,7 @@ through the common patch generation checks. To run ``patchcheck``:
 The automated patch checklist runs through:
 
 * Are there any whitespace problems in Python files?
-  (using ``Tools/patchcheck/reindent.py``)
+  (using :cpy-file:`Tools/patchcheck/reindent.py`)
 * Are there any whitespace problems in C files?
 * Are there any whitespace problems in the documentation?
 * Has the documentation been updated?

--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -249,7 +249,7 @@ through the common patch generation checks. To run ``patchcheck``:
 
    .. code-block:: dosbatch
 
-      python.bat Tools\scripts\patchcheck.py
+      python.bat Tools\patchcheck\patchcheck.py
 
 The automated patch checklist runs through:
 


### PR DESCRIPTION
`patchcheck.py`, `reindent.py` are moved from `Tools\scripts\` to `Tools\patchcheck\`
Ref: https://github.com/python/cpython/pull/98186

`reindent-rst.py` are deleted.
whitespaces in docs are handled by `patchcheck.py` itself
Ref: https://github.com/python/cpython/pull/97675

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->