### PR TITLE
 omitting the "unused" prompt in code example

### DIFF
--- a/documentation/markup.rst
+++ b/documentation/markup.rst
@@ -618,7 +618,6 @@ an "unused" primary prompt; this is an example of what *not* to do:
 
    >>> 1 + 1
    2
-   >>>
 
 Syntax highlighting is handled in a smart way:
 

--- a/documentation/markup.rst
+++ b/documentation/markup.rst
@@ -611,8 +611,8 @@ preceding paragraph and delimited by indentation.
 
 Representing an interactive session requires including the prompts and output
 along with the Python code.  No special markup is required for interactive
-sessions.  After the last line of input or output presented, there should not be
-an "unused" primary prompt; this is an example of what *not* to do:
+sessions. After the last line of input or output is presented, there should
+be no trailing prompt. An example of correct usage is:
 
 .. code-block:: python
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
# Omitting the "unused" prompt in code example

updated the doc by removing unused prompt





 
 

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1210.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->