### PR TITLE
Remove redundant references to python-committers

### DIFF
--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -29,8 +29,7 @@ After a candidate has demonstrated consistent contributions, commit privileges
 are granted through these steps:
 
 #. A core developer (submitter, usually the mentor) starts a poll in the
-   `Committers category`_ on the `Python Discourse`_ and cross-posts it to
-   the `python-committers mailing list`_.
+   `Committers category`_ on the `Python Discourse`_.
 
    - Open for 7 days
    - Results shown upon close
@@ -45,8 +44,6 @@ are granted through these steps:
 
    - A request for account details as required by
      `🔒 python/voters <https://github.com/python/voters>`_
-   - A request for the committer's preferred address for subscription to
-     the `python-committers mailing list`_
    - A reminder about the `Code of Conduct`_ and guidance on reporting issues
      to the PSF Conduct WG
 
@@ -62,4 +59,3 @@ are granted through these steps:
 .. _Code of Conduct: https://www.python.org/psf/conduct/
 .. _Committers category: https://discuss.python.org/c/committers/5
 .. _Python Discourse: https://discuss.python.org
-.. _python-committers mailing list: https://mail.python.org/mailman3/lists/python-committers.python.org/

--- a/core-developers/motivations.rst
+++ b/core-developers/motivations.rst
@@ -89,9 +89,9 @@ participating in the CPython core development process:
    If there's a kind of link you'd like to include in your entry that isn't
    already covered by the categories mentioned above, please start a discussion
    about that on the Committers category on the Python Discourse
-   (discuss.python.org) or the python-committers mailing list.
+   (discuss.python.org).
 
-   The Committers Discourse category or the python-committers mailing list
+   The Committers Discourse category
    is also the appropriate point of contact for any other
    questions or suggestions relating to this page.
 

--- a/developer-workflow/communication-channels.rst
+++ b/developer-workflow/communication-channels.rst
@@ -91,8 +91,7 @@ the `Committers`_ category, where posting is restricted to the `CPython
 <https://github.com/python/cpython>`_ core developers.
 
 The Committers category is often used for announcements and notifications.
-It is also the designated venue for the core developer promotion votes
-(as the Discourse equivalent of the `python-committers`_ mailing list).
+It is also the designated venue for the core developer promotion votes.
 
 Tutorials for new users
 -----------------------


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


The [python-committers](https://mail.python.org/mailman3/lists/python-committers.python.org/) mailing list is read-only after being closed in favour of discuss.python.org:

* https://github.com/python/steering-council/blob/main/updates/2023-07-steering-council-update.md#2023-07-17 
* https://mail.python.org/archives/list/python-committers@python.org/message/6WA76BWOJMQFPOJBSFAJABDXVGHOY732/


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1166.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->