### PR TITLE
Python 3.13 is now main

### DIFF
--- a/_static/devguide_overrides.css
+++ b/_static/devguide_overrides.css
@@ -69,6 +69,11 @@
     stroke: #008844;
 }
 
+.release-cycle-chart .release-cycle-blob.release-cycle-blob-prerelease {
+    fill: teal;
+    stroke: darkgreen;
+}
+
 .release-cycle-chart .release-cycle-blob.release-cycle-blob-feature {
     fill: #2222EE;
     stroke: #008888;

--- a/include/release-cycle.json
+++ b/include/release-cycle.json
@@ -10,7 +10,7 @@
   "3.12": {
     "branch": "3.12",
     "pep": 693,
-    "status": "feature",
+    "status": "bugfix",
     "first_release": "2023-10-02",
     "end_of_life": "2028-10",
     "release_manager": "Thomas Wouters"

--- a/include/release-cycle.json
+++ b/include/release-cycle.json
@@ -10,7 +10,7 @@
   "3.12": {
     "branch": "3.12",
     "pep": 693,
-    "status": "bugfix",
+    "status": "prerelease",
     "first_release": "2023-10-02",
     "end_of_life": "2028-10",
     "release_manager": "Thomas Wouters"

--- a/include/release-cycle.json
+++ b/include/release-cycle.json
@@ -1,6 +1,14 @@
 {
-  "3.12": {
+  "3.13": {
     "branch": "main",
+    "pep": 693,
+    "status": "feature",
+    "first_release": "2024-10-07",
+    "end_of_life": "2029-10",
+    "release_manager": "Thomas Wouters"
+  },
+  "3.12": {
+    "branch": "3.12",
     "pep": 693,
     "status": "feature",
     "first_release": "2023-10-02",

--- a/versions.rst
+++ b/versions.rst
@@ -5,7 +5,7 @@
 Status of Python Versions
 =========================
 
-The main branch is currently the future Python 3.12, and is the only
+The ``main`` branch is currently the future Python 3.13, and is the only
 branch that accepts new features.  The latest release for each Python
 version can be found on the `download page <https://www.python.org/downloads/>`_.
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

We don't have a PEP for 3.13 yet, so I left it pointing to the 3.12 PEP for now.

For first release, I put the first Monday in October 2024. We can adjust when we know the real date.

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1099.org.readthedocs.build/versions/

<!-- readthedocs-preview cpython-devguide end -->