### PR TITLE
Replace deprecated utcnow() with now(UTC)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,6 @@ The official home of this guide is https://devguide.python.org.
 Compilation
 -----------
 
-For the compilation of the devguide, you need to use a version of Python which
-supports the ``venv`` module, because the ``make html`` command will create a
-virtual environment and will install the ``Sphinx`` package::
+For the compilation of the devguide, Python 3.11+ is needed::
 
     make html

--- a/_tools/generate_release_cycle.py
+++ b/_tools/generate_release_cycle.py
@@ -44,7 +44,7 @@ class Versions:
 
     def write_csv(self) -> None:
         """Output CSV files."""
-        now_str = str(dt.datetime.utcnow())
+        now_str = str(dt.datetime.now(dt.UTC))
 
         versions_by_category = {"branches": {}, "end-of-life": {}}
         headers = None


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
`datetime.datetime.utcnow` raises a deprecation warning in Python 3.12: https://github.com/python/cpython/issues/103857.

`datetime.UTC` is new in 3.11, and is an alias of `datetime.timezone.utc`, but I think we're fine requiring 3.11+ here.

https://docs.python.org/3/library/datetime.html#datetime.UTC


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1097.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->