### PR TITLE
Strip space from pasted text

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -166,6 +166,6 @@ ogp_custom_meta_tags = [
 
 # Strip the dollar prompt when copying code
 # https://sphinx-copybutton.readthedocs.io/en/latest/use.html#strip-and-configure-input-prompts-for-code-cells
-copybutton_prompt_text = "$"
+copybutton_prompt_text = "$ "
 # https://sphinx-copybutton.readthedocs.io/en/latest/use.html#honor-line-continuation-characters-when-copying-multline-snippets
 copybutton_line_continuation_character = "\\"


### PR DESCRIPTION
Fixes #1141 
Added a space after $ so the leading space is not copied.

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1142.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->