### PR TITLE
Update checklist: remove new core devs from triage team

### DIFF
--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -50,6 +50,7 @@ are granted through these steps:
 #. Once the candidate has provided the pertinent details, the approver will:
 
    - enable the various new privileges;
+   - remove from triage team, if applicable;
    - add the new committer's details to
      `🔒 python/voters <https://github.com/python/voters>`_;
    - update the devguide to publicly list the new committer's team membership

--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -50,10 +50,9 @@ are granted through these steps:
 #. Once the candidate has provided the pertinent details, the approver will:
 
    - Enable the various new privileges.
-   - Remove from triage team, if applicable.
-   - Add the new committer's details to
-     `🔒 python/voters <https://github.com/python/voters>`_.
-   - Update the devguide to publicly list the new committer's team membership
+   - Remove the new committer from the triage team, if applicable.
+   - Add their details to `🔒 python/voters <https://github.com/python/voters>`_.
+   - Update the devguide to publicly list their team membership
      at :ref:`developers`.
    - Send an announcement email to the `Committers Discourse category
      <https://discuss.python.org/c/committers/5>`_.

--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -31,8 +31,8 @@ are granted through these steps:
 #. A core developer (submitter, usually the mentor) starts a poll in the
    `Committers category`_ on the `Python Discourse`_.
 
-   - Open for 7 days.
-   - Results shown upon close.
+   - open for 7 days
+   - results shown upon close
 
 #. If the candidate receives at least two-thirds positive votes when the poll closes
    (as per :pep:`13`), the submitter `emails the steering council

--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -55,7 +55,8 @@ are granted through these steps:
      `🔒 python/voters <https://github.com/python/voters>`_.
    - Update the devguide to publicly list the new committer's team membership
      at :ref:`developers`.
-   - Send an announcement email to the Committers Discourse category.
+   - Send an announcement email to the `Committers Discourse category
+     <https://discuss.python.org/c/committers/5>`_.
 
 .. _Code of Conduct: https://www.python.org/psf/conduct/
 .. _Committers category: https://discuss.python.org/c/committers/5

--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -31,8 +31,8 @@ are granted through these steps:
 #. A core developer (submitter, usually the mentor) starts a poll in the
    `Committers category`_ on the `Python Discourse`_.
 
-   - Open for 7 days
-   - Results shown upon close
+   - Open for 7 days.
+   - Results shown upon close.
 
 #. If the candidate receives at least two-thirds positive votes when the poll closes
    (as per :pep:`13`), the submitter `emails the steering council
@@ -43,19 +43,19 @@ are granted through these steps:
    (approver) will email the candidate:
 
    - A request for account details as required by
-     `🔒 python/voters <https://github.com/python/voters>`_
+     `🔒 python/voters <https://github.com/python/voters>`_.
    - A reminder about the `Code of Conduct`_ and guidance on reporting issues
-     to the PSF Conduct WG
+     to the PSF Conduct WG.
 
 #. Once the candidate has provided the pertinent details, the approver will:
 
-   - enable the various new privileges;
-   - remove from triage team, if applicable;
-   - add the new committer's details to
-     `🔒 python/voters <https://github.com/python/voters>`_;
-   - update the devguide to publicly list the new committer's team membership
-     at :ref:`developers`;
-   - send an announcement email to the Committers Discourse category.
+   - Enable the various new privileges.
+   - Remove from triage team, if applicable.
+   - Add the new committer's details to
+     `🔒 python/voters <https://github.com/python/voters>`_.
+   - Update the devguide to publicly list the new committer's team membership
+     at :ref:`developers`.
+   - Send an announcement email to the Committers Discourse category.
 
 .. _Code of Conduct: https://www.python.org/psf/conduct/
 .. _Committers category: https://discuss.python.org/c/committers/5


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

When adding new core devs, we can do some tidyup and remove them from the [triage team](https://github.com/orgs/python/teams?query=triage) (they could be in "Docs Triagers" or "Python triage").

Also a little tidy up: punctuate list items following this [Google style guide](https://developers.google.com/tech-writing/one/lists-and-tables#punctuate_items_appropriately), and add a link for convenience.

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1191.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->