### PR TITLE
Remove outdated reference to Python 3.5

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -629,8 +629,7 @@ every rule.
 
 ``Programs``
      Source code for C executables, including the main function for the
-     CPython interpreter (in versions prior to Python 3.5, these files are
-     in the Modules directory).
+     CPython interpreter.
 
 ``Python``
      The code that makes up the core CPython runtime. This includes the


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Python 3.5 went EOL in 2020.

https://devguide.python.org/versions/#unsupported-versions

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1120.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->