### PR TITLE
Improve C API guidelines for return values

### DIFF
--- a/developer-workflow/c-api.rst
+++ b/developer-workflow/c-api.rst
@@ -113,8 +113,8 @@ Guidelines for expanding/changing the public API
   and ``NULL`` if and only if an exception is raised.
   Other API must return ``0`` on success,
   and a negative value if and only if an exception is raised.
-  Unless there is need to distinguish between error types,
-  ``-1`` should be used as the error value.
+  ``-1`` should be used as the error value;
+  the caller should use the C idiom ``if (func() < 0)`` to check for errors.
 
 - APIs with lesser and greater results must return ``0`` for the lesser result,
   and ``1`` for the greater result.

--- a/developer-workflow/c-api.rst
+++ b/developer-workflow/c-api.rst
@@ -110,9 +110,9 @@ Guidelines for expanding/changing the public API
   fields, arguments and return values are well defined.
 
 - Functions returning ``PyObject *`` must return a valid pointer on success,
-  and ``NULL`` if and only if an exception is raised.
+  and ``NULL`` if, and only if, an exception is raised.
   Most other API must return ``0`` on success,
-  and a negative value if and only if an exception is raised.
+  and a negative value if, and only if, an exception is raised.
   Unless there is need to distinguish between error types,
   ``-1`` should be used as the error value.
 

--- a/developer-workflow/c-api.rst
+++ b/developer-workflow/c-api.rst
@@ -110,9 +110,9 @@ Guidelines for expanding/changing the public API
   fields, arguments and return values are well defined.
 
 - Functions returning ``PyObject *`` must return a valid pointer on success,
-  and ``NULL`` if, and only if, an exception is raised.
+  and ``NULL`` if and only if an exception is raised.
   Most other API must return ``0`` on success,
-  and a negative value if, and only if, an exception is raised.
+  and a negative value if and only if an exception is raised.
   Unless there is need to distinguish between error types,
   ``-1`` should be used as the error value.
 

--- a/developer-workflow/c-api.rst
+++ b/developer-workflow/c-api.rst
@@ -111,7 +111,7 @@ Guidelines for expanding/changing the public API
 
 - Functions returning ``PyObject *`` must return a valid pointer on success,
   and ``NULL`` if and only if an exception is raised.
-  Most other API must return ``0`` on success,
+  Other API must return ``0`` on success,
   and a negative value if and only if an exception is raised.
   Unless there is need to distinguish between error types,
   ``-1`` should be used as the error value.

--- a/developer-workflow/c-api.rst
+++ b/developer-workflow/c-api.rst
@@ -110,9 +110,11 @@ Guidelines for expanding/changing the public API
   fields, arguments and return values are well defined.
 
 - Functions returning ``PyObject *`` must return a valid pointer on success,
-  and ``NULL`` with an exception raised on error.
-  Most other API must return ``-1`` with an exception raised on error,
-  and ``0`` on success.
+  and ``NULL`` if and only if an exception is raised.
+  Most other API must return ``0`` on success,
+  and a negative value if and only if an exception is raised.
+  Unless there is need to distinguish between error types,
+  ``-1`` should be used as the error value.
 
 - APIs with lesser and greater results must return ``0`` for the lesser result,
   and ``1`` for the greater result.

--- a/developer-workflow/c-api.rst
+++ b/developer-workflow/c-api.rst
@@ -111,7 +111,7 @@ Guidelines for expanding/changing the public API
 
 - Functions returning ``PyObject *`` must return a valid pointer on success,
   and ``NULL`` if and only if an exception is raised.
-  Other API must return ``0`` on success,
+  Other API must return an ``int``: return ``0`` on success,
   and a negative value if and only if an exception is raised.
   ``-1`` should be used as the error value;
   the caller should use the C idiom ``if (func() < 0)`` to check for errors.


### PR DESCRIPTION
Clarify that returning an error indicator should be done iff an
exception is raised.

For functions returning an int, a _negative value_ should be returned.
Suggest -1 unless there is a need to distinguish between error types.


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1129.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->