### PR TITLE
Add guidelines for C API with output parameters

### DIFF
--- a/developer-workflow/c-api.rst
+++ b/developer-workflow/c-api.rst
@@ -123,7 +123,7 @@ Guidelines for expanding/changing the public API
   - ``return 1``: lookup succeeded; item was found
 
 - APIs with output parameters should ensure that each output parameter has a
-  valid value, no matter the return value of the API. Example::
+  valid value, no matter the return value of the API. Example:
 
   .. code-block:: c
 

--- a/developer-workflow/c-api.rst
+++ b/developer-workflow/c-api.rst
@@ -122,6 +122,28 @@ Guidelines for expanding/changing the public API
   - ``return 0``: lookup succeeded; no item was found
   - ``return 1``: lookup succeeded; item was found
 
+- APIs with output parameters should ensure that each output parameter has a
+  valid value, no matter the return value of the API. Example::
+
+  .. code-block:: c
+
+     int
+     PyFoo_Bar(PyObject **out)
+     {
+         PyObject *value;
+         int rc = foo_bar(&value);
+         if (rc < 0) {
+             out = NULL;
+             return -1;
+         }
+         if (rc == 0) {
+             out = NULL;
+             return 0;
+         }
+         out = Py_NewRef(value);
+         return 1;
+     }
+
 Please start a public discussion if these guidelines won't work for your API.
 
 .. note::

--- a/developer-workflow/c-api.rst
+++ b/developer-workflow/c-api.rst
@@ -123,7 +123,7 @@ Guidelines for expanding/changing the public API
   - ``return 1``: lookup succeeded; item was found
 
 - APIs with output parameters should ensure that each output parameter is
-  initialised for all code paths.
+  initialized for all code paths.
   Example:
 
   .. code-block:: c

--- a/developer-workflow/c-api.rst
+++ b/developer-workflow/c-api.rst
@@ -122,8 +122,9 @@ Guidelines for expanding/changing the public API
   - ``return 0``: lookup succeeded; no item was found
   - ``return 1``: lookup succeeded; item was found
 
-- APIs with output parameters should ensure that each output parameter has a
-  valid value, no matter the return value of the API. Example:
+- APIs with output parameters should ensure that each output parameter is
+  initialised for all code paths.
+  Example:
 
   .. code-block:: c
 

--- a/developer-workflow/c-api.rst
+++ b/developer-workflow/c-api.rst
@@ -133,14 +133,14 @@ Guidelines for expanding/changing the public API
          PyObject *value;
          int rc = foo_bar(&value);
          if (rc < 0) {
-             out = NULL;
+             *out = NULL;
              return -1;
          }
          if (rc == 0) {
-             out = NULL;
+             *out = NULL;
              return 0;
          }
-         out = Py_NewRef(value);
+         *out = Py_NewRef(value);
          return 1;
      }
 

--- a/developer-workflow/c-api.rst
+++ b/developer-workflow/c-api.rst
@@ -132,14 +132,17 @@ Guidelines for expanding/changing the public API
      {
          PyObject *value;
          int rc = foo_bar(&value);
+         // Error case
          if (rc < 0) {
              *out = NULL;
              return -1;
          }
+         // Not found (lesser result)
          if (rc == 0) {
              *out = NULL;
              return 0;
          }
+         // Found (greater result)
          *out = Py_NewRef(value);
          return 1;
      }


### PR DESCRIPTION


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1128.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->