### PR TITLE
Document `keepalive` for buildbot workers may be the reason for frequent disconnects

### DIFF
--- a/testing/new-buildbot-worker.rst
+++ b/testing/new-buildbot-worker.rst
@@ -195,6 +195,13 @@ by tests that fail.  Unfortunately we do not currently have a way to notify you
 only of failures on your builders, so doing periodic spot checks is also a good
 idea.
 
+If your buildbot worker is disconnecting regularly, it may be a symptom of the
+default keep-alive value being set too high (``600`` for 10 minutes). You
+can edit the `**keepalive** setting
+<https://docs.buildbot.net/latest/manual/installation/worker.html#cmdoption-buildbot-worker-create-worker-keepalive>`_
+in the ``buildbot.tac`` file found in your build area to a lower value
+(e.g. ``180`` for 3 minutes).
+
 
 Latent workers
 --------------

--- a/testing/new-buildbot-worker.rst
+++ b/testing/new-buildbot-worker.rst
@@ -195,12 +195,12 @@ by tests that fail.  Unfortunately we do not currently have a way to notify you
 only of failures on your builders, so doing periodic spot checks is also a good
 idea.
 
-If your buildbot worker is disconnecting regularly, it may be a symptom of the
-default keep-alive value being set too high (``600`` for 10 minutes). You
-can edit the `**keepalive** setting
-<https://docs.buildbot.net/latest/manual/installation/worker.html#cmdoption-buildbot-worker-create-worker-keepalive>`_
-in the ``buildbot.tac`` file found in your build area to a lower value
-(e.g. ``180`` for 3 minutes).
+.. note::
+   If your buildbot worker is disconnecting regularly, it may be a symptom of the
+   default ``keepalive`` value (``600`` for 10 minutes) being `set too high
+   <https://docs.buildbot.net/latest/manual/installation/worker.html#cmdoption-buildbot-worker-create-worker-keepalive>`_
+   You can change it to a lower value (e.g. ``180`` for 3 minutes)
+   in the ``buildbot.tac`` file found in your build area.
 
 
 Latent workers

--- a/testing/new-buildbot-worker.rst
+++ b/testing/new-buildbot-worker.rst
@@ -197,9 +197,9 @@ idea.
 
 .. note::
    If your buildbot worker is disconnecting regularly, it may be a symptom of the
-   default ``keepalive`` value (``600`` for 10 minutes) being `set too high
+   default ``keepalive`` value (``600`` for 10 minutes) being `set
    <https://docs.buildbot.net/latest/manual/installation/worker.html#cmdoption-buildbot-worker-create-worker-keepalive>`_
-   You can change it to a lower value (e.g. ``180`` for 3 minutes)
+   too high. You can change it to a lower value (e.g. ``180`` for 3 minutes)
    in the ``buildbot.tac`` file found in your build area.
 
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1221.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->