### PR TITLE
Don't suggest to start build with infinite number of threads

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -29,7 +29,7 @@ instructions please see the :ref:`setup guide <setup>`.
 
 3. Build Python, on UNIX and macOS use::
 
-      ./configure --with-pydebug && make -j
+      ./configure --with-pydebug && make -j4
 
    and on Windows use:
 


### PR DESCRIPTION
Hi.

Just a small enhancement proposal, as I don't think calling `make` with unbounded number of threads is desirable.

Using `make -j` will start "infinite" number of jobs according to `make` docs, which slows down the build and consumes too many resources.

Suggesting `make -j4` seems to be a sane default, advanced users will know how to adjust it.

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1087.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->