### PR TITLE
Note when to backport changes

### DIFF
--- a/developer-workflow/development-cycle.rst
+++ b/developer-workflow/development-cycle.rst
@@ -78,7 +78,7 @@ releases; the terms are used interchangeably. These releases have a
 
 The only changes allowed to occur in a maintenance branch without debate are
 bug fixes, test improvements, and edits to the documentation.
-Also, a general rule for maintenance branches is that compatibility 
+Also, a general rule for maintenance branches is that compatibility
 must not be broken at any point between sibling micro releases (3.5.1, 3.5.2,
 etc.).  For both rules, only rare exceptions are accepted and **must** be
 discussed first.

--- a/developer-workflow/development-cycle.rst
+++ b/developer-workflow/development-cycle.rst
@@ -83,7 +83,7 @@ must not be broken at any point between sibling micro releases (3.5.1, 3.5.2,
 etc.).  For both rules, only rare exceptions are accepted and **must** be
 discussed first.
 
-Back-porting changes reduces the risk of future conflicts.
+Backporting changes reduces the risk of future conflicts.
 For documentation, it increases the visibility of improvements,
 since most readers access the `stable documentation <https://docs.python.org/3/>`__
 rather than the `development documentation <https://docs.python.org/dev/>`__.

--- a/developer-workflow/development-cycle.rst
+++ b/developer-workflow/development-cycle.rst
@@ -83,15 +83,10 @@ must not be broken at any point between sibling micro releases (3.5.1, 3.5.2,
 etc.).  For both rules, only rare exceptions are accepted and **must** be
 discussed first.
 
-Backporting serves dual purposes. First, it increases the visibility of
-documentation changes since most users refer to stable versions at
-`docs.python.org/3/ <https://docs.python.org/3/>`_ rather
-than the `docs.python.org/dev/ <https://docs.python.org/dev/>`_ documentation.
-Second, it minimizes conflicts for future bugfix backports.
-
-Backporting should target enhancements in documentation and tests for
-currently **stable** versions, specifically branches in a **bugfix** release cycle
-or higher.
+Back-porting changes reduces the risk of future conflicts.
+For documentation, it increases the visibility of improvements,
+since most readers access the `stable documentation <https://docs.python.org/3/>`__
+rather than the `development documentation <https://docs.python.org/dev/>`__.
 
 A new maintenance branch is normally created when the next feature release
 cycle reaches feature freeze, i.e. at its first beta pre-release.

--- a/developer-workflow/development-cycle.rst
+++ b/developer-workflow/development-cycle.rst
@@ -77,10 +77,21 @@ releases; the terms are used interchangeably. These releases have a
 **micro version** number greater than zero.
 
 The only changes allowed to occur in a maintenance branch without debate are
-bug fixes.  Also, a general rule for maintenance branches is that compatibility
+bug fixes. Also, a general rule for maintenance branches is that compatibility
 must not be broken at any point between sibling micro releases (3.5.1, 3.5.2,
-etc.).  For both rules, only rare exceptions are accepted and **must** be
-discussed first.
+etc.). For both rules, only rare exceptions are accepted and **must** be
+discussed first. Among the rare exceptions to the rules of bug fixes and compatibility,
+backporting of documentation and tests is encouraged.
+
+Backporting serves dual purposes. First, it increases the visibility of
+documentation changes since most users refer to stable versions at
+`docs.python.org/3/ <https://docs.python.org/3/>`_ rather
+than the `docs.python.org/dev/ <https://docs.python.org/dev/>`_ documentation.
+Second, it minimizes conflicts for future bugfix backports.
+
+Backporting should target enhancements in documentation and tests for
+currently **stable** versions, specifically branches in a **bugfix** release cycle
+or higher.
 
 A new maintenance branch is normally created when the next feature release
 cycle reaches feature freeze, i.e. at its first beta pre-release.

--- a/developer-workflow/development-cycle.rst
+++ b/developer-workflow/development-cycle.rst
@@ -77,11 +77,10 @@ releases; the terms are used interchangeably. These releases have a
 **micro version** number greater than zero.
 
 The only changes allowed to occur in a maintenance branch without debate are
-bug fixes. Also, a general rule for maintenance branches is that compatibility
-must not be broken at any point between sibling micro releases (3.5.1, 3.5.2,
-etc.). For both rules, only rare exceptions are accepted and **must** be
-discussed first. Among the rare exceptions to the rules of bug fixes and compatibility,
-backporting of documentation and tests is encouraged.
+bug fixes and the backporting of documentation and tests.  Also, a general rule
+for maintenance branches is that compatibility must not be broken at any point
+between sibling micro releases (3.5.1, 3.5.2, etc.). For both rules,
+only rare exceptions are accepted and **must** be discussed first.
 
 Backporting serves dual purposes. First, it increases the visibility of
 documentation changes since most users refer to stable versions at

--- a/developer-workflow/development-cycle.rst
+++ b/developer-workflow/development-cycle.rst
@@ -77,10 +77,11 @@ releases; the terms are used interchangeably. These releases have a
 **micro version** number greater than zero.
 
 The only changes allowed to occur in a maintenance branch without debate are
-bug fixes and the backporting of documentation and tests.  Also, a general rule
-for maintenance branches is that compatibility must not be broken at any point
-between sibling micro releases (3.5.1, 3.5.2, etc.). For both rules,
-only rare exceptions are accepted and **must** be discussed first.
+bug fixes, test improvements, and edits to the documentation.
+Also, a general rule for maintenance branches is that compatibility 
+must not be broken at any point between sibling micro releases (3.5.1, 3.5.2,
+etc.).  For both rules, only rare exceptions are accepted and **must** be
+discussed first.
 
 Backporting serves dual purposes. First, it increases the visibility of
 documentation changes since most users refer to stable versions at

--- a/versions.rst
+++ b/versions.rst
@@ -50,8 +50,7 @@ Status key
     but new source-only versions can be released
 :end-of-life: release cycle is frozen; no further changes can be pushed to it.
 
-See also :ref:`devcycle` for branch information and :ref:`maintbranch` for details on
-backporting documentation and test changes above the **bugfix** level.
+See also the :ref:`devcycle` page for more information about branches and backporting.
 
 By default, the end-of-life is scheduled 5 years after the first release,
 but can be adjusted by the release manager of each branch.  All Python 2

--- a/versions.rst
+++ b/versions.rst
@@ -50,7 +50,8 @@ Status key
     but new source-only versions can be released
 :end-of-life: release cycle is frozen; no further changes can be pushed to it.
 
-See also the :ref:`devcycle` page for more information about branches.
+See also :ref:`devcycle` for branch information and :ref:`maintbranch` for details on
+backporting documentation and test changes above the **bugfix** level.
 
 By default, the end-of-life is scheduled 5 years after the first release,
 but can be adjusted by the release manager of each branch.  All Python 2


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

- Adds guidelines on what release cycles (where) should get backports of documentation and testing improvements. 

## Closes

- #1168
- Maybe #1069(?)


<details>
<summary>Changes visualized:</summary>
<a href="https://cpython-devguide--1169.org.readthedocs.build/developer-workflow/development-cycle/#maintenance-branches">Dev. Cycle</a>
<img src="https://github.com/python/devguide/assets/45884264/ce42405c-7286-4b64-916f-ee6ece0a38c6">
<a href="https://cpython-devguide--1169.org.readthedocs.build/versions/#status-key">Versions</a>
<img src="https://github.com/python/devguide/assets/45884264/7b388dc7-781c-4a34-b640-490a0b1303fe">
</details>


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1169.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->