### PR TITLE
Activate tabs based on browser's operating system

### DIFF
--- a/_static/activate_tab.js
+++ b/_static/activate_tab.js
@@ -1,0 +1,42 @@
+// Based on https://stackoverflow.com/a/38241481/724176
+function getOS() {
+  const userAgent = window.navigator.userAgent,
+    platform =
+      window.navigator?.userAgentData?.platform || window.navigator.platform,
+    macosPlatforms = ["macOS", "Macintosh", "MacIntel", "MacPPC", "Mac68K"],
+    windowsPlatforms = ["Win32", "Win64", "Windows", "WinCE"],
+    iosPlatforms = ["iPhone", "iPad", "iPod"];
+
+  if (macosPlatforms.includes(platform)) {
+    return "macOS";
+  } else if (iosPlatforms.includes(platform)) {
+    return "iOS";
+  } else if (windowsPlatforms.includes(platform)) {
+    return "Windows";
+  } else if (/Android/.test(userAgent)) {
+    return "Android";
+  } else if (/Linux/.test(platform)) {
+    return "Unix";
+  }
+
+  return "unknown";
+}
+
+function activateTab(tabName) {
+  // Find all label elements containing the specified tab name
+  const labels = document.querySelectorAll(".tab-label");
+
+  labels.forEach((label) => {
+    if (label.textContent.includes(tabName)) {
+      // Find the associated input element using the 'for' attribute
+      const tabInputId = label.getAttribute("for");
+      const tabInput = document.getElementById(tabInputId);
+
+      // Check if the input element exists before attempting to set the "checked" attribute
+      if (tabInput) {
+        // Activate the tab by setting its "checked" attribute to true
+        tabInput.checked = true;
+      }
+    }
+  });
+}

--- a/conf.py
+++ b/conf.py
@@ -45,6 +45,9 @@ html_static_path = ['_static']
 html_css_files = [
     'devguide_overrides.css',
 ]
+html_js_files = [
+    "activate_tab.js",
+]
 html_logo = "_static/python-logo.svg"
 html_favicon = "_static/favicon.png"
 

--- a/index.rst
+++ b/index.rst
@@ -2,6 +2,14 @@
 Python Developer's Guide
 ========================
 
+.. raw:: html
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      activateTab(getOS());
+    });
+    </script>
+
 .. highlight:: bash
 
 This guide is a comprehensive resource for :ref:`contributing <contributing>`

--- a/testing/run-write-tests.rst
+++ b/testing/run-write-tests.rst
@@ -5,6 +5,14 @@
 Running and writing tests
 =========================
 
+.. raw:: html
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      activateTab(getOS());
+    });
+    </script>
+
 .. note::
 
     This document assumes you are working from an


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

For https://github.com/python/devguide/issues/1196.

After https://github.com/python/devguide/pull/1205 and https://github.com/python/devguide/pull/1206, we now have Unix/macOS/Windows tabs for https://devguide.python.org/ and https://devguide.python.org/testing/run-write-tests/.

This PR adds some JavaScript to check the browser's operating system, and then activates the relevant tab.

I've tested:

* [x] macOS with Chrome, Safari, Firefox, Opera -> macOS tab
* [x] Android with Chrome and Samsung Internet -> Unix tab (default)

Would be good if some other people could test:

* [ ] Linux -> Unix tab
* [ ] Windows -> Windows tab
* [ ] iPhone/iPad -> Unix tab (default)
* [ ] Anything else? -> Unix tab (default)
