### PR TITLE
Maintain support for pre-Python 3.11

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,9 +21,9 @@ nickname of "the devguide" by the Python core developers.
 
 The official home of this guide is https://devguide.python.org.
 
-Compilation
+Render HTML
 -----------
 
-For the compilation of the devguide::
+To render the devguide to HTML under ``_build/html``, run::
 
     make html

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,6 @@ The official home of this guide is https://devguide.python.org.
 Compilation
 -----------
 
-For the compilation of the devguide, Python 3.11+ is needed::
+For the compilation of the devguide::
 
     make html

--- a/_tools/generate_release_cycle.py
+++ b/_tools/generate_release_cycle.py
@@ -5,6 +5,7 @@ import argparse
 import csv
 import datetime as dt
 import json
+import sys
 
 import jinja2
 
@@ -44,7 +45,10 @@ class Versions:
 
     def write_csv(self) -> None:
         """Output CSV files."""
-        now_str = str(dt.datetime.now(dt.UTC))
+        if sys.version_info >= (3, 11):
+            now_str = str(dt.datetime.now(dt.UTC))
+        else:
+            now_str = str(dt.datetime.utcnow())
 
         versions_by_category = {"branches": {}, "end-of-life": {}}
         headers = None


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Re: https://github.com/python/devguide/pull/1097#issuecomment-1574641062

Let's maintain support for Python versions earlier than 3.11.

Done as an `if/else` rather than a long ternary, as tools like pyupgrade can automatically remove the old code when the time comes.

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1107.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->