### PR TITLE
Update gdb & Victor's guide links, and fix voters link ignore

### DIFF
--- a/advanced-tools/gdb.rst
+++ b/advanced-tools/gdb.rst
@@ -21,7 +21,7 @@ GDB 7 and later
 ===============
 
 In gdb 7, support for `extending gdb with Python
-<https://sourceware.org/gdb/current/onlinedocs/gdb/Python.html#Python>`_ was
+<https://sourceware.org/gdb/onlinedocs/gdb/Python.html#Python>`_ was
 added. When CPython is built you will notice a ``python-gdb.py`` file in the
 root directory of your checkout. Read the module docstring for details on how
 to use the file to enhance gdb for easier debugging of a CPython process.

--- a/advanced-tools/gdb.rst
+++ b/advanced-tools/gdb.rst
@@ -21,7 +21,7 @@ GDB 7 and later
 ===============
 
 In gdb 7, support for `extending gdb with Python
-<https://sourceware.org/gdb/onlinedocs/gdb/Python.html#Python>`_ was
+<https://sourceware.org/gdb/onlinedocs/gdb/Python.html>`_ was
 added. When CPython is built you will notice a ``python-gdb.py`` file in the
 root directory of your checkout. Read the module docstring for details on how
 to use the file to enhance gdb for easier debugging of a CPython process.

--- a/conf.py
+++ b/conf.py
@@ -81,7 +81,7 @@ linkcheck_anchors_ignore = [
 
 linkcheck_ignore = [
     # The voters repo is private and appears as a 404
-    'https://github.com/python/voters/',
+    'https://github.com/python/voters',
     # The python-core team link is private, redirects to login
     'https://github.com/orgs/python/teams/python-core',
     # The Discourse groups are private unless you are logged in

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -314,7 +314,7 @@ You can run the build of Python you've compiled with:
 See the `PCBuild readme`_ for more details on what other software is necessary
 and how to build.
 
-.. _Victor Stinner's guide: https://cpython-core-tutorial.readthedocs.io/en/latest/build_cpython_windows.html
+.. _Victor Stinner's guide: https://web.archive.org/web/20220907075854/https://cpython-core-tutorial.readthedocs.io/en/latest/build_cpython_windows.html
 .. _Visual Studio: https://visualstudio.microsoft.com/
 .. _PCBuild readme: https://github.com/python/cpython/blob/main/PCbuild/readme.txt
 .. _Git for Windows download from the official Git website: https://git-scm.com/download/win


### PR DESCRIPTION
Fixes #1044

## Changes Made 

1.   In ``advanced-tools/gdb.rst`` there was a broken link under the topic of [GDB 7 and later](https://devguide.python.org/advanced-tools/gdb/#gdb-7-and-later) which was named as _extending gdb with Python_ ``https://sourceware.org/gdb/current/onlinedocs/gdb/Python.html#Python`` which has now been replaced by the following link ``https://sourceware.org/gdb/onlinedocs/gdb/Python.html``

2. In ``conf.py`` there was a _slash_  at the end of the link ``https://github.com/python/voters/`` which made this link broken and this issue has been resolved by removing the _slash_ from the end of the link ``https://github.com/python/voters``