### PR TITLE
Update planned 3.13.0 release date: 2024-10-01

### DIFF
--- a/include/release-cycle.json
+++ b/include/release-cycle.json
@@ -3,7 +3,7 @@
     "branch": "main",
     "pep": 719,
     "status": "feature",
-    "first_release": "2024-10-07",
+    "first_release": "2024-10-01",
     "end_of_life": "2029-10",
     "release_manager": "Thomas Wouters"
   },


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Before the [PEP 719](https://peps.python.org/pep-0719/) schedule was published, we used the first Monday in October 2024 as a placeholder (https://github.com/python/devguide/pull/1099).

Let's update it to match the PEP.


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1132.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->