### PR TITLE
Added link of Python Developer Roadmap

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ The CPython Developer's Guide
 This guide covers how to contribute to CPython. It is known by the
 nickname of "the devguide" by the Python core developers.
 
-The official home of this guide is https://devguide.python.org.
+The official home of this guide is https://devguide.python.org and if you want to have a structured roadmap to Python then do visit [Python Developer Roadmap](https://roadmap.sh/python).
 
 Compilation
 -----------


### PR DESCRIPTION
Hi,

I came across your repository [devguide](https://github.com/python/devguide) and found it to be a valuable resource for Python enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["Python Developer Roadmap"](https://roadmap.sh/python). I took the initiative to submit a ["Pull Request"](https://github.com/python/devguide/pull/1055) adding it.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz