### PR TITLE
Adding Codespaces Documentation

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -666,12 +666,20 @@ Contribute using GitHub Codespaces
 
 What is GitHub Codespaces?
 --------------------------
+set up the same environment but locally in a docker container if you'd prefer th
+If you'd like to start contributing to CPython without needing to set up a local
+developer environment, you can use
+`GitHub Codespaces <https://github.com/features/codespaces>`_.
+Codespaces is a cloud-based development environment offered by GitHub that
+allows developers to write, build, test, and debug code directly within their
+web browser or in Visual Studio Code (VS Code).
 
-If you'd like to start contributing to CPython without needing to set up a local developer environment, you can use `GitHub Codespaces <https://github.com/features/codespaces>`_.
-Codespaces is a cloud-based development environment offered by GitHub that allows developers to write, build, test, and debug code directly within their web browser or in Visual Studio Code (VS Code).
-
-To help you get started, CPython contains a `devcontainer folder <https://github.com/python/cpython/tree/main/.devcontainer>`_ with a JSON configuration file that provides consistent and versioned codespace configurations for all users of the project.
-It also contains a Dockerfile that allows you to set up the same environment but locally in a Docker container if you'd prefer to use that directly.
+To help you get started, CPython contains a
+`devcontainer folder <https://github.com/python/cpython/tree/main/.devcontainer>`_
+with a JSON configuration file that provides consistent and versioned codespace
+configurations for all users of the project. It also contains a Dockerfile that
+allows you to set up the same environment but locally in a Docker container if
+you'd prefer to use that directly.
 
 .. _codespaces-create-a-codespace:
 
@@ -679,27 +687,40 @@ Create a CPython codespace
 --------------------------
 
 Here are the basic steps needed to contribute a patch using Codespaces.
-You first need to navigate to the `CPython repo <https://github.com/python/cpython>`_ hosted on GitHub.
+You first need to navigate to the
+`CPython repo <https://github.com/python/cpython>`_ hosted on GitHub.
 
 Then you will need to:
 
-1. Press the ``,`` key to launch the codespace setup screen for the current branch (alternatively, click the green :guilabel:`Code` button and choose the ``codespaces`` tab and then press the green :guilabel:`Create codespace on main` button).
-3. A screen should appear that lets you know your codespace is being set up. (Note: Since the CPython devcontainer is provided, codespaces will use the configuration it specifies.)
-4. A `web version of VS Code <https://vscode.dev/>`_ will open inside your web browser, already linked up with your code and a terminal to the remote codespace where CPython and its documentation have already been built.
-5. Use the terminal with the usual Git commands to create a new branch, commit and push your changes once you're ready!
+1. Press the ``,`` key to launch the codespace setup screen for the current
+   branch (alternatively, click the green :guilabel:`Code` button and choose
+   the ``codespaces`` tab and then press the
+   green :guilabel:`Create codespace on main` button).
+2. A screen should appear that lets you know your codespace is being set up.
+   (Note: Since the CPython devcontainer is provided, codespaces will use the
+   configuration it specifies.)
+3. A `web version of VS Code <https://vscode.dev/>`_ will open inside your web
+   browser, already linked up with your code and a terminal to the remote
+   codespace where CPython and its documentation have already been built.
+4. Use the terminal with the usual Git commands to create a new branch, commit
+   and push your changes once you're ready!
 
-If you close your repository and come back later you can always resume your codespace by navigating to the CPython repo, selecting the codespaces tab and selecting your most recent codespaces session.
-You should then be able to pick up from where you left off!
+If you close your repository and come back later you can always resume your
+codespace by navigating to the CPython repo, selecting the codespaces tab and
+selecting your most recent codespaces session. You should then be able to pick
+up from where you left off!
 
 .. _codespaces-use-locally:
 
 Use Codespaces Locally
 ----------------------
 
