### PR TITLE
Add Android platform to the experts list

### DIFF
--- a/core-developers/experts.rst
+++ b/core-developers/experts.rst
@@ -297,6 +297,7 @@ Platforms
 Platform              Maintainers
 ===================   ===========
 AIX                   David.Edelsohn^
+Android
 Cygwin                jlt63^, stutzbach^
 FreeBSD
 HP-UX


### PR DESCRIPTION
We support Android, as best-effort, I believe. I don't think we have anyone leading it though, right?