### PR TITLE
Append a hash ?digest to CSS files for cache-busting

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -34,7 +34,7 @@ exclude_patterns = [
     '.github',
 ]
 
-def _asset_hash(path: str) -> str:
+def _asset_hash(path: os.PathLike[str]) -> str:
     """Append a `?digest=` to an url based on the file content."""
     full_path = (Path(html_static_path[0]) / path).resolve()
     digest = hashlib.sha1(full_path.read_bytes()).hexdigest()

--- a/conf.py
+++ b/conf.py
@@ -1,6 +1,8 @@
+import hashlib
 import os
 import sys
 import time
+from pathlib import Path
 
 # Location of custom extensions.
 sys.path.insert(0, os.path.abspath(".") + "/_extensions")
@@ -32,6 +34,14 @@ exclude_patterns = [
     '.github',
 ]
 
+def _asset_hash(path: str) -> str:
+    """Append a `?digest=` to an url based on the file content."""
+    full_path = (Path(html_static_path[0]) / path).resolve()
+    digest = hashlib.sha1(full_path.read_bytes()).hexdigest()
+
+    return f"{path}?digest={digest}"
+
+
 html_theme = 'furo'
 html_theme_options = {
     "source_repository": "https://github.com/python/devguide",
@@ -39,7 +49,7 @@ html_theme_options = {
 }
 html_static_path = ['_static']
 html_css_files = [
-    'devguide_overrides.css',
+    _asset_hash('devguide_overrides.css'),
 ]
 html_logo = "_static/python-logo.svg"
 html_favicon = "_static/favicon.png"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
Similar to https://github.com/python/python-docs-theme/pull/108.

Fix the problems we saw at https://github.com/python/devguide/pull/1034#issuecomment-1411782361 when the CSS file changed but browsers kept the old version cached for 24 hours.

Append a `?digest=hash` to the end of the `pydoctheme.css`, computed from the file contents, so when a new CSS file is deployed, the old one is no longer used from the browser cache.

For example:

`<link rel="stylesheet" type="text/css" href="_static/devguide_overrides.css?digest=951d6a16b747d96c03796069dbeb516764307ae2" />`

This is based on how @pradyunsg's Furo theme does it:

https://github.com/pradyunsg/furo/blob/193643fdb6787501195555244f4a9e953ef544bb/src/furo/__init__.py#L149-L161

Thanks @pradyunsg!

# Demo

View the source of pages at https://cpython-devguide--1054.org.readthedocs.build/.

Furo's css already has a digest, this PR adds it to `devguide_overrides.css`.

Check the colours load in the EOL chart at https://cpython-devguide--1054.org.readthedocs.build/versions/