### PR TITLE
Add timeout to CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,11 @@ env:
 jobs:
   test:
     name: Check build, markup, and links
-
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3"

--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   documentation-links:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: readthedocs/actions/preview@v1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,9 +5,10 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

This linkcheck job hung and was going to take the full (6h?) time before I cancelled it after 5.5 hours!

https://github.com/python/devguide/actions/runs/6558353388/job/17811745428

Let's add a timeout. 10 minutes should be more than enough for these.


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1200.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->