### PR TITLE
Fix typos to follow style guide

### DIFF
--- a/core-developers/motivations.rst
+++ b/core-developers/motivations.rst
@@ -166,7 +166,7 @@ participating in the CPython core development process:
    business started declining) to being a full time independent consultant,
    David started contributing directly to CPython development.  He became a
    committer in 2009.  He subsequently took over primary maintenance of the
-   email package from Barry Warsaw, and contributed the unicode oriented API.
+   email package from Barry Warsaw, and contributed the Unicode oriented API.
    David is also active in mentoring new contributors and, when time is
    available, working on the infrastructure that supports CPython development,
    specifically the Roundup-based bug tracker and the buildbot system.
@@ -175,7 +175,7 @@ participating in the CPython core development process:
    primarily in Python, through the company in which he is a partner, `Murray &
    Walker, Inc <https://www.murrayandwalker.com>`_.  He has done contract work
    focused specifically on CPython development both through the PSF (the
-   kickstart of the email unicode API development) and directly funded by
+   kickstart of the email Unicode API development) and directly funded by
    interested corporations (additional development work on email funded by
    QNX, and work on CPython ICC support funded by Intel).  He would like to
    spend more of his (and his company's) time on open source work, and so is

--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -56,7 +56,7 @@ sections are in title case, you can either convert all titles to
 sentence case or use the dominant style in the new section title.
 
 Sentences that start with a word for which specific rules require
-starting it with a lower case letter should be avoided.
+starting it with a lowercase letter should be avoided.
 
 .. note::
 
@@ -92,7 +92,7 @@ Python
 reST
    For "reStructuredText," an easy to read, plaintext markup syntax
    used to produce Python documentation.  When spelled out, it is
-   always one word and both forms start with a lower case 'r'.
+   always one word and both forms start with a lowercase 'r'.
 
 Unicode
    The name of a character coding system. This is always written

--- a/documentation/translating.rst
+++ b/documentation/translating.rst
@@ -151,7 +151,7 @@ The important steps look like this:
 - Create the GitHub repo (anywhere) with the right hierarchy (using the
   cookiecutter).
 - Gather people to help you translate. You can't do it alone.
-- You can use any tool to translate, as long as you can synchronize with git.
+- You can use any tool to translate, as long as you can synchronize with Git.
   Some use Transifex, and some use only GitHub. You can choose another
   way if you like; it's up to you.
 - Ensure we update this page to reflect your work and progress, either via a
@@ -211,7 +211,7 @@ Here's what we're using:
   from one file to others.
 - `pospell <https://pypi.org/project/pospell/>`__ to check for typos in ``.po`` files.
 - `powrap <https://pypi.org/project/powrap/>`__ to rewrap the ``.po`` files
-  before committing. This helps keep git diffs short.
+  before committing. This helps keep Git diffs short.
 - `potodo <https://pypi.org/project/potodo/>`__ to list what needs to be translated.
 
 
@@ -240,7 +240,7 @@ Ask on the `translation mailing list <translation_ml_>`_, or better, make a PR o
 <https://github.com/python/devguide/>`__.
 
 
-I have a translation, but it's not in git. What should I do?
+I have a translation, but it's not in Git. What should I do?
 ------------------------------------------------------------
 
 You can ask for help on the `translation mailing list <translation_ml_>`_, and
@@ -248,7 +248,7 @@ the team will help you create an appropriate repository. You can still use tools
 if you like.
 
 
-My git hierarchy does not match yours. Can I keep it?
+My Git hierarchy does not match yours. Can I keep it?
 -----------------------------------------------------
 
 No, inside the ``github.com/python`` organization we’ll all have the

--- a/getting-started/git-boot-camp.rst
+++ b/getting-started/git-boot-camp.rst
@@ -10,11 +10,11 @@ Git Bootcamp and Cheat Sheet
 
    This section provides instructions on common tasks in CPython's
    workflow. It's designed to assist new contributors who have
-   some familiarity with git and GitHub.
+   some familiarity with Git and GitHub.
 
-   If you are new to git and GitHub, please become comfortable with
+   If you are new to Git and GitHub, please become comfortable with
    these instructions before submitting a pull request. As there are several
-   ways to accomplish these tasks using git and GitHub, this section reflects
+   ways to accomplish these tasks using Git and GitHub, this section reflects
    one method suitable for new contributors. Experienced contributors may
    desire a different approach.
 
@@ -23,9 +23,9 @@ In this section, we will go over some commonly used Git commands that are
 relevant to CPython's workflow.
 
 .. note::
-   Setting up git aliases for common tasks can be useful to you. You can
+   Setting up Git aliases for common tasks can be useful to you. You can
    get more information about that in
-   `git documentation <https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases>`_
+   `Git documentation <https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases>`_
 
 .. _fork-cpython:
 
@@ -544,7 +544,7 @@ page.  Find the event that says something like::
 
 By following the link to ``<commit_sha1>``, you will get the full commit hash.
 
-Alternatively, the commit hash can also be obtained by the following git
+Alternatively, the commit hash can also be obtained by the following Git
 commands:
 
 .. code-block:: bash

--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -132,7 +132,7 @@ You should have already :ref:`set up your system <setup>`,
      git pull origin <branch-name>  # pull = fetch + merge
 
     If you have made local changes that have not been pushed to your fork and
-    there are merge conflicts, git will warn you about this and enter conflict
+    there are merge conflicts, Git will warn you about this and enter conflict
     resolution mode. See :ref:`resolving-merge-conflicts` below.
 
 * If time passes and there are merge conflicts with the main branch, GitHub
@@ -165,14 +165,14 @@ resolved as follows:
       git status
 
 #. Edit the affected files and bring them to their intended final state.
-   Make sure to remove the special "conflict markers" inserted by git.
+   Make sure to remove the special "conflict markers" inserted by Git.
 
 #. Commit the affected files::
 
       git add <filenames>
       git merge --continue
 
-When running the final command, git may open an editor for writing a commit
+When running the final command, Git may open an editor for writing a commit
 message. It is usually okay to leave that as-is and close the editor.
 
 See `the merge command's documentation <https://git-scm.com/docs/git-merge>`_
@@ -303,7 +303,7 @@ to explain in proper depth what has happened (detail should be good enough
 that a core developer reading the commit message understands the
 justification for the change).
 
-Check :ref:`the git bootcamp <accepting-and-merging-a-pr>` for further
+Check :ref:`the Git bootcamp <accepting-and-merging-a-pr>` for further
 instructions on how the commit message should look like when merging a pull
 request.
 

--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -241,7 +241,7 @@ should do to help ensure that your pull request is accepted.
 ``patchcheck`` is a simple automated patch checklist that guides a developer
 through the common patch generation checks. To run ``patchcheck``:
 
-   On *UNIX* (including macOS)::
+   On *Unix* (including macOS)::
 
       make patchcheck
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -15,28 +15,28 @@ directory structure of the CPython source code.
 Alternatively, if you have `Docker <https://www.docker.com/>`_ installed you
 might want to use `our official images
 <https://gitlab.com/python-devs/ci-images/blob/main/README.md>`_.  These
-contain the latest releases of several Python versions, along with git head,
+contain the latest releases of several Python versions, along with Git head,
 and are provided for development and testing purposes only.
 
 .. seealso::
 
    The :ref:`quick-reference` gives brief summary of the process from
-   installing git to submitting a pull request.
+   installing Git to submitting a pull request.
 
 .. _vcsetup:
 
-Install ``git``
-===============
+Install Git
+===========
 
-CPython is developed using `git <https://git-scm.com>`_ for version control. The git
-command line program is named ``git``; this is also used to refer to git
-itself. git is easily available for all common operating systems.
+CPython is developed using `Git <https://git-scm.com>`_ for version control. The Git
+command line program is named ``git``; this is also used to refer to Git
+itself. Git is easily available for all common operating systems.
 
 - **Install**
 
   As the CPython repo is hosted on GitHub, please refer to either the
   `GitHub setup instructions <https://docs.github.com/en/get-started/quickstart/set-up-git>`_
-  or the `git project instructions <https://git-scm.com>`_ for step-by-step
+  or the `Git project instructions <https://git-scm.com>`_ for step-by-step
   installation directions. You may also want to consider a graphical client
   such as `TortoiseGit <https://tortoisegit.org/>`_ or
   `GitHub Desktop <https://desktop.github.com/>`_.

--- a/index.rst
+++ b/index.rst
@@ -27,7 +27,7 @@ instructions please see the :ref:`setup guide <setup>`.
       git clone https://github.com/<your_username>/cpython
       cd cpython
 
-3. Build Python, on UNIX and macOS use::
+3. Build Python, on Unix and macOS use::
 
       ./configure --with-pydebug && make -j
 
@@ -39,7 +39,7 @@ instructions please see the :ref:`setup guide <setup>`.
 
    See also :ref:`more detailed instructions <compiling>`,
    :ref:`how to install and build dependencies <build-dependencies>`,
-   and the platform-specific pages for :ref:`UNIX <unix-compiling>`,
+   and the platform-specific pages for :ref:`Unix <unix-compiling>`,
    :ref:`macOS`, and :ref:`Windows <windows-compiling>`.
 
 4. :ref:`Run the tests <runtests>`::

--- a/internals/parser.rst
+++ b/internals/parser.rst
@@ -570,7 +570,7 @@ Pegen has some special grammatical elements and rules:
 
 * Strings with single quotes (') (e.g. ``'class'``) denote KEYWORDS.
 * Strings with double quotes (") (e.g. ``"match"``) denote SOFT KEYWORDS.
-* Upper case names (e.g. ``NAME``) denote tokens in the :cpy-file:`Grammar/Tokens` file.
+* Uppercase names (e.g. ``NAME``) denote tokens in the :cpy-file:`Grammar/Tokens` file.
 * Rule names starting with ``invalid_`` are used for specialized syntax errors.
 
   - These rules are NOT used in the first pass of the parser.

--- a/testing/new-buildbot-worker.rst
+++ b/testing/new-buildbot-worker.rst
@@ -26,7 +26,7 @@ contribute a buildbot but have questions.
 
 As for what kind of buildbot to run...take a look at our `current fleet
 <https://buildbot.python.org/all/>`_.  Pretty much anything that isn't
-on that list would be interesting: different Linux/UNIX distributions,
+on that list would be interesting: different Linux/Unix distributions,
 different versions of the various OSes, other OSes if you or someone are
 prepared to make the test suite actually pass on that new OS.  Even if you only
 want to run an OS that's already on our list there may be utility in setting it


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Following the [devguide style guide](https://devguide.python.org/documentation/style-guide/#capitalization):

* unicode -> Unicode
* UNIX -> Unix

Also:

* git -> Git when the proper noun (not changing `git` the command)
* lower case and upper case -> lowercase and uppercase (more common in CPython docs, also according to Microsoft and Red Hat style guides)


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1163.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->