### PR TITLE
Reviewing PRs: On GitHub the nosy list is called subscribers

### DIFF
--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -416,7 +416,7 @@ request (we cannot force anyone to review pull requests and no one is
 employed to look at pull requests). If your pull request has not
 received any notice from reviewers (i.e., no comment made) after one
 month, first "ping" the issue on the `issue tracker`_ to remind the
-nosy list that the pull request needs a review.
+subscribers that the pull request needs a review.
 If you don't get a response within a week after pinging the issue,
 you can post on the `Core Development Discourse category`_
 to ask for someone to review your pull request.


### PR DESCRIPTION
When reading through this section, I stumbled over the term "nosy list", not knowing what it means.

It seems to be a [legacy concept](https://devguide.python.org/triage/github-bpo-faq/#where-is-the-nosy-list),
so this PR rephrases it to fit in with existing GitHub [terminology](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-issues#stay-up-to-date).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->