### PR TITLE
Clarify that PyUnstable macros use "PyUnstable" prefix

### DIFF
--- a/developer-workflow/c-api.rst
+++ b/developer-workflow/c-api.rst
@@ -217,6 +217,8 @@ Moving an API from the public tier to Unstable
 ----------------------------------------------
 
 * Expose the API under its new name, with the ``PyUnstable_`` prefix.
+  The ``PyUnstable_`` prefix must be used for all symbols (functions, macros,
+  variables, etc.).
 * Make the old name an alias (e.g. a ``static inline`` function calling the
   new function).
 * Deprecate the old name, typically using :c:macro:`Py_DEPRECATED`.


### PR DESCRIPTION
Discussion: https://github.com/python/cpython/pull/108440#issuecomment-1699105964

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1158.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->