### PR TITLE
Point to buildbot config repo rather than mailing list for adding a worker

### DIFF
--- a/testing/new-buildbot-worker.rst
+++ b/testing/new-buildbot-worker.rst
@@ -46,8 +46,9 @@ everything required to do normal python development:  a compiler, a linker, and
 compiled python.
 
 In order to set up the buildbot software, you will need to obtain an identifier
-and password for your worker so it can join the fleet.  Email
-python-buildbots@python.org to discuss adding your worker and to obtain the
+and password for your worker so it can join the fleet.  Open an issue in the
+`configuration repository <https://github.com/python/buildmaster-config/issue/new/choose>`_
+to discuss adding your worker and to obtain the
 needed workername and password.  You can do some of the steps that follow
 before having the credentials, but it is easiest to have them before
 the "buildbot worker" step below.


### PR DESCRIPTION


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1156.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->