### PR TITLE
Add inline tabs on Quick Reference page for commands on different systems

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -11,9 +11,9 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx_copybutton',
+    'sphinx_inline_tabs',
     'sphinxext.opengraph',
     'sphinxext.rediraffe',
-    'sphinx_inline_tabs',
 ]
 
 # The master toctree document.

--- a/conf.py
+++ b/conf.py
@@ -13,6 +13,7 @@ extensions = [
     'sphinx_copybutton',
     'sphinxext.opengraph',
     'sphinxext.rediraffe',
+    'sphinx_inline_tabs',
 ]
 
 # The master toctree document.

--- a/index.rst
+++ b/index.rst
@@ -27,7 +27,7 @@ instructions please see the :ref:`setup guide <setup>`.
       git clone https://github.com/<your_username>/cpython
       cd cpython
 
-3. Build Python, on Unix and macOS use:
+3. Build Python:
 
    .. tab:: Unix
 

--- a/index.rst
+++ b/index.rst
@@ -66,15 +66,15 @@ instructions please see the :ref:`setup guide <setup>`.
 
          ./python.exe -m test -j3
 
+      Note: :ref:`Most <mac-python.exe>` macOS systems use
+      :file:`./python.exe` in order to avoid filename conflicts with
+      the ``Python`` directory.
+
    .. tab:: Windows
 
       .. code-block:: dosbatch
 
          .\python.bat -m test -j3
-
-   Note: :ref:`Most <mac-python.exe>` macOS systems use
-   :file:`./python.exe` in order to avoid filename conflicts with
-   the ``Python`` directory.
 
 5. Create a new branch where your work for the issue will go, e.g.::
 

--- a/index.rst
+++ b/index.rst
@@ -27,27 +27,54 @@ instructions please see the :ref:`setup guide <setup>`.
       git clone https://github.com/<your_username>/cpython
       cd cpython
 
-3. Build Python, on Unix and macOS use::
+3. Build Python, on Unix and macOS use:
 
-      ./configure --with-pydebug && make -j
+   .. tab:: Unix
 
-   and on Windows use:
+      .. code-block:: shell
 
-   .. code-block:: dosbatch
+         ./configure --with-pydebug && make -j
 
-      PCbuild\build.bat -e -d
+   .. tab:: macOS
+
+      .. code-block:: shell
+
+         ./configure --with-pydebug && make -j
+
+   .. tab:: Windows
+
+      .. code-block:: dosbatch
+
+         PCbuild\build.bat -e -d
 
    See also :ref:`more detailed instructions <compiling>`,
    :ref:`how to install and build dependencies <build-dependencies>`,
    and the platform-specific pages for :ref:`Unix <unix-compiling>`,
    :ref:`macOS`, and :ref:`Windows <windows-compiling>`.
 
-4. :ref:`Run the tests <runtests>`::
+4. :ref:`Run the tests <runtests>`:
 
-      ./python -m test -j3
+   .. tab:: Unix
 
-   On :ref:`most <mac-python.exe>` macOS systems, replace :file:`./python`
-   with :file:`./python.exe`.  On Windows, use :file:`python.bat`.
+      .. code-block:: shell
+
+         ./python -m test -j3
+
+   .. tab:: macOS
+
+      .. code-block:: shell
+
+         ./python.exe -m test -j3
+
+   .. tab:: Windows
+
+      .. code-block:: dosbatch
+
+         .\python.bat -m test -j3
+
+   Note: :ref:`Most <mac-python.exe>` macOS systems use
+   :file:`./python.exe` in order to avoid filename conflicts with
+   the ``Python`` directory.
 
 5. Create a new branch where your work for the issue will go, e.g.::
 
@@ -57,17 +84,25 @@ instructions please see the :ref:`setup guide <setup>`.
    <https://github.com/python/cpython/issues>`_.  Trivial issues (e.g. typo fixes) do
    not require any issue to be created.
 
-6. Once you fixed the issue, run the tests, and the patchcheck.
+6. Once you fixed the issue, run the tests, and the patchcheck:
 
-   On Unix and macOS use::
+   .. tab:: Unix
 
-      make patchcheck
+      .. code-block:: shell
 
-   and on Windows:
+         make patchcheck
+      
+   .. tab:: macOS
 
-   .. code-block:: dosbatch
+      .. code-block:: shell
 
-      .\python.bat Tools\patchcheck\patchcheck.py
+         make patchcheck
+
+   .. tab:: Windows
+
+      .. code-block:: dosbatch
+
+         .\python.bat Tools\patchcheck\patchcheck.py
 
    If everything is ok, commit.
 

--- a/index.rst
+++ b/index.rst
@@ -91,7 +91,7 @@ instructions please see the :ref:`setup guide <setup>`.
       .. code-block:: shell
 
          make patchcheck
-      
+
    .. tab:: macOS
 
       .. code-block:: shell

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ sphinx-notfound-page>=1.0.0
 sphinx_copybutton>=0.3.3
 sphinxext-opengraph>=0.7.1
 sphinxext-rediraffe
+sphinx-inline-tabs>=2023.4.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 Sphinx~=7.2.6
 furo>=2022.6.4
 jinja2
+sphinx-inline-tabs>=2023.4.21
 sphinx-lint==0.6.8
 sphinx-notfound-page>=1.0.0
 sphinx_copybutton>=0.3.3
 sphinxext-opengraph>=0.7.1
 sphinxext-rediraffe
-sphinx-inline-tabs>=2023.4.21


### PR DESCRIPTION
This is for work on #1196

This PR introduces a new dependency: [sphinx-inline-tabs](https://sphinx-inline-tabs.readthedocs.io/en/latest/)

There were two design decisions I am not set on:

1. Should we say "Unix" or "Linux"? I picked "Unix" because the [setup docs](https://devguide.python.org/getting-started/setup-building/#mac-python-exe) say "Unix".
2. Is the most useful order Unix, then macOS, then Windows. I would presume most developers are using macOS, but other examples I've seen start with "Linux" (e.g., [PyPI](https://pip.pypa.io/en/stable/installation/), [Pillow](https://pillow.readthedocs.io/en/stable/installation.html#basic-installation)), so I put "Unix" first.

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1205.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->