### PR TITLE
Rename 'make autobuild' to 'make htmllive'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ help:
 	@echo "  venv       to create a venv with necessary tools"
 	@echo "  html       to make standalone HTML files"
 	@echo "  htmlview   to open the index page built by the html target in your browser"
-	@echo "  autobuild  to rebuild and reload HTML files in your browser"
+	@echo "  htmllive   to rebuild and reload HTML files in your browser"
 	@echo "  clean      to remove the venv and build files"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
@@ -159,10 +159,10 @@ doctest: html
 htmlview: html
 	$(PYTHON) -c "import os, webbrowser; webbrowser.open('file://' + os.path.realpath('_build/html/index.html'))"
 
-.PHONY: autobuild
-autobuild: SPHINXBUILD = $(VENVDIR)/bin/sphinx-autobuild
-autobuild: SPHINXOPTS = --re-ignore="/\.idea/|/venv/"
-autobuild: html
+.PHONY: htmllive
+htmllive: SPHINXBUILD = $(VENVDIR)/bin/sphinx-autobuild
+htmllive: SPHINXOPTS = --re-ignore="/\.idea/|/venv/"
+htmllive: html
 
 .PHONY: check
 check: ensure-venv


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Follow on from https://github.com/python/devguide/pull/1208.

Naming things: After using this more, I think it is better as `make htmllive`, as you can do `make html<TAB>` and see the various related options:

```console
❯ make html
html      htmlhelp  htmllive  htmlview
```

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1212.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->