### PR TITLE
Add a URL for bpo and clarify historical tracker in note

### DIFF
--- a/triage/issue-tracker.rst
+++ b/triage/issue-tracker.rst
@@ -17,8 +17,9 @@ If you would like to file an issue about this devguide, please do so at the
 `devguide repo`_.
 
 .. note::
+    Prior to moving the issue tracker to GitHub,
     Python used to use a dedicated `Roundup`_ instance as its issue tracker.
-    That old bug tracker was hosted under the domain ``bugs.python.org``
+    That `old bug tracker`_ was hosted under the domain ``bugs.python.org``
     (sometimes called ``bpo`` for short). Currently a read-only version is still
     available on that domain for historical purposes. All ``bpo`` data has been
     migrated to the current `issue tracker`_ on GitHub.
@@ -160,3 +161,4 @@ reason either as ``complete`` or ``not planned``.
 .. _checklists: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/about-task-lists
 .. _duplicates: https://docs.github.com/en/issues/tracking-your-work-with-issues/marking-issues-or-pull-requests-as-a-duplicate
 .. _Core Development Discourse category: https://discuss.python.org/c/core-dev/23
+.. _old bug tracker: https://bugs.python.org/

--- a/triage/issue-tracker.rst
+++ b/triage/issue-tracker.rst
@@ -20,7 +20,7 @@ If you would like to file an issue about this devguide, please do so at the
     Prior to moving the issue tracker to GitHub,
     Python used to use a dedicated `Roundup`_ instance as its issue tracker.
     That `old bug tracker`_ was hosted under the domain ``bugs.python.org``
-    (sometimes called ``bpo`` for short). Currently a read-only version is still
+    (sometimes called ``bpo`` for short). A read-only version is
     available on that domain for historical purposes. All ``bpo`` data has been
     migrated to the current `issue tracker`_ on GitHub.
 


### PR DESCRIPTION
When reviewing #1212, I noticed that we could be a bit clearer in the note about the historical tracker. 

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1214.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->