### PR TITLE
Remove Distutils from the experts index

### DIFF
--- a/core-developers/experts.rst
+++ b/core-developers/experts.rst
@@ -100,7 +100,6 @@ dbm
 decimal               facundobatista, rhettinger, mdickinson
 difflib               tim-one (inactive)
 dis                   1st1
-distutils             merwok, dstufft
 doctest               tim-one (inactive)
 email                 warsaw, bitdancer*, maxking
 encodings             malemburg


### PR DESCRIPTION


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1198.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->