-On the bottom left side of the codespace screen you will see a green or grey square that says :guilabel:`Codespaces`.
-You can click this for additional options. If you prefer working in a locally installed copy of VS Code you can select the option ``Open in VS Code``.
-You will still be working on the remote codespace instance, thus using the remote instance's compute power.
-The compute power may be a much higher spec than your local machine which can be helpful.
+On the bottom left side of the codespace screen you will see a green or grey
+square that says :guilabel:`Codespaces`. You can click this for additional
+options. If you prefer working in a locally installed copy of VS Code you can
+select the option ``Open in VS Code``. You will still be working on the remote
+codespace instance, thus using the remote instance's compute power. The compute
+power may be a much higher spec than your local machine which can be helpful.
 
 
 .. TODO: add docker instructions

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -667,7 +667,7 @@ Contribute Using GitHub Codespaces
 What is Github Codespaces
 -------------------------
 
-If you'd like to start contributing to CPython without needing to set up a local developer environment, you can use `Github Codespaces <https://github.com/features/codespaces>`_.
+If you'd like to start contributing to CPython without needing to set up a local developer environment, you can use `GitHub Codespaces <https://github.com/features/codespaces>`_.
 Codespaces is a cloud-based development environment offered by GitHub that allows developers to write, build, test, and debug code directly within their web browser or in Visual Studio Code (VS Code).
 
 To help you get started CPython contains a `devcontainer folder <https://github.com/python/cpython/tree/main/.devcontainer>`_ with a json file that provides consistent and versioned codespace configurations for all users of the project.

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -684,7 +684,7 @@ You first need to navigate to the `CPython repo <https://github.com/python/cpyth
 Then you will need to:
 
 1. Click the green :guilabel:`Code` button and choose the ``codespaces`` tab.
-2. Press the green :guilabel:`create a new codespace on main` button.
+2. Press the green :guilabel:`Create codespace on main` button.
 3. A screen should appear that lets you know your codespace is being set up. (Note: Since the CPython devcontainer is provided codespaces will use the configurations it specifies.)
 4. VS Code will open inside of your web browser, already linked up with your code and a terminal to the remote codespace.
 5. Use the terminal with the usual git commands to create a new branch, commit and push your changes once you're ready!

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -659,7 +659,7 @@ every rule.
 
 .. _using-codespaces:
 
-Contribute Using GitHub Codespaces
+Contribute using GitHub Codespaces
 ==================================
 
 .. _codespaces-whats-codespaces:

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -666,41 +666,41 @@ Contribute Using Github Codespaces
 
 What is Github Codespaces
 -------------------------
-  
-If you'd like to start contributing to CPython without needing to set up a local developer environment, you can use `Github Codespaces <https://github.com/features/codespaces>`_.
-Codespaces is a cloud-based development environment offered by GitHub that allows developers to write, build, test, and debug code directly within their web browser or in Visual Studio Code (VS Code).  
 
-To help you get started CPython contains a `devcontainer folder <https://github.com/python/cpython/tree/main/.devcontainer>`_ with a json file that provides consistent and versioned codespace configurations for all users of the project. 
+If you'd like to start contributing to CPython without needing to set up a local developer environment, you can use `Github Codespaces <https://github.com/features/codespaces>`_.
+Codespaces is a cloud-based development environment offered by GitHub that allows developers to write, build, test, and debug code directly within their web browser or in Visual Studio Code (VS Code).
+
+To help you get started CPython contains a `devcontainer folder <https://github.com/python/cpython/tree/main/.devcontainer>`_ with a json file that provides consistent and versioned codespace configurations for all users of the project.
 It also contains a docker file that allows you to set up the same environment but locally in a docker container if you'd prefer to do that.
 
 .. _codespaces-create-a-codespace:
 
 Create A CPython Codespace
---------------------------       
+--------------------------
 
 Here are the basic steps needed to contribute a patch using Codespaces.
 You first need to navigate to the `CPython repo <https://github.com/python/cpython>`_ hosted on GitHub.
 
 Then you will need to:
 
-1. Click the green :guilabel:`Code` button and choose the `codespaces` tab.
+1. Click the green :guilabel:`Code` button and choose the ``codespaces`` tab.
 2. Press the green :guilabel:`create a new codespace on main` button.
-3. A screen should appear that lets you know your codespace is being set up. (Note: Since the CPython devcontainer is provided codespaces will use the configurations it specifies.) 
+3. A screen should appear that lets you know your codespace is being set up. (Note: Since the CPython devcontainer is provided codespaces will use the configurations it specifies.)
 4. VS Code will open inside of your web browser, already linked up with your code and a terminal to the remote codespace.
 5. Use the terminal with the usual git commands to create a new branch, commit and push your changes once you're ready!
 
