### PR TITLE
Fix PowerShell command

### DIFF
--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -249,7 +249,7 @@ On *Windows* (after any successful build):
 
 .. code-block:: dosbatch
 
-   python.bat Tools\patchcheck\patchcheck.py
+   .\python.bat Tools\patchcheck\patchcheck.py
 
 The automated patch checklist runs through:
 


### PR DESCRIPTION
Quoting PowerShell: `The term 'python.bat' is not recognized as the name of a cmdlet, function, script file, or operable program.`

`.\python.bat` however works perfectly.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1202.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->