### PR TITLE
Rewrite 'Regenerating configure' section of building guide

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -490,7 +490,7 @@ using GNU Autoconf.
 After editing :file:`configure.ac`, run ``make regen-configure`` to generate
 :file:`configure`, :cpy-file:`pyconfig.h.in`, and :cpy-file:`aclocal.m4`.
 When submitting a patch with changes made to :file:`configure.ac`,
-you must also regenerate these files.
+you must also include the changes in these generated files.
 
 The recommended and by far the easiest way to regenerate :file:`configure` is:
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -483,24 +483,30 @@ Regenerate ``configure``
 
 If a change is made to Python which relies on some POSIX system-specific
 functionality (such as using a new system call), it is necessary to update the
-:file:`configure` script to test for availability of the functionality.
-Python's :file:`configure` script is generated from :file:`configure.ac`
+:cpy-file:`configure` script to test for availability of the functionality.
+Python's :file:`configure` script is generated from :cpy-file:`configure.ac`
 using GNU Autoconf.
 
 After editing :file:`configure.ac`, run ``make regen-configure`` to generate
-:file:`configure`, :file:`pyconfig.h.in`, and :file:`aclocal.m4`.
+:file:`configure`, :cpy-file:`pyconfig.h.in`, and :cpy-file:`aclocal.m4`.
 When submitting a patch with changes made to :file:`configure.ac`,
 you must also regenerate these files.
 
-The recommended and by far the easiest way to regenerate :file:`configure` is::
+The recommended and by far the easiest way to regenerate :file:`configure` is:
+
+.. code-block:: bash
 
    $ make regen-configure
 
-This Make target will run a Podman or Docker container (depending on your
-environment); you only need to commit the changes.
-Behind the scenes this Make target runs one of the following container images::
+If you are regenerating :file:`configure` in a clean repo,
+run one of the following containers instead:
+
+.. code-block:: bash
 
    $ podman run --rm --pull=always -v $(pwd):/src:Z quay.io/tiran/cpython_autoconf:271
+
+.. code-block:: bash
+
    $ docker run --rm --pull=always -v $(pwd):/src quay.io/tiran/cpython_autoconf:271
 
 Notice that the images are tagged with ``271``.
@@ -513,7 +519,9 @@ For GNU Autoconf v2.69, change the ``:271`` tag to ``:269``.
 If you cannot, or don't want to use the ``cpython_autoconf`` containers,
 install the :program:`autoconf-archive` and :program:`pkg-config` utilities,
 and make sure the :file:`pkg.m4` macro file located in the appropriate
-:program:`alocal` location::
+:program:`alocal` location:
+
+.. code-block:: bash
 
    $ ls $(aclocal --print-ac-dir) | grep pkg.m4
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -487,7 +487,7 @@ functionality (such as using a new system call), it is necessary to update the
 Python's :file:`configure` script is generated from :file:`configure.ac`
 using GNU Autoconf.
 
-After editing :file:`configure.ac`, run :program:`autoreconf` to regenerate
+After editing :file:`configure.ac`, run ``make regen-configure`` to generate
 :file:`configure`, :file:`pyconfig.h.in`, and :file:`aclocal.m4`.
 When submitting a patch with changes made to :file:`configure.ac`,
 you must also those generated files.

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -490,7 +490,7 @@ using GNU Autoconf.
 After editing :file:`configure.ac`, run ``make regen-configure`` to generate
 :file:`configure`, :file:`pyconfig.h.in`, and :file:`aclocal.m4`.
 When submitting a patch with changes made to :file:`configure.ac`,
-you must also those generated files.
+you must also regenerate these files.
 
 The recommended and by far the easiest way to regenerate :file:`configure` is::
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -479,27 +479,23 @@ If a change is made to Python which relies on some POSIX system-specific
 functionality (such as using a new system call), it is necessary to update the
 :cpy-file:`configure` script to test for availability of the functionality.
 Python's :file:`configure` script is generated from :cpy-file:`configure.ac`
-using GNU Autoconf.
+using `GNU Autoconf <https://www.gnu.org/software/autoconf/>`_.
 
 After editing :file:`configure.ac`, run ``make regen-configure`` to generate
 :file:`configure`, :cpy-file:`pyconfig.h.in`, and :cpy-file:`aclocal.m4`.
-When submitting a patch with changes made to :file:`configure.ac`,
-you must also include the changes in these generated files.
+When submitting a pull request with changes made to :file:`configure.ac`,
+make sure you also commit the changes in the generated files.
 
-The recommended and by far the easiest way to regenerate :file:`configure` is:
-
-.. code-block:: bash
+The recommended and by far the easiest way to regenerate :file:`configure` is::
 
    $ make regen-configure
 
 If you are regenerating :file:`configure` in a clean repo,
-run one of the following containers instead:
-
-.. code-block:: bash
+run one of the following containers instead::
 
    $ podman run --rm --pull=always -v $(pwd):/src:Z quay.io/tiran/cpython_autoconf:271
 