-If you close your repository and come back later you can always resume your codespace by navigating to the CPython repo, selecting the codespaces tab and selecting your most recent codespaces session. 
-You should then be able to pick up from where you left off! 
+If you close your repository and come back later you can always resume your codespace by navigating to the CPython repo, selecting the codespaces tab and selecting your most recent codespaces session.
+You should then be able to pick up from where you left off!
 
 .. _codespaces-use-locally:
 
 Use Codespaces Locally
------------------------  
- 
-On the bottom left side of the codespace screen you will see a green or grey square that says :guilabel:`Codespaces`. 
-You can click on this for additional options. If you prefer working on a locally installed copy of VS Code you can select the option `Open in VS Code`. 
+-----------------------
+
+On the bottom left side of the codespace screen you will see a green or grey square that says :guilabel:`Codespaces`.
+You can click on this for additional options. If you prefer working on a locally installed copy of VS Code you can select the option ``Open in VS Code``.
 You will still be working on the remote codespace instance, thus utilising the remote instance compute power.
 The compute power may be a much higher spec than your local machine which can be helpful.
 
 
-.. TODO: add docker instructions 
+.. TODO: add docker instructions

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -685,9 +685,9 @@ Then you will need to:
 
 1. Click the green :guilabel:`Code` button and choose the ``codespaces`` tab.
 2. Press the green :guilabel:`Create codespace on main` button.
-3. A screen should appear that lets you know your codespace is being set up. (Note: Since the CPython devcontainer is provided codespaces will use the configurations it specifies.)
-4. VS Code will open inside of your web browser, already linked up with your code and a terminal to the remote codespace.
-5. Use the terminal with the usual git commands to create a new branch, commit and push your changes once you're ready!
+3. A screen should appear that lets you know your codespace is being set up. (Note: Since the CPython devcontainer is provided, codespaces will use the configuration it specifies.)
+4. VS Code will open inside your web browser, already linked up with your code and a terminal to the remote codespace.
+5. Use the terminal with the usual Git commands to create a new branch, commit and push your changes once you're ready!
 
 If you close your repository and come back later you can always resume your codespace by navigating to the CPython repo, selecting the codespaces tab and selecting your most recent codespaces session.
 You should then be able to pick up from where you left off!

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -698,7 +698,7 @@ Use Codespaces Locally
 ----------------------
 
 On the bottom left side of the codespace screen you will see a green or grey square that says :guilabel:`Codespaces`.
-You can click on this for additional options. If you prefer working on a locally installed copy of VS Code you can select the option ``Open in VS Code``.
+You can click this for additional options. If you prefer working in a locally installed copy of VS Code you can select the option ``Open in VS Code``.
 You will still be working on the remote codespace instance, thus utilising the remote instance compute power.
 The compute power may be a much higher spec than your local machine which can be helpful.
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -671,7 +671,7 @@ If you'd like to start contributing to CPython without needing to set up a local
 Codespaces is a cloud-based development environment offered by GitHub that allows developers to write, build, test, and debug code directly within their web browser or in Visual Studio Code (VS Code).
 
 To help you get started, CPython contains a `devcontainer folder <https://github.com/python/cpython/tree/main/.devcontainer>`_ with a JSON configuration file that provides consistent and versioned codespace configurations for all users of the project.
-It also contains a Dockerfile that allows you to set up the same environment but locally in a Docker container if you'd prefer.
+It also contains a Dockerfile that allows you to set up the same environment but locally in a Docker container if you'd prefer to use that directly.
 
 .. _codespaces-create-a-codespace:
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -685,7 +685,7 @@ Then you will need to:
 
 1. Press the ``,`` key to launch the codespace setup screen for the current branch (alternatively, click the green :guilabel:`Code` button and choose the ``codespaces`` tab and then press the green :guilabel:`Create codespace on main` button).
 3. A screen should appear that lets you know your codespace is being set up. (Note: Since the CPython devcontainer is provided, codespaces will use the configuration it specifies.)
