### PR TITLE
Add experts for runtime lifecycle management

### DIFF
--- a/core-developers/experts.rst
+++ b/core-developers/experts.rst
@@ -356,6 +356,7 @@ py3 transition      benjaminp
 release management  tarekziade, malemburg, benjaminp, warsaw,
                     gvanrossum, anthonybaxter^, merwok, ned-deily,
                     birkenfeld, JulienPalard
+runtime lifecycle   ericsnowcurrently, kumaraditya303
 str.format          ericvsmith*
 subinterpreters     ericsnowcurrently, kumaraditya303
 testing             voidspace, ezio-melotti

--- a/core-developers/experts.rst
+++ b/core-developers/experts.rst
@@ -356,7 +356,7 @@ py3 transition      benjaminp
 release management  tarekziade, malemburg, benjaminp, warsaw,
                     gvanrossum, anthonybaxter^, merwok, ned-deily,
                     birkenfeld, JulienPalard
-runtime lifecycle   ericsnowcurrently, kumaraditya303
+runtime lifecycle   ericsnowcurrently, kumaraditya303, zooba
 str.format          ericvsmith*
 subinterpreters     ericsnowcurrently, kumaraditya303
 testing             voidspace, ezio-melotti


### PR DESCRIPTION
This includes things like https://github.com/python/cpython/pull/102222 which currently does not has an obvious expert entry. 

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1068.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->