### PR TITLE
Add recommended locales to the testing document

### DIFF
--- a/testing/run-write-tests.rst
+++ b/testing/run-write-tests.rst
@@ -112,6 +112,10 @@ or buildbots include:
   cases of "i" and "I".
 * ``ps_AF`` --- used in ``test_decimal``
 
+On Linux and macOS, the ``locale`` command can be used to list available
+locales and change the settings. Environment variables ``LANG`` and those
+prefixed with ``LC_`` can be used to set the locale.
+
 Unexpected skips
 ----------------
 

--- a/testing/run-write-tests.rst
+++ b/testing/run-write-tests.rst
@@ -96,6 +96,21 @@ CPython checkout. The script tries to balance speed with thoroughness. But if
 you want the most thorough tests you should use the strenuous approach shown
 above.
 
+Locale support
+--------------
+
+Some tests require specific locales to run successfully. These locales are
+often non-default, non-English, non-UTF-8 locales. If a necessary locale is
+unavailable, the test is skipped or runs in the dry-run mode.
+Additional locales that you may find helpful to set up on developer's machines
+or buildbots include:
+
+* ``en_US`` (``en_US.utf8``, ``en_US.iso88591``) -- the standard default
+* ``de_DE`` (``de_DE.UTF-8``) or ``fr_FR`` (``fr_FR.utf8``, ``fr_FR.iso88591``,
+  ``fr_FR.iso885915@euro``) -- common non-English locales
+* ``tr_TR`` (``tr_TR.iso88599``) -- Turkish has different rules for upper/lower
+  cases of "i" and "I".
+* ``ps_AF`` -- used in ``test_decimal``
 
 Unexpected skips
 ----------------

--- a/testing/run-write-tests.rst
+++ b/testing/run-write-tests.rst
@@ -105,12 +105,12 @@ unavailable, the test is skipped or runs in the dry-run mode.
 Additional locales that you may find helpful to set up on developer's machines
 or buildbots include:
 
-* ``en_US`` (``en_US.utf8``, ``en_US.iso88591``) -- the standard default
+* ``en_US`` (``en_US.utf8``, ``en_US.iso88591``) --- the standard default
 * ``de_DE`` (``de_DE.UTF-8``) or ``fr_FR`` (``fr_FR.utf8``, ``fr_FR.iso88591``,
-  ``fr_FR.iso885915@euro``) -- common non-English locales
-* ``tr_TR`` (``tr_TR.iso88599``) -- Turkish has different rules for upper/lower
+  ``fr_FR.iso885915@euro``) --- common non-English locales
+* ``tr_TR`` (``tr_TR.iso88599``) --- Turkish has different rules for upper/lower
   cases of "i" and "I".
-* ``ps_AF`` -- used in ``test_decimal``
+* ``ps_AF`` --- used in ``test_decimal``
 
 Unexpected skips
 ----------------


### PR DESCRIPTION
Closes #874 

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1187.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->