### PR TITLE
Link to Discourse first in "Help with Documentation" section (take 2)

### DIFF
--- a/documentation/help-documenting.rst
+++ b/documentation/help-documenting.rst
@@ -37,9 +37,10 @@ The in-development and recent maintenance branches are rebuilt once per day.
 
 If you would like to be more involved with documentation, consider subscribing
 to the `Documentation category on the Python Discourse
-<https://discuss.python.org/c/documentation/26>`_ and the `docs@python.org <https://mail.python.org/mailman3/lists/docs.python.org/>`_
+<https://discuss.python.org/c/documentation/26>`_ and the
+`docs@python.org <https://mail.python.org/mailman3/lists/docs.python.org/>`_
 mailing list where user issues are raised and documentation toolchain,
-projects, and standards are discussed.  
+projects, and standards are discussed.
 
 
 Helping with documentation issues

--- a/documentation/help-documenting.rst
+++ b/documentation/help-documenting.rst
@@ -36,11 +36,10 @@ and :ref:`maintenance <maintbranch>` branches at https://docs.python.org/dev/.
 The in-development and recent maintenance branches are rebuilt once per day.
 
 If you would like to be more involved with documentation, consider subscribing
-to the `docs@python.org <https://mail.python.org/mailman3/lists/docs.python.org/>`_
-mailing list and the `Documentation category on the Python Discourse
-<https://discuss.python.org/c/documentation/26>`_,
-where user issues are raised and documentation toolchain, projects, and standards
-are discussed.
+to the `Documentation category on the Python Discourse
+<https://discuss.python.org/c/documentation/26>`_ and the `docs@python.org <https://mail.python.org/mailman3/lists/docs.python.org/>`_
+mailing list where user issues are raised and documentation toolchain,
+projects, and standards are discussed.  
 
 
 Helping with documentation issues

--- a/documentation/help-documenting.rst
+++ b/documentation/help-documenting.rst
@@ -38,9 +38,9 @@ The in-development and recent maintenance branches are rebuilt once per day.
 If you would like to be more involved with documentation, consider subscribing
 to the `Documentation category on the Python Discourse
 <https://discuss.python.org/c/documentation/26>`_ and the
-`docs@python.org <https://mail.python.org/mailman3/lists/docs.python.org/>`_
-mailing list where user issues are raised and documentation toolchain,
-projects, and standards are discussed.
+`docs@python.org <https://mail.python.org/mailman3/lists/docs.python.org/>`_ mailing list
+where user issues are raised and documentation toolchain, projects, and standards
+are discussed.
 
 
 Helping with documentation issues


### PR DESCRIPTION
The Docs Discourse forum is the preferred way.
I reordered the sentence so that the discourse forum is mentioned first.

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1118.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->