### PR TITLE
Update issue-tracker.rst - change Roundup link to canonical link

### DIFF
--- a/triage/issue-tracker.rst
+++ b/triage/issue-tracker.rst
@@ -154,7 +154,7 @@ reason either as ``complete`` or ``not planned``.
 .. _issue tracker: https://github.com/python/cpython/issues
 .. _advanced search: https://github.com/search/advanced
 .. _devguide repo: https://github.com/python/devguide/issues
-.. _Roundup: https://roundup.sourceforge.io/
+.. _Roundup: https://www.roundup-tracker.org/
 .. _Python Discourse: https://discuss.python.org/
 .. _autolinks: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls
 .. _checklists: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/about-task-lists


### PR DESCRIPTION
Use www.roundup-trcker.org rather than roundup.sourceforge.io.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1213.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->