### PR TITLE
Move author to a block at end of document for CPython Internals docs on parser and GC

### DIFF
--- a/internals/garbage-collector.rst
+++ b/internals/garbage-collector.rst
@@ -6,8 +6,6 @@
 Garbage collector design
 ========================
 
-:Author: Pablo Galindo Salgado
-
 .. highlight:: none
 
 Abstract
@@ -497,3 +495,9 @@ tracking status of the object.
       False
       >>> gc.is_tracked({"a": []})
       True
+
+
+.. admonition:: Document History
+   :class: note
+
+   Pablo Galindo Salgado - Original Author

--- a/internals/parser.rst
+++ b/internals/parser.rst
@@ -919,7 +919,7 @@ References
    http://web.cs.ucla.edu/~todd/research/pepm08.pdf
 
 
-.. admonition:: Document History
+.. admonition:: Document history
    :class: note
 
-   Pablo Galindo Salgado - Original Author
+   Pablo Galindo Salgado - Original author

--- a/internals/parser.rst
+++ b/internals/parser.rst
@@ -4,8 +4,6 @@
 Guide to the parser
 ===================
 
-:Author: Pablo Galindo Salgado
-
 .. highlight:: none
 
 Abstract
@@ -919,3 +917,9 @@ References
 
 .. [3] Warth et al.
    http://web.cs.ucla.edu/~todd/research/pepm08.pdf
+
+
+.. admonition:: Document History
+   :class: note
+
+   Pablo Galindo Salgado - Original Author


### PR DESCRIPTION
- Move the author to a document history block at the end of the parser and GC docs

This is the second of three CPython Internals PRs.

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1193.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->