### PR TITLE
Document 'make htmllive'

### DIFF
--- a/documentation/devguide.rst
+++ b/documentation/devguide.rst
@@ -44,11 +44,11 @@ in the checkout directory.  On Windows use:
 
 You will find the generated files in ``_build/html``.
 
-.. tip:: * Substitute ``htmlview`` for ``html`` to open the docs in a web browser
+.. tip:: * Replace ``html`` with ``htmlview`` to open the docs in a web browser
            once the build completes.
-         * Substitute ``htmllive`` (Unix only) for ``html`` to automatically
-           rebuild the docs, start a local server, and reload the page in your
-           browser after you save reST files.
+         * Replace ``html`` with ``htmllive`` to rebuild the docs,
+           start a local server, and automatically reload the page in your
+           browser when you make changes to reST files (Unix only).
 
 Note that ``make check`` runs automatically when you submit
 a :ref:`pull request <pullrequest>`.  You may wish to run ``make check``

--- a/documentation/devguide.rst
+++ b/documentation/devguide.rst
@@ -42,9 +42,15 @@ in the checkout directory.  On Windows use:
 
    > .\make html
 
-You will find the generated files in ``_build/html`` or, if you use
-``make htmlview``, the docs will be opened in a browser once the build
-completes.  Note that ``make check`` runs automatically when you submit
+You will find the generated files in ``_build/html``.
+
+.. tip:: * Substitute ``htmlview`` for ``html`` to open the docs in a web browser
+           once the build completes.
+         * Substitute ``htmllive`` (Unix only) for ``html`` to automatically
+           rebuild the docs, start a local server, and reload the page in your
+           browser after you save reST files.
+
+Note that ``make check`` runs automatically when you submit
 a :ref:`pull request <pullrequest>`.  You may wish to run ``make check``
 and ``make linkcheck`` to make sure that it runs without errors.
 

--- a/documentation/start-documenting.rst
+++ b/documentation/start-documenting.rst
@@ -122,11 +122,11 @@ To build the docs as HTML, run::
 
    make html
 
-.. tip:: * Substitute ``htmlview`` for ``html`` to open the docs in a web browser
+.. tip:: * Replace ``html`` with ``htmlview`` to open the docs in a web browser
            once the build completes.
-         * Substitute ``htmllive`` (Unix only) for ``html`` to automatically
-           rebuild the docs, start a local server, and reload the page in your
-           browser after you save reST files.
+         * Replace ``html`` with ``htmllive`` to rebuild the docs,
+           start a local server, and automatically reload the page in your
+           browser when you make changes to reST files (Unix only).
 
 To check the docs for common errors with `Sphinx Lint`_
 (which is run on all :ref:`pull requests <pullrequest>`), use::

--- a/documentation/start-documenting.rst
+++ b/documentation/start-documenting.rst
@@ -122,8 +122,11 @@ To build the docs as HTML, run::
 
    make html
 
-.. tip:: Substitute ``htmlview`` for ``html`` to open the docs in a web browser
-         once the build completes.
+.. tip:: * Substitute ``htmlview`` for ``html`` to open the docs in a web browser
+           once the build completes.
+         * Substitute ``htmllive`` (Unix only) for ``html`` to automatically
+           rebuild the docs, start a local server, and reload the page in your
+           browser after you save reST files.
 
 To check the docs for common errors with `Sphinx Lint`_
 (which is run on all :ref:`pull requests <pullrequest>`), use::


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

As suggested on [Discuss](https://discuss.python.org/t/make-htmllive-new-docs-makefile-target-for-easier-editing/38574/2?u=hugovk).

Use the same "Tip" infobox on the pages for CPython docs and for the devguide.

![image](https://github.com/python/devguide/assets/1324225/cf7b269f-af2d-45be-aaad-e1e04e31d5d4)

Note, I didn’t add `htmllive` to `make.bat` because I don’t have Windows to test it. Would a Windows user like to add the equivalent commands to `make.bat`, so we can remove the "(Unix only)"? I’d suggest here for the devguide first.


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1219.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->