### PR TITLE
Enable nit-picky mode in ``conf.py``

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 PYTHON        = python3
 VENVDIR       = ./venv
 BUILDDIR      = _build
-SPHINXOPTS    = -W --keep-going -n
+SPHINXOPTS    = -W --keep-going
 SPHINXBUILD   = $(VENVDIR)/bin/sphinx-build
 SPHINXLINT    = $(VENVDIR)/bin/sphinx-lint
 PAPER         =

--- a/conf.py
+++ b/conf.py
@@ -32,6 +32,8 @@ exclude_patterns = [
     '.github',
 ]
 
+nitpicky = True
+
 
 html_theme = 'furo'
 html_theme_options = {


### PR DESCRIPTION
This will mean references will be checked regardless of how Sphinx is run.

A

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1170.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->