### PR TITLE
Automatically edit PRs with link to RTD preview

### DIFF
--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -1,0 +1,17 @@
+name: Read the Docs PR preview
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "cpython-devguide"
+          single-version: "true"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Once merged, this will automatically add a docs preview link to PRs.

> GitHub Action that automatically edits Pull Requests' descriptions with a link to documentation's preview on Read the Docs.

https://github.com/readthedocs/actions/tree/v1/preview

For example: https://github.com/python/docs-community/pull/75