### PR TITLE
Experts Index: Remove deleted modules

### DIFF
--- a/core-developers/experts.rst
+++ b/core-developers/experts.rst
@@ -61,15 +61,12 @@ aifc                  bitdancer
 argparse
 array
 ast                   benjaminp, pablogsal, isidentical
-asynchat              josiahcarlson, giampaolo*, stutzbach^
 asyncio               1st1, asvetlov, gvanrossum, graingert, kumaraditya303, willingc
-asyncore              josiahcarlson, giampaolo*, stutzbach^
 atexit
 audioop               serhiy-storchaka
 base64
 bdb
 binascii
-binhex
 bisect                rhettinger*
 builtins
 bz2
@@ -135,7 +132,6 @@ idlelib               kbkaiser (inactive), terryjreedy*, serwy (inactive),
                       taleinat
 imaplib
 imghdr
-imp
 importlib             brettcannon
 inspect               1st1
 io                    benjaminp, stutzbach^
@@ -205,7 +201,6 @@ shlex
 shutil                tarekziade, giampaolo
 signal                gpshead
 site
-smtpd                 giampaolo
 smtplib
 sndhdr
 socket                gpshead
@@ -220,7 +215,6 @@ stringprep
 struct                mdickinson, meadori
 subprocess            astrand^ (inactive), giampaolo, gpshead*
 sunau
-symbol
 symtable              benjaminp
 sys
 sysconfig             FFY00

--- a/core-developers/experts.rst
+++ b/core-developers/experts.rst
@@ -112,7 +112,6 @@ fcntl                 Yhg1s
 filecmp
 fileinput
 fnmatch
-formatter
 fractions             mdickinson
 ftplib                giampaolo*
 functools             rhettinger*


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

* `asynchat`, `asyncore` and `smtpd` were removed in 3.12 by PEP 594 "Removing dead batteries from the standard library" https://peps.python.org/pep-0594/#deprecated-modules

* `binhex` was removed in 3.11 https://github.com/python/cpython/issues/89248

* `formatter` was removed in 3.10 https://github.com/python/cpython/issues/86465

* `imp` was removed in 3.12 https://github.com/python/cpython/pull/98573

* `symbol` was removed in 3.10 https://github.com/python/cpython/issues/85111

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1088.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->