### PR TITLE
Don't force table widths in versions.rst

### DIFF
--- a/versions.rst
+++ b/versions.rst
@@ -23,7 +23,7 @@ Dates shown in *italic* are scheduled and can be adjusted.
 
 .. csv-table::
    :header-rows: 1
-   :widths: 5, 5, 15, 15, 12, 40
+   :width: 100%
    :file: include/branches.csv
 
 .. Remember to update main branch in the paragraph above too
@@ -34,7 +34,7 @@ Unsupported Versions
 
 .. csv-table::
    :header-rows: 1
-   :widths: 5, 5, 15, 15, 12, 40
+   :width: 100%
    :file: include/end-of-life.csv
 
 


### PR DESCRIPTION
Setting `:widths:` leads to weird wrapping, as some columns are too narrow. Just letting Sphinx figure it out, OTOH, looks fine. Let the software be smart.

Signed-off-by: FeRD (Frank Dana) <ferdnyc@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->