### PR TITLE
Use sphinx-notfound-page to create a 404 page matching the theme

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -7,6 +7,7 @@ sys.path.insert(0, os.path.abspath(".") + "/_extensions")
 
 extensions = [
     'custom_roles',
+    'notfound.extension',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx_copybutton',
@@ -139,6 +140,9 @@ intersphinx_mapping = {
 }
 
 todo_include_todos = True
+
+# sphinx-notfound-page
+notfound_urls_prefix = "/"
 
 # sphinxext-opengraph config
 ogp_site_url = "https://devguide.python.org/"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Sphinx==6.1.3
 furo>=2022.6.4
 jinja2
 sphinx-lint==0.6.7
+sphinx-notfound-page
 sphinx_copybutton>=0.3.3
 sphinxext-opengraph>=0.7.1
 sphinxext-rediraffe


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Use https://github.com/readthedocs/sphinx-notfound-page to create a 404 page with our theme, and also menu, so users can hopefully find their way more easily.

Docs: https://sphinx-notfound-page.readthedocs.io/


# Before

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/1324225/216434971-b6494881-cba8-4f6c-a724-bbd56eb7ffb0.png">

https://devguide.python.org/bleep-bloop

# After

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/1324225/217310336-2cd1fd48-e0fc-4214-b056-770913c07d73.png">

https://cpython-devguide--1042.org.readthedocs.build/bleep-bloop