-4. VS Code will open inside your web browser, already linked up with your code and a terminal to the remote codespace.
+4. A `web version of VS Code <https://vscode.dev/>`_ will open inside your web browser, already linked up with your code and a terminal to the remote codespace where CPython and its documentation have already been built.
 5. Use the terminal with the usual Git commands to create a new branch, commit and push your changes once you're ready!
 
 If you close your repository and come back later you can always resume your codespace by navigating to the CPython repo, selecting the codespaces tab and selecting your most recent codespaces session.

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -670,8 +670,8 @@ What is Github Codespaces
 If you'd like to start contributing to CPython without needing to set up a local developer environment, you can use `GitHub Codespaces <https://github.com/features/codespaces>`_.
 Codespaces is a cloud-based development environment offered by GitHub that allows developers to write, build, test, and debug code directly within their web browser or in Visual Studio Code (VS Code).
 
-To help you get started CPython contains a `devcontainer folder <https://github.com/python/cpython/tree/main/.devcontainer>`_ with a json file that provides consistent and versioned codespace configurations for all users of the project.
-It also contains a docker file that allows you to set up the same environment but locally in a docker container if you'd prefer to do that.
+To help you get started CPython contains a `devcontainer folder <https://github.com/python/cpython/tree/main/.devcontainer>`_ with a JSON file that provides consistent and versioned codespace configurations for all users of the project.
+It also contains a Dockerfile that allows you to set up the same environment but locally in a Docker container if you'd prefer.
 
 .. _codespaces-create-a-codespace:
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -699,7 +699,7 @@ Use Codespaces Locally
 
 On the bottom left side of the codespace screen you will see a green or grey square that says :guilabel:`Codespaces`.
 You can click this for additional options. If you prefer working in a locally installed copy of VS Code you can select the option ``Open in VS Code``.
-You will still be working on the remote codespace instance, thus utilising the remote instance compute power.
+You will still be working on the remote codespace instance, thus using the remote instance's compute power.
 The compute power may be a much higher spec than your local machine which can be helpful.
 
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -695,7 +695,7 @@ You should then be able to pick up from where you left off!
 .. _codespaces-use-locally:
 
 Use Codespaces Locally
------------------------
+----------------------
 
 On the bottom left side of the codespace screen you will see a green or grey square that says :guilabel:`Codespaces`.
 You can click on this for additional options. If you prefer working on a locally installed copy of VS Code you can select the option ``Open in VS Code``.

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -670,7 +670,7 @@ What is GitHub Codespaces?
 If you'd like to start contributing to CPython without needing to set up a local developer environment, you can use `GitHub Codespaces <https://github.com/features/codespaces>`_.
 Codespaces is a cloud-based development environment offered by GitHub that allows developers to write, build, test, and debug code directly within their web browser or in Visual Studio Code (VS Code).
 
-To help you get started CPython contains a `devcontainer folder <https://github.com/python/cpython/tree/main/.devcontainer>`_ with a JSON file that provides consistent and versioned codespace configurations for all users of the project.
+To help you get started, CPython contains a `devcontainer folder <https://github.com/python/cpython/tree/main/.devcontainer>`_ with a JSON configuration file that provides consistent and versioned codespace configurations for all users of the project.
 It also contains a Dockerfile that allows you to set up the same environment but locally in a Docker container if you'd prefer.
 
 .. _codespaces-create-a-codespace:

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -683,8 +683,7 @@ You first need to navigate to the `CPython repo <https://github.com/python/cpyth
 
 Then you will need to:
 
-1. Click the green :guilabel:`Code` button and choose the ``codespaces`` tab.
-2. Press the green :guilabel:`Create codespace on main` button.
+1. Press the ``,`` key to launch the codespace setup screen for the current branch (alternatively, click the green :guilabel:`Code` button and choose the ``codespaces`` tab and then press the green :guilabel:`Create codespace on main` button).
 3. A screen should appear that lets you know your codespace is being set up. (Note: Since the CPython devcontainer is provided, codespaces will use the configuration it specifies.)
 4. VS Code will open inside your web browser, already linked up with your code and a terminal to the remote codespace.
 5. Use the terminal with the usual Git commands to create a new branch, commit and push your changes once you're ready!

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -659,8 +659,8 @@ every rule.
 
 .. _using-codespaces:
 
-Contribute Using Github Codespaces
-===================================
+Contribute Using GitHub Codespaces
+==================================
 
 .. _codespaces-whats-codespaces:
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -664,8 +664,8 @@ Contribute using GitHub Codespaces
 
 .. _codespaces-whats-codespaces:
 
-What is Github Codespaces
--------------------------
+What is GitHub Codespaces?
+--------------------------
 
 If you'd like to start contributing to CPython without needing to set up a local developer environment, you can use `GitHub Codespaces <https://github.com/features/codespaces>`_.
 Codespaces is a cloud-based development environment offered by GitHub that allows developers to write, build, test, and debug code directly within their web browser or in Visual Studio Code (VS Code).

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -675,7 +675,7 @@ It also contains a Dockerfile that allows you to set up the same environment but
 
 .. _codespaces-create-a-codespace:
 
