### PR TITLE
Python 3.10 now only accepts security fixes

### DIFF
--- a/include/release-cycle.json
+++ b/include/release-cycle.json
@@ -18,7 +18,7 @@
   "3.10": {
     "branch": "3.10",
     "pep": 619,
-    "status": "bugfix",
+    "status": "security",
     "first_release": "2021-10-04",
     "end_of_life": "2026-10",
     "release_manager": "Pablo Galindo Salgado"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Python 3.10.11 has been released.

> The final regular bugfix release for Python 3.10! It is now entering security-fix-only mode. This also means this is the last version for which we will ship Windows and macOS installers. If you rely on these binary releases, it’s time to upgrade to Python 3.11.


https://discuss.python.org/t/python-3-11-3-3-10-11-and-3-12-0-alpha-7-released/25481?u=hugovk
