### PR TITLE
Overhaul Building the Documentation section for clarity

### DIFF
--- a/documentation/start-documenting.rst
+++ b/documentation/start-documenting.rst
@@ -103,7 +103,7 @@ before building the documentation.
 .. _using-make-make-bat:
 .. _doc-build-make:
 
-Build using Make / make.bat
+Build using make / make.bat
 ---------------------------
 
 A Unix ``Makefile`` is provided, :cpy-file:`Doc/Makefile`,
@@ -112,10 +112,10 @@ that attempts to emulate it as closely as practical.
 
 .. important::
 
-   The Windows ``make.bat`` batch file lacks a ``make venv`` target,
-   automatically installing any missing dependencies
-   into your current environment.
-   Make sure the environment you `created above <doc-create-venv-windows>`__
+   The Windows ``make.bat`` batch file lacks a ``make venv`` target.
+   Instead, it automatically installs any missing dependencies
+   into the currently activated environment (or the base Python, if none).
+   Make sure the environment you :ref:`created above <doc-create-venv-windows>`
    is `activated <venv-activate_>`__ before running ``make.bat``.
 
 To build the docs as HTML, run::
@@ -125,12 +125,12 @@ To build the docs as HTML, run::
 .. tip:: Substitute ``htmlview`` for ``html`` to open the docs in a web browser
          once the build completes.
 
-To check the docs for common errors with `sphinx-lint`_
+To check the docs for common errors with `Sphinx Lint`_
 (which is run on all :ref:`pull requests <pullrequest>`), use::
 
    make check
 
-To list other supported :program:`Make` targets for your platform, run::
+To list other supported :program:`make` targets, run::
 
    make help
 
@@ -146,7 +146,7 @@ Build using Sphinx directly
 Advanced users may want to invoke Sphinx directly,
 to pass specialized options or to handle specific use cases.
 
-First, ensure the environment you `created above <doc-create-venv-windows>`__
+Make sure the environment you :ref:`created above <doc-create-venv-windows>`
 is `activated <venv-activate_>`__.
 Then, install the documentation requirements, :cpy-file:`Doc/requirements.txt`.
 Using pip::
@@ -164,7 +164,7 @@ replace ``html`` above with the desired builder ``name``.
 .. _docutils: https://docutils.sourceforge.io/
 .. _Sphinx: https://www.sphinx-doc.org/
 .. _Sphinx builder: https://www.sphinx-doc.org/en/master/usage/builders/index.html
-.. _sphinx-lint: https://github.com/sphinx-contrib/sphinx-lint
+.. _Sphinx Lint: https://github.com/sphinx-contrib/sphinx-lint
 .. _venv-activate: https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#activating-a-virtual-environment
 .. _venv-create: https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment
 

--- a/documentation/start-documenting.rst
+++ b/documentation/start-documenting.rst
@@ -64,79 +64,109 @@ Building the documentation
 
 .. highlight:: bash
 
-The toolset used to build the docs is written in Python and is called Sphinx_.
-Sphinx is maintained separately and is not included in this tree.  Also needed
-are blurb_, a tool to create :file:`Misc/NEWS` on demand; and
-python-docs-theme_, the Sphinx theme for the Python documentation.
+To build the documentation, follow the steps in one of the sections below.
+You can view the documentation after building the HTML
+by opening the file :file:`Doc/build/html/index.html` in a web browser.
 
-To build the documentation, follow the instructions from one of the sections
-below.  You can view the documentation after building the HTML by pointing
-a browser at the file :file:`Doc/build/html/index.html`.
+.. note::
 
-You are expected to have installed the latest stable version of
-Sphinx_ and blurb_ on your system or in a virtualenv_ (which can be
-created using ``make venv``), so that the Makefile can find the
-``sphinx-build`` command.  You can also specify the location of
-``sphinx-build`` with the ``SPHINXBUILD`` :command:`make` variable.
+   The following instructions all assume your current working dir is
+   the ``Doc`` subdirectory in your :ref:`CPython repository clone <checkout>`.
+   Make sure to switch to it with ``cd Doc`` if necessary.
+
+
+.. _doc-create-venv:
+
+Create a virtual environment
+----------------------------
+
+.. _doc-create-venv-unix:
+
+**On Unix platforms** that support :program:`make`
+(including Linux, macOS and BSD),
+you can create a new :mod:`venv` with the required dependencies using::
+
+   make venv
+
+Building the docs with :program:`make` will automatically use this environment
+without you having to activate it.
+
+.. _doc-create-venv-windows:
+
+**On Windows**, or if not using :program:`make`,
+`create a new virtual environment <venv-create_>`__ manually.
+Always be sure to `activate this environment <venv-activate_>`__
+before building the documentation.
 
 
 .. _building-using-make:
+.. _using-make-make-bat:
+.. _doc-build-make:
 
-Using make / make.bat
----------------------
+Build using Make / make.bat
+---------------------------
 
-**On Unix**, run the following from the root of your :ref:`repository clone
-<checkout>` to build the output as HTML::
+A Unix ``Makefile`` is provided, :cpy-file:`Doc/Makefile`,
+along with a :cpy-file:`Doc/make.bat` batch file for Windows
+that attempts to emulate it as closely as practical.
 
-   cd Doc
-   make venv
+.. important::
+
+   The Windows ``make.bat`` batch file lacks a ``make venv`` target,
+   automatically installing any missing dependencies
+   into your current environment.
+   Make sure the environment you `created above <doc-create-venv-windows>`__
+   is `activated <venv-activate_>`__ before running ``make.bat``.
+
+To build the docs as HTML, run::
+
    make html
 
