### PR TITLE
Add inline tabs on Helping with the Developer’s Guide page for commands on different systems

### DIFF
--- a/documentation/devguide.rst
+++ b/documentation/devguide.rst
@@ -46,6 +46,8 @@ To build the devguide from the checkout directory:
 
 .. tab:: Unix/macOS
 
+   .. code-block:: shell
+
       make html
 
 .. tab:: Windows

--- a/documentation/devguide.rst
+++ b/documentation/devguide.rst
@@ -44,15 +44,7 @@ you*.
 
 To build the devguide from the checkout directory:
 
-.. tab:: Unix
-
-   .. code-block:: shell
-
-      make html
-
-.. tab:: macOS
-
-   .. code-block:: shell
+.. tab:: Unix/macOS
 
       make html
 

--- a/documentation/devguide.rst
+++ b/documentation/devguide.rst
@@ -32,15 +32,27 @@ To build the devguide, some additional dependencies are required (most
 importantly, `Sphinx`_), and the standard way to install dependencies in
 Python projects is to create a virtualenv, and then install dependencies from
 a ``requirements.txt`` file. For your convenience, this is all *automated for
-you*. To build the devguide on a Unix-like system use::
+you*.
 
-   $ make html
+To build the devguide from the checkout directory:
 
-in the checkout directory.  On Windows use:
+.. tab:: Unix
 
-.. code-block:: doscon
+   .. code-block:: shell
 
-   > .\make html
+      make html
+
+.. tab:: macOS
+
+   .. code-block:: shell
+
+      make html
+
+.. tab:: Windows
+
+   .. code-block:: dosbatch
+
+      .\make html
 
 You will find the generated files in ``_build/html``.
 

--- a/documentation/devguide.rst
+++ b/documentation/devguide.rst
@@ -4,6 +4,14 @@
 Helping with the Developer's Guide
 ==================================
 
+.. raw:: html
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      activateTab(getOS());
+    });
+    </script>
+
 .. highlight:: console
 
 The Developer's Guide (what you're reading now) uses the same process as the


### PR DESCRIPTION
Hey again team! I was hoping to knock a few more of these out this weekend.

This PR should close a single TODO in #1196.

I did restructure the writing a bit to break up the directive "to build the devguide..." from the long paragraph before it.

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1223.org.readthedocs.build/documentation/devguide/

<!-- readthedocs-preview cpython-devguide end -->