### PR TITLE
Avoid the deprecated `.. cmdoption::` directive

### DIFF
--- a/documentation/markup.rst
+++ b/documentation/markup.rst
@@ -575,12 +575,12 @@ The directives are:
 
    Describes a Python :term:`bytecode` instruction.
 
-.. describe:: cmdoption
+.. describe:: option
 
    Describes a Python command line option or switch.  Option argument names
    should be enclosed in angle brackets.  Example::
 
-      .. cmdoption:: -m <module>
+      .. option:: -m <module>
 
          Run a module as a script.
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Companion to https://github.com/python/cpython/pull/110292.

``cmdoption`` has been [deprecated](https://www.sphinx-doc.org/en/master/usage/domains/standard.html#directive-option) since [Sphinx 1.0 (2010)](https://pypi.org/project/Sphinx/1.0/).


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1176.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->