-or alternatively ``make -C Doc/ venv html``.  ``htmlview`` can be used
-instead of ``html`` to conveniently open the docs in a browser once the
-build completes.
+.. tip:: Substitute ``htmlview`` for ``html`` to open the docs in a web browser
+         once the build completes.
 
-You can also use ``make help`` to see a list of targets supported by
-:command:`make`.  Note that ``make check`` is automatically run when
-you submit a :ref:`pull request <pullrequest>`, so you should make
-sure that it runs without errors.
+To check the docs for common errors with `sphinx-lint`_
+(which is run on all :ref:`pull requests <pullrequest>`), use::
 
-**On Windows**, the :cpy-file:`Doc/make.bat` batchfile tries to emulate
-:command:`make` as closely as possible, but the venv target is not implemented,
-so you will probably want to make sure you are working in a virtual environment
-before proceeding, otherwise all dependencies will be automatically installed
-on your system.
+   make check
 
-When ready, run the following from the root of your :ref:`repository clone
-<checkout>` to build the output as HTML::
+To list other supported :program:`Make` targets for your platform, run::
 
-   cd Doc
-   make html
+   make help
 
-You can also use ``make help`` to see a list of targets supported by
-:cpy-file:`Doc/make.bat`.
+See :cpy-file:`Doc/README.rst` for more information.
 
-See also :cpy-file:`Doc/README.rst` for more information.
 
-Using sphinx-build
-------------------
+.. _using-sphinx-build:
+.. _doc-build-sphinx:
 
-Sometimes we directly want to execute the sphinx-build tool instead of through
-``make`` (although the latter is still the preferred way). In this case, you can
-use the following command line from the ``Doc`` directory (make sure to install
-Sphinx_, blurb_ and python-docs-theme_ packages from PyPI)::
+Build using Sphinx directly
+---------------------------
 
-   sphinx-build -b<builder> . build/<builder>
+Advanced users may want to invoke Sphinx directly,
+to pass specialized options or to handle specific use cases.
 
-where ``<builder>`` is one of html, text, latex, or htmlhelp (for explanations
-see the make targets above).
+First, ensure the environment you `created above <doc-create-venv-windows>`__
+is `activated <venv-activate_>`__.
+Then, install the documentation requirements, :cpy-file:`Doc/requirements.txt`.
+Using pip::
+
+   python -m pip install --upgrade -r requirements.txt
+
+Finally, directly invoke Sphinx with::
+
+   python -m sphinx -b html . build/html
+
+To use a different `Sphinx builder`_,
+replace ``html`` above with the desired builder ``name``.
 
 
 .. _docutils: https://docutils.sourceforge.io/
-.. _python-docs-theme: https://pypi.org/project/python-docs-theme/
 .. _Sphinx: https://www.sphinx-doc.org/
-.. _virtualenv: https://virtualenv.pypa.io/
-.. _blurb: https://pypi.org/project/blurb/
+.. _Sphinx builder: https://www.sphinx-doc.org/en/master/usage/builders/index.html
+.. _sphinx-lint: https://github.com/sphinx-contrib/sphinx-lint
+.. _venv-activate: https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#activating-a-virtual-environment
+.. _venv-create: https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment
 
 
 Style Guide


### PR DESCRIPTION
As discussed in #1037 , the [Building the documentation section](https://devguide.python.org/documentation/start-documenting/#building-the-documentation) is potentially confusing and difficult to follow to a new contributor (i.e. the primary target audience), as it lacks a clear, concrete, step by step structure, muddles minor or advanced details and elaboration with key basic information, and has some out of date information (sphinx-build, dependency names/versions, third-party virtualenv, etc), which also isn't in keeping with the [Diataxis principles for guides](https://diataxis.fr/how-to-guides/) like this.

Furthermore, as @peterjpxie mentioned, it manually lists certain dependencies and states that they are required to be installed no less than three times (including twice in the intro paragraph), which can naturally confuse the contributor into thinking they need to install such themselves first, which is instead handled for the user automatically with `make venv`/running `make.bat`, and should be installed via the `requirements.txt` rather than manually otherwise. Furthermore, it doesn't at least link to how to create and activate the necessary environment on Windows and non-make usage, nor state how to install the required dependencies or link to the canonical listing of them (in the `requirements.txt`).

Therefore, this overhauls the section to address the above issues, with the following major changes (not exhaustive):

* Eliminate repeated and inconsistent listings of required dependencies, and instead refer to the canonical `requirements.txt` when appropriate
* Put step by step commands into codeblocks, so they are easier to find, follow and copy accurately
* Factor out implementation details and highly specific information that merely distract the reader from the core guide content, and refer to the readme for that instead
* Add an admonition at the top stating that all commands assume a CWD of `Doc`, and the user should `cd` to it if not, instead of an inconstantly either repeating `cd Docs`, assuming it's been run, or assuming the opposite.
* Instead of just an offhand link to the third-party `virtualenv` package, include a short section explicitly stating how to create a venv with the Makefile, or otherwise, linking to the [up-to-date section in the PyPUG](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) describing venv creation and activation, and more explicitly remind Windows users they need to manually activate it.
* Factor out the distinction between the Makefile and `make.bat` into the above section, making the actual Build with make/make.bat section work the same on *nix and Windows
* Revise the "sphinx-build" section to state how to install the requirements from the `requirements.txt` (instead of manually listing them yet again), and follow modern best practices with the invocation.

Fixes #1037