### PR TITLE
Add `-j auto` to the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,19 +4,21 @@
 # You can set these variables from the command line.
 PYTHON        = python3
 VENVDIR       = ./venv
-BUILDDIR      = _build
-SPHINXOPTS    = -W --keep-going
 SPHINXBUILD   = $(VENVDIR)/bin/sphinx-build
+SPHINXOPTS    = -W --keep-going
+BUILDDIR      = _build
 BUILDER       = html
-SPHINXLINT    = $(VENVDIR)/bin/sphinx-lint
+JOBS          = auto
 PAPER         =
+SPHINXLINT    = $(VENVDIR)/bin/sphinx-lint
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -b $(BUILDER) \
                   -d $(BUILDDIR)/doctrees \
-                  $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) \
+                  $(PAPEROPT_$(PAPER)) \
+                  -j $(JOBS) $(SPHINXOPTS) \
                   . $(BUILDDIR)/$(BUILDER)
 
 .PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,9 @@ PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -b $(BUILDER) \
                   -d $(BUILDDIR)/doctrees \
+                  -j $(JOBS) \
                   $(PAPEROPT_$(PAPER)) \
-                  -j $(JOBS) $(SPHINXOPTS) \
+                  $(SPHINXOPTS) \
                   . $(BUILDDIR)/$(BUILDER)
 
 .PHONY: help


### PR DESCRIPTION
This PR adds `-j auto` to the `Makefile`.

I found out that it was missing while working on https://github.com/sphinx-doc/sphinx/issues/10779, and after adding it the time required to build the devguide went down from 2.9s to 1.4s, so about twice as fast (this is on a 16-cores CPU).


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1220.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->