-Create A CPython Codespace
+Create a CPython codespace
 --------------------------
 
 Here are the basic steps needed to contribute a patch using Codespaces.

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -655,3 +655,52 @@ every rule.
 
 
 .. _issue tracker: https://github.com/python/cpython/issues
+
+
+.. _using-codespaces:
+
+Contribute Using Github Codespaces
+===================================
+
+.. _codespaces-whats-codespaces:
+
+What is Github Codespaces
+-------------------------
+  
+If you'd like to start contributing to CPython without needing to set up a local developer environment, you can use `Github Codespaces <https://github.com/features/codespaces>`_.
+Codespaces is a cloud-based development environment offered by GitHub that allows developers to write, build, test, and debug code directly within their web browser or in Visual Studio Code (VS Code).  
+
+To help you get started CPython contains a `devcontainer folder <https://github.com/python/cpython/tree/main/.devcontainer>`_ with a json file that provides consistent and versioned codespace configurations for all users of the project. 
+It also contains a docker file that allows you to set up the same environment but locally in a docker container if you'd prefer to do that.
+
+.. _codespaces-create-a-codespace:
+
+Create A CPython Codespace
+--------------------------       
+
+Here are the basic steps needed to contribute a patch using Codespaces.
+You first need to navigate to the `CPython repo <https://github.com/python/cpython>`_ hosted on GitHub.
+
+Then you will need to:
+
+1. Click the green :guilabel:`Code` button and choose the `codespaces` tab.
+2. Press the green :guilabel:`create a new codespace on main` button.
+3. A screen should appear that lets you know your codespace is being set up. (Note: Since the CPython devcontainer is provided codespaces will use the configurations it specifies.) 
+4. VS Code will open inside of your web browser, already linked up with your code and a terminal to the remote codespace.
+5. Use the terminal with the usual git commands to create a new branch, commit and push your changes once you're ready!
+
+If you close your repository and come back later you can always resume your codespace by navigating to the CPython repo, selecting the codespaces tab and selecting your most recent codespaces session. 
+You should then be able to pick up from where you left off! 
+
+.. _codespaces-use-locally:
+
+Use Codespaces Locally
+-----------------------  
+ 
+On the bottom left side of the codespace screen you will see a green or grey square that says :guilabel:`Codespaces`. 
+You can click on this for additional options. If you prefer working on a locally installed copy of VS Code you can select the option `Open in VS Code`. 
+You will still be working on the remote codespace instance, thus utilising the remote instance compute power.
+The compute power may be a much higher spec than your local machine which can be helpful.
+
+
+.. TODO: add docker instructions 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -666,7 +666,7 @@ Contribute using GitHub Codespaces
 
 What is GitHub Codespaces?
 --------------------------
-set up the same environment but locally in a docker container if you'd prefer th
+
 If you'd like to start contributing to CPython without needing to set up a local
 developer environment, you can use
 `GitHub Codespaces <https://github.com/features/codespaces>`_.


### PR DESCRIPTION
Hi, I'd like to add documentation to show how to use Codespaces for contributing to CPython with the [devcontainer](https://github.com/python/cpython/tree/main/.devcontainer) files Brett added. I've added the instructions at the bottom of the `Setup and Building` page. I initially added them as a separate page but thought this might be more appropriate. Feel free to let me know if you think they should live somewhere else.  

This is a PR that would solve https://github.com/python/devguide/issues/1138. I added some context about the discussions and places where some people had asked for docs in the issue. (Also sorry for the other closed PR's still getting used to contributing :)) 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1144.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->