### PR TITLE
Add `make autobuild` to rebuild and reload HTML files in your browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ htmlview: html
 
 .PHONY: autobuild
 autobuild: SPHINXBUILD = $(VENVDIR)/bin/sphinx-autobuild
-autobuild: SPHINXOPTS =  # sphinx-autobuild has no "--keep-going"
+autobuild: SPHINXOPTS = --re-ignore="/\.idea/|/venv/"
 autobuild: html
 
 .PHONY: check

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ help:
 	@echo "  venv       to create a venv with necessary tools"
 	@echo "  html       to make standalone HTML files"
 	@echo "  htmlview   to open the index page built by the html target in your browser"
+	@echo "  autobuild  to rebuild and reload HTML files in your browser"
 	@echo "  clean      to remove the venv and build files"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
@@ -178,6 +179,11 @@ doctest: ensure-venv
 .PHONY: htmlview
 htmlview: html
 	$(PYTHON) -c "import os, webbrowser; webbrowser.open('file://' + os.path.realpath('_build/html/index.html'))"
+
+.PHONY: autobuild
+autobuild: SPHINXBUILD = $(VENVDIR)/bin/sphinx-autobuild
+autobuild: SPHINXOPTS =  # sphinx-autobuild has no "--keep-going"
+autobuild: html
 
 .PHONY: check
 check: ensure-venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-Sphinx~=7.2.6
 furo>=2022.6.4
 jinja2
+sphinx-autobuild
 sphinx-inline-tabs>=2023.4.21
 sphinx-lint==0.6.8
 sphinx-notfound-page>=1.0.0
 sphinx_copybutton>=0.3.3
 sphinxext-opengraph>=0.7.1
 sphinxext-rediraffe
+Sphinx~=7.2.6


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Add a `make autobuild` target to use https://github.com/executablebooks/sphinx-autobuild.

When you run it, it builds the docs and serves them at something like http://127.0.0.1:8000/

You can visit any page, for example http://127.0.0.1:8000/documentation/style-guide.html, and when you edit/save your source `.rst` file, it will automatically rebuild and update the page in the browser.

This drastically improves the edit/inspect loop. A very nice touch is it will also keep you at the same position in the page.

Compare before:

1. switch to IDE: edit, save
2. switch to prompt: `make html`
3. switch to browser: reload, inspect
4. repeat

To this PR:

1. switch to IDE: edit, save
2. ~switch to prompt: `make html`~
3. switch to browser: ~reload,~ inspect
4. repeat


We can add the same thing to CPython Docs and PEPs later.

cc @pradyunsg 



<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1208.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->