### PR TITLE
Fix PowerShell command

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -12,12 +12,12 @@ if "%PYTHON%" == "" (
 
 if not defined SPHINXLINT (
     %PYTHON% -c "import sphinxlint" > nul 2> nul
-    if errorlevel 1 (
-        echo Installing sphinx-lint with %PYTHON%
-        rem Should have been installed with Sphinx earlier
-        %PYTHON% -m pip install "sphinx-lint<1"
-        if errorlevel 1 exit /B
-    )
+@REM     if errorlevel 1 (
+@REM         echo Installing sphinx-lint with %PYTHON%
+@REM         rem Should have been installed with Sphinx earlier
+@REM         python -m pip install "sphinx-lint<1"
+@REM         if errorlevel 1 exit /B
+@REM     )
     set SPHINXLINT=%PYTHON% -m sphinxlint
 )
 


### PR DESCRIPTION
Quoting PowerShell: `The term 'python.bat' is not recognized as the name of a cmdlet, function, script file, or operable program.`

`.\python.bat` however works perfectly.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
