### PR TITLE
Update communication-channels.rst

### DIFF
--- a/developer-workflow/communication-channels.rst
+++ b/developer-workflow/communication-channels.rst
@@ -252,7 +252,7 @@ Additional Repositories
 
 `Python Core Workflow`_ hosts the codebase for tools such as `blurb`_.
 
-Other Core Workflows can be found here:
+Other Core Workflows are:
 
 * `cherry_picker`_
 * `bedevere`_

--- a/developer-workflow/communication-channels.rst
+++ b/developer-workflow/communication-channels.rst
@@ -254,7 +254,7 @@ Additional Repositories
 
 Other core workflow tools are:
 
-* `cherry_picker`_
+* `cherry_picker`_ (`PyPI`_)
 * `bedevere`_
 * `blurb_it`_
 * `miss-islington`_
@@ -266,7 +266,8 @@ source of benchmarks for all Python implementations.
 
 .. _Python Core Workflow: https://github.com/python/core-workflow
 .. _blurb: https://pypi.org/project/blurb
-.. _cherry_picker: https://pypi.org/project/cherry_picker/
+.. _cherry_picker: https://github.com/python/cherry-picker
+.. _PyPI: https://pypi.org/project/cherry_picker/
 .. _bedevere: https://github.com/python/bedevere
 .. _blurb_it: https://github.com/python/blurb_it
 .. _miss-islington: https://github.com/python/miss-islington

--- a/developer-workflow/communication-channels.rst
+++ b/developer-workflow/communication-channels.rst
@@ -252,9 +252,24 @@ Additional Repositories
 
 `Python Core Workflow`_ hosts the codebase for tools such as `blurb`_.
 
+Other Core Workflows can be found here:
+
+* `cherry_picker`_
+* `bedevere`_
+* `blurb_it`_
+* `miss-islington`_
+* `cla_bot`_
+* `cpython-emailer-webhook`_
+
 Python `Performance Benchmark`_ project is intended to be an authoritative
 source of benchmarks for all Python implementations.
 
 .. _Python Core Workflow: https://github.com/python/core-workflow
 .. _blurb: https://pypi.org/project/blurb
+.. _cherry_picker: https://pypi.org/project/cherry_picker/
+.. _bedevere: https://github.com/python/bedevere
+.. _blurb_it: https://github.com/python/blurb_it
+.. _miss-islington: https://github.com/python/miss-islington
+.. _cla_bot: https://github.com/ambv/cla-bot
+.. _cpython-emailer-webhook: https://github.com/berkerpeksag/cpython-emailer-webhook
 .. _Performance Benchmark: https://github.com/python/pyperformance

--- a/developer-workflow/communication-channels.rst
+++ b/developer-workflow/communication-channels.rst
@@ -271,6 +271,6 @@ source of benchmarks for all Python implementations.
 .. _bedevere: https://github.com/python/bedevere
 .. _blurb_it: https://github.com/python/blurb_it
 .. _miss-islington: https://github.com/python/miss-islington
-.. _cla_bot: https://github.com/ambv/cla-bot
+.. _cla-bot: https://github.com/ambv/cla-bot
 .. _cpython-emailer-webhook: https://github.com/berkerpeksag/cpython-emailer-webhook
 .. _Performance Benchmark: https://github.com/python/pyperformance

--- a/developer-workflow/communication-channels.rst
+++ b/developer-workflow/communication-channels.rst
@@ -258,7 +258,7 @@ Other core workflow tools are:
 * `bedevere`_
 * `blurb_it`_
 * `miss-islington`_
-* `cla_bot`_
+* `cla-bot`_
 * `cpython-emailer-webhook`_
 
 Python `Performance Benchmark`_ project is intended to be an authoritative

--- a/developer-workflow/communication-channels.rst
+++ b/developer-workflow/communication-channels.rst
@@ -252,7 +252,7 @@ Additional Repositories
 
 `Python Core Workflow`_ hosts the codebase for tools such as `blurb`_.
 
-Other Core Workflows are:
+Other core workflow tools are:
 
 * `cherry_picker`_
 * `bedevere`_

--- a/developer-workflow/communication-channels.rst
+++ b/developer-workflow/communication-channels.rst
@@ -250,13 +250,11 @@ order to make open source pleasant for everyone involved.
 Additional Repositories
 =======================
 
-`Python Core Workflow`_ hosts the codebase for tools such as `cherry_picker`_
-and `blurb`_.
+`Python Core Workflow`_ hosts the codebase for tools such as `blurb`_.
 
 Python `Performance Benchmark`_ project is intended to be an authoritative
 source of benchmarks for all Python implementations.
 
 .. _Python Core Workflow: https://github.com/python/core-workflow
-.. _cherry_picker: https://pypi.org/project/cherry_picker/
 .. _blurb: https://pypi.org/project/blurb
 .. _Performance Benchmark: https://github.com/python/pyperformance


### PR DESCRIPTION
Removed `cherry_picker` from the "Additional Repositories" section under "Following Python's Development" as its been moved to its own repository according to issue #1093


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1094.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->