### PR TITLE
Restore `#what-s-new-and-news-entries` anchor

### DIFF
--- a/core-developers/committing.rst
+++ b/core-developers/committing.rst
@@ -74,8 +74,8 @@ to enter the public source tree. Ask yourself the following questions:
    be added as well. Changes that affect only documentation generally do not
    require a ``NEWS`` entry. (See the following section for more information.)
 
-
 .. _news-entry:
+.. _what-s-new-and-news-entries:
 
 Updating NEWS and What's New in Python
 --------------------------------------


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Used at least on https://blurb-it.herokuapp.com/: 

> [add a blurb](https://devguide.python.org/committing/#what-s-new-and-news-entries) to CPython pull request.
