### PR TITLE
Bump Sphinx to 7.2.5

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1,8 +1,6 @@
-import hashlib
 import os
 import sys
 import time
-from pathlib import Path
 
 # Location of custom extensions.
 sys.path.insert(0, os.path.abspath(".") + "/_extensions")
@@ -35,14 +33,6 @@ exclude_patterns = [
 ]
 
 
-def _asset_hash(path: os.PathLike[str]) -> str:
-    """Append a `?digest=` to an url based on the file content."""
-    full_path = (Path(html_static_path[0]) / path).resolve()
-    digest = hashlib.sha1(full_path.read_bytes()).hexdigest()
-
-    return f"{path}?digest={digest}"
-
-
 html_theme = 'furo'
 html_theme_options = {
     "source_repository": "https://github.com/python/devguide",
@@ -50,7 +40,7 @@ html_theme_options = {
 }
 html_static_path = ['_static']
 html_css_files = [
-    _asset_hash('devguide_overrides.css'),
+    'devguide_overrides.css',
 ]
 html_logo = "_static/python-logo.svg"
 html_favicon = "_static/favicon.png"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Sphinx==7.2.3
 furo>=2022.6.4
 jinja2
 sphinx-lint==0.6.8
-sphinx-notfound-page>=1.0.0rc1
+sphinx-notfound-page>=1.0.0
 sphinx_copybutton>=0.3.3
 sphinxext-opengraph>=0.7.1
 sphinxext-rediraffe

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==7.2.3
+Sphinx~=7.2.4
 furo>=2022.6.4
 jinja2
 sphinx-lint==0.6.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx~=7.2.4
+Sphinx~=7.2.5
 furo>=2022.6.4
 jinja2
 sphinx-lint==0.6.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==7.1.1
+Sphinx==7.2.3
 furo>=2022.6.4
 jinja2
 sphinx-lint==0.6.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Sphinx==7.2.3
 furo>=2022.6.4
 jinja2
 sphinx-lint==0.6.8
-sphinx-notfound-page
+sphinx-notfound-page>=1.0.0rc1
 sphinx_copybutton>=0.3.3
 sphinxext-opengraph>=0.7.1
 sphinxext-rediraffe


### PR DESCRIPTION
This also removes ``_asset_hash()``, which is no longer needed.

A

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1155.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->