-.. code-block:: bash
+::
 
    $ docker run --rm --pull=always -v $(pwd):/src quay.io/tiran/cpython_autoconf:271
 
@@ -510,12 +506,10 @@ For Python 3.12 and newer, GNU Autoconf v2.71 is required.
 For Python 3.11 and earlier, GNU Autoconf v2.69 is required.
 For GNU Autoconf v2.69, change the ``:271`` tag to ``:269``.
 
-If you cannot, or don't want to use the ``cpython_autoconf`` containers,
+If you cannot (or don't want to) use the ``cpython_autoconf`` containers,
 install the :program:`autoconf-archive` and :program:`pkg-config` utilities,
 and make sure the :file:`pkg.m4` macro file located in the appropriate
-:program:`alocal` location:
-
-.. code-block:: bash
+:program:`aclocal` location::
 
    $ ls $(aclocal --print-ac-dir) | grep pkg.m4
 
@@ -525,7 +519,7 @@ and make sure the :file:`pkg.m4` macro file located in the appropriate
    For example, running :program:`autoconf` by itself will not regenerate
    :file:`pyconfig.h.in`.
    :program:`autoreconf` runs :program:`autoconf` and a number of other tools
-   repeatedly as is appropriate.
+   repeatedly as appropriate.
 
 .. _build_troubleshooting:
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -483,31 +483,47 @@ Regenerate ``configure``
 
 If a change is made to Python which relies on some POSIX system-specific
 functionality (such as using a new system call), it is necessary to update the
-``configure`` script to test for availability of the functionality.
+:file:`configure` script to test for availability of the functionality.
+Python's :file:`configure` script is generated from :file:`configure.ac`
+using GNU Autoconf.
 
-Python's ``configure`` script is generated from ``configure.ac`` using Autoconf.
-Instead of editing ``configure``, edit ``configure.ac`` and then run
-``autoreconf`` to regenerate ``configure`` and a number of other files (such as
-``pyconfig.h``).
+After editing :file:`configure.ac`, run :program:`autoreconf` to regenerate
+:file:`configure`, :file:`pyconfig.h.in`, and :file:`aclocal.m4`.
+When submitting a patch with changes made to :file:`configure.ac`,
+you must also those generated files.
 
-When submitting a patch with changes made to ``configure.ac``, you should also
-include the generated files.
+The recommended and by far the easiest way to regenerate :file:`configure` is::
 
-Note that running ``autoreconf`` is not the same as running ``autoconf``. For
-example, ``autoconf`` by itself will not regenerate ``pyconfig.h.in``.
-``autoreconf`` runs ``autoconf`` and a number of other tools repeatedly as is
-appropriate.
+   $ make regen-configure
 
-Python's ``configure.ac`` script typically requires a specific version of
-Autoconf.  At the moment, this reads: ``AC_PREREQ(2.69)``. It also requires
-to have the ``autoconf-archive`` and ``pkg-config`` utilities installed in
-the system and the ``pkg.m4`` macro file located in the appropriate ``alocal``
-location. You can easily check if this is correctly configured by running::
+This Make target will run a Podman or Docker container (depending on your
+environment); you only need to commit the changes.
+Behind the scenes this Make target runs one of the following container images::
+
+   $ podman run --rm --pull=always -v $(pwd):/src:Z quay.io/tiran/cpython_autoconf:271
+   $ docker run --rm --pull=always -v $(pwd):/src quay.io/tiran/cpython_autoconf:271
+
+Notice that the images are tagged with ``271``.
+Python's :file:`configure.ac` script requires a specific version of
+GNU Autoconf.
+For Python 3.12 and newer, GNU Autoconf v2.71 is required.
+For Python 3.11 and earlier, GNU Autoconf v2.69 is required.
+For GNU Autoconf v2.69, change the ``:271`` tag to ``:269``.
+
+If you cannot, or don't want to use the ``cpython_autoconf`` containers,
+install the :program:`autoconf-archive` and :program:`pkg-config` utilities,
+and make sure the :file:`pkg.m4` macro file located in the appropriate
+:program:`alocal` location::
 
    $ ls $(aclocal --print-ac-dir) | grep pkg.m4
 
-If the system copy of Autoconf does not match this version, you will need to
-install your own copy of Autoconf.
+.. note::
+
+   Running :program:`autoreconf` is not the same as running :program:`autoconf`.
+   For example, running :program:`autoconf` by itself will not regenerate
+   :file:`pyconfig.h.in`.
+   :program:`autoreconf` runs :program:`autoconf` and a number of other tools
+   repeatedly as is appropriate.
 
 .. _build_troubleshooting:
 


### PR DESCRIPTION
Instead of talking a lot about how to regenerate `configure` using GNU Autotools, first recommend what we really want people to do: use `make regen-configure`. Second, mention that it's possible to run Christian's containers to regenerate configure. Lastly, talk briefly about regenerating using autotools directly. (IMO, we should remove that last bit; we just want people to use the containers.)

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1109.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->