### PR TITLE
Clarify close as not planned for triage

### DIFF
--- a/triage/triaging.rst
+++ b/triage/triaging.rst
@@ -22,7 +22,7 @@ Checklist for triaging
 * You might also leave a brief comment about the proposed next action needed.
   If there is a long message list, a summary can be very helpful.
 * If the issue is clearly invalid (unrelated to CPython, duplicate, spam, etc),
-  you can close it as "not planned".
+  you can use GitHub's "Close as not planned" option.
 
 Assignees
 ---------


### PR DESCRIPTION
Clarify the close step in the triage checklist. TIL from @erlend-aasland. 👍🏼 


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1186.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->