### PR TITLE
Make clear who can add labels on GitHub

### DIFF
--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -5,7 +5,8 @@
 GitHub Labels
 =============
 
-We're using labels on GitHub to categorize issues and pull requests.
+Triagers, core developers and bots can add labels on GitHub
+to categorize issues and pull requests.
 Many labels are shared for both use cases, while some are dedicated
 only to one. Below is a possibly inexhaustive list, but it should get
 you going. For a full list, see `here <https://github.com/python/cpython/issues/labels>`_.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

There was a bit of confusion on a recent PR whether contributors can add labels to issues and PRs.

Let's make explicit that only triagers, core devs and bots can.