### PR TITLE
Update instructions for building on macOS

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -413,14 +413,13 @@ Apple no longer provides header files for the deprecated system version of
 OpenSSL which means that you will not be able to build the ``_ssl`` extension.
 One solution is to install these libraries from a third-party package
 manager, like Homebrew_ or MacPorts_, and then add the appropriate paths
-for the header and library files to your ``configure`` command.  For example,
-with **Homebrew**,
+for the header and library files to your ``configure`` command.
 
-For Python 3.10 and newer::
+For example, with **Homebrew**, install the dependencies::
 
     $ brew install pkg-config openssl xz gdbm tcl-tk
 
-and ``configure``::
+Then, for Python 3.10 and newer::
 
     $ CFLAGS="-I$(brew --prefix gdbm)/include -I$(brew --prefix xz)/include" \
       LDFLAGS="-L$(brew --prefix gdbm)/lib -I$(brew --prefix xz)/lib" \
@@ -428,11 +427,7 @@ and ``configure``::
                   --with-openssl="$(brew --prefix openssl)"
 
 
-For Python versions 3.9 through 3.7::
-
-    $ brew install pkg-config openssl@1.1 xz gdbm tcl-tk
-
-and ``configure``::
+For Python 3.7 through 3.9::
 
     $ export PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig"; \
       CFLAGS="-I$(brew --prefix gdbm)/include -I$(brew --prefix xz)/include" \

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -414,16 +414,16 @@ OpenSSL which means that you will not be able to build the ``_ssl`` extension.
 One solution is to install these libraries from a third-party package
 manager, like Homebrew_ or MacPorts_, and then add the appropriate paths
 for the header and library files to your ``configure`` command.  For example,
-
-with **Homebrew**::
+with **Homebrew**,
 
 For Python 3.10 and newer::
 
     $ brew install pkg-config openssl xz gdbm tcl-tk
 
+and ``configure``::
+
     $ CFLAGS="-I$(brew --prefix gdbm)/include -I$(brew --prefix xz)/include" \
       LDFLAGS="-L$(brew --prefix gdbm)/lib -I$(brew --prefix xz)/lib" \
-      PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig" \
       ./configure --with-pydebug \
                   --with-openssl="$(brew --prefix openssl)"
 
@@ -431,6 +431,8 @@ For Python 3.10 and newer::
 For Python versions 3.9 through 3.7::
 
     $ brew install pkg-config openssl@1.1 xz gdbm tcl-tk
+
+and ``configure``::
 
     $ export PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig"; \
       CFLAGS="-I$(brew --prefix gdbm)/include -I$(brew --prefix xz)/include" \

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -419,7 +419,7 @@ For example, with **Homebrew**, install the dependencies::
 
     $ brew install pkg-config openssl@1.1 xz gdbm tcl-tk
 
-Then, for Python 3.10 and newer::
+Then, for Python 3.10 and newer, run ``configure``::
 
     $ CFLAGS="-I$(brew --prefix gdbm)/include -I$(brew --prefix xz)/include" \
       LDFLAGS="-L$(brew --prefix gdbm)/lib -I$(brew --prefix xz)/lib" \
@@ -438,11 +438,11 @@ Or, for Python 3.7 through 3.9::
               --with-tcltk-libs="$(pkg-config --libs tcl tk)" \
               --with-tcltk-includes="$(pkg-config --cflags tcl tk)"
 
-and ``make``::
+And finally, run ``make``::
 
     $ make -s -j2
 
-or **MacPorts**::
+Alternatively, with **MacPorts**::
 
     $ sudo port install pkgconfig openssl xz gdbm
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -427,7 +427,7 @@ Then, for Python 3.10 and newer::
                   --with-openssl="$(brew --prefix openssl@1.1)"
 
 
-For Python 3.7 through 3.9::
+Or, for Python 3.7 through 3.9::
 
     $ export PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig"; \
       CFLAGS="-I$(brew --prefix gdbm)/include -I$(brew --prefix xz)/include" \

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -417,14 +417,14 @@ for the header and library files to your ``configure`` command.
 
 For example, with **Homebrew**, install the dependencies::
 
-    $ brew install pkg-config openssl xz gdbm tcl-tk
+    $ brew install pkg-config openssl@1.1 xz gdbm tcl-tk
 
 Then, for Python 3.10 and newer::
 
     $ CFLAGS="-I$(brew --prefix gdbm)/include -I$(brew --prefix xz)/include" \
       LDFLAGS="-L$(brew --prefix gdbm)/lib -I$(brew --prefix xz)/lib" \
       ./configure --with-pydebug \
-                  --with-openssl="$(brew --prefix openssl)"
+                  --with-openssl="$(brew --prefix openssl@1.1)"
 
 
 For Python 3.7 through 3.9::

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -417,24 +417,26 @@ for the header and library files to your ``configure`` command.  For example,
 
 with **Homebrew**::
 
-    $ brew install pkg-config openssl@1.1 xz gdbm tcl-tk
-
 For Python 3.10 and newer::
+
+    $ brew install pkg-config openssl xz gdbm tcl-tk
 
     $ CFLAGS="-I$(brew --prefix gdbm)/include -I$(brew --prefix xz)/include" \
       LDFLAGS="-L$(brew --prefix gdbm)/lib -I$(brew --prefix xz)/lib" \
       PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig" \
       ./configure --with-pydebug \
-                  --with-openssl=$(brew --prefix openssl)
+                  --with-openssl="$(brew --prefix openssl)"
 
 
 For Python versions 3.9 through 3.7::
 
-    $ CFLAGS="-I$(brew --prefix gdbm)/include -I$(brew --prefix xz)/include" \
+    $ brew install pkg-config openssl@1.1 xz gdbm tcl-tk
+
+    $ export PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig"; \
+      CFLAGS="-I$(brew --prefix gdbm)/include -I$(brew --prefix xz)/include" \
       LDFLAGS="-L$(brew --prefix gdbm)/lib -L$(brew --prefix xz)/lib" \
-      PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig" \
       ./configure --with-pydebug \
-              --with-openssl=$(brew --prefix openssl@1.1) \
+              --with-openssl="$(brew --prefix openssl@1.1)" \
               --with-tcltk-libs="$(pkg-config --libs tcl tk)" \
               --with-tcltk-includes="$(pkg-config --cflags tcl tk)"
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -423,6 +423,7 @@ Then, for Python 3.10 and newer::
 
     $ CFLAGS="-I$(brew --prefix gdbm)/include -I$(brew --prefix xz)/include" \
       LDFLAGS="-L$(brew --prefix gdbm)/lib -I$(brew --prefix xz)/lib" \
+      PKG_CONFIG_PATH="$(brew --prefix tcl-tk)/lib/pkgconfig" \
       ./configure --with-pydebug \
                   --with-openssl="$(brew --prefix openssl@1.1)"
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

1. Update the command for building Python 3.7 through 3.9 by exporting `PKG_CONFIG_PATH` so `pkg-config` can find `tcl` and `tk`
2. Instruct users on installing `openssl` with `brew` for building Python 3.10

Fixes: #1049

Signed-off-by: César Román <thecesrom@gmail.com>