### PR TITLE
Rename expert labels to topic labels

### DIFF
--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -64,6 +64,7 @@ and :gh-label:`OS-freebsd`.
 
 
 .. _Expert labels:
+.. _Topic labels:
 
 Topic labels
 ============

--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -68,7 +68,7 @@ and :gh-label:`OS-freebsd`.
 Topic labels
 ============
 
-These labels are used to specify the area of expertise required to address
+These labels are used to denote the specific topic area, if any, of
 the issue/PR.  This includes both specific modules/packages and generic
 interest areas.
 

--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -54,9 +54,10 @@ These labels are mostly used to specify which :ref:`part of the codebase
   (written in Python) and other changes related to tests, :mod:`unittest`,
   or :mod:`doctest`.
 
+.. _Expert labels:
 
-Expert labels
-=============
+Topic labels
+============
 
 These labels are used to specify the area of expertise required to address
 the issue/PR.  This includes both specific modules/packages and generic
@@ -66,8 +67,8 @@ Adding these labels is also a way to notify the relevant experts, since
 they are encouraged to subscribe to them.  Depending on the label,
 this might also automatically add the issue to a GitHub project.
 
-You can see the `full list of expert labels on GitHub
-<https://github.com/python/cpython/labels?q=expert>`_.
+You can see the `full list of topic labels on GitHub
+<https://github.com/python/cpython/labels?q=topic>`_.
 
 
 OS labels

--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -54,6 +54,15 @@ These labels are mostly used to specify which :ref:`part of the codebase
   (written in Python) and other changes related to tests, :mod:`unittest`,
   or :mod:`doctest`.
 
+OS labels
+=========
+
+These labels are used to specify which operating systems are affected.
+Since most issues either affect all systems or are specific to Unix,
+the only available labels are :gh-label:`OS-windows`, :gh-label:`OS-mac`,
+and :gh-label:`OS-freebsd`.
+
+
 .. _Expert labels:
 
 Topic labels
@@ -69,15 +78,6 @@ this might also automatically add the issue to a GitHub project.
 
 You can see the `full list of topic labels on GitHub
 <https://github.com/python/cpython/labels?q=topic>`_.
-
-
-OS labels
-=========
-
-These labels are used to specify which operating systems are affected.
-Since most issues either affect all systems or are specific to Unix,
-the only available labels are :gh-label:`OS-windows`, :gh-label:`OS-mac`,
-and :gh-label:`OS-freebsd`.
 
 
 Version labels


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
For https://github.com/python/core-workflow/issues/450.

To merge once labels are renamed for https://github.com/python/core-workflow/issues/450#issuecomment-1509743345.

New name and anchor:

* https://cpython-devguide--1076.org.readthedocs.build/triage/labels/#topic-labels

Keep the old anchor pointing to the same bit:

* https://cpython-devguide--1076.org.readthedocs.build/triage/labels/#expert-labels


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1076.org.readthedocs.build

<!-- readthedocs-preview cpython-devguide end -->