### PR TITLE
Add 'C API' to the style guide

### DIFF
--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -76,7 +76,7 @@ be used to ensure consistency throughout the documentation:
 
 C API
   Python's `API <https://docs.python.org/3/c-api/>`_ used by C programmers
-  to write extension modules. Unhyphenated and capitalized.
+  to write extension modules. Capitalized and unhyphenated.
 
 CPU
    For "central processing unit." Many style guides say this should be

--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -74,6 +74,10 @@ presentation in the Python documentation.
 Other terms and words deserve special mention as well; these conventions should
 be used to ensure consistency throughout the documentation:
 
+C API
+  Python's `API <https://docs.python.org/3/c-api/>`_ used by C programmers
+  to write extension modules. Unhyphenated and capitalized.
+
 CPU
    For "central processing unit." Many style guides say this should be
    spelled out on the first use (and if you must use it, do so!). For

--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -76,7 +76,7 @@ be used to ensure consistency throughout the documentation:
 
 C API
   Python's `API <https://docs.python.org/3/c-api/>`_ used by C programmers
-  to write extension modules. Capitalized and unhyphenated.
+  to write extension modules. All caps and unhyphenated.
 
 CPU
    For "central processing unit." Many style guides say this should be

--- a/internals/parser.rst
+++ b/internals/parser.rst
@@ -711,7 +711,7 @@ When a pegen-generated parser detects that an exception is raised, it will
 is and it will unwind the stack and report the exception. This means that if a
 :ref:`rule action <peg-grammar-actions>` raises an exception all parsing will
 stop at that exact point. This is done to allow to correctly propagate any
-exception set by calling Python C-API functions. This also includes :exc:`SyntaxError`
+exception set by calling Python's C API functions. This also includes :exc:`SyntaxError`
 exceptions and this is the main mechanism the parser uses to report custom syntax
 error messages.
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

This is often written "C-API" but "C API" is both more common and used at https://docs.python.org/3/c-api/

In the CPython repo:

```console
❯ rg "C API" | wc -l
    1039

❯ rg "C-API" | wc -l
      69
```

In the devguide (before this PR fixes the lone "C-API"):

```console
❯ rg "C API" | wc -l
      25

❯ rg "C-API" | wc -l
       1
```

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1222.org.readthedocs.build/documentation/style-guide/#capitalization

<!-- readthedocs-preview cpython-devguide end -->