### PR TITLE
Remove/update references to EOL Python versions

### DIFF
--- a/development-tools/clinic.rst
+++ b/development-tools/clinic.rst
@@ -834,8 +834,7 @@ To save time, and to minimize how much you need to learn
 to achieve your first port to Argument Clinic, the walkthrough above tells
 you to use "legacy converters".  "Legacy converters" are a convenience,
 designed explicitly to make porting existing code to Argument Clinic
-easier.  And to be clear, their use is acceptable when porting code for
-Python 3.4.
+easier.
 
 However, in the long term we probably want all our blocks to
 use Argument Clinic's real syntax for converters.  Why?  A couple

--- a/development-tools/gdb.rst
+++ b/development-tools/gdb.rst
@@ -297,8 +297,6 @@ thread is doing at the Python level::
         #8 Frame 0x7fffd00024a0, for file /home/david/coding/python-svn/Lib/test/lock_tests.py, line 378, in _check_notify (self=<ConditionTests(_testMethodName='test_notify', _resultForDoCleanups=<TestResult(_original_stdout=<cStringIO.StringO at remote 0xc191e0>, skipped=[], _mirrorOutput=False, testsRun=39, buffer=False, _original_stderr=<file at remote 0x7ffff7fc6340>, _stdout_buffer=<cStringIO.StringO at remote 0xc9c7f8>, _stderr_buffer=<cStringIO.StringO at remote 0xc9c790>, _moduleSetUpFailed=False, expectedFailures=[], errors=[], _previousTestClass=<type at remote 0x928310>, unexpectedSuccesses=[], failures=[], shouldStop=False, failfast=False) at remote 0xc185a0>, _threads=(0,), _cleanups=[], _type_equality_funcs={<type at remote 0x7eba00>: <instancemethod at remote 0xd750e0>, <type at remote 0x7e7820>: <instancemethod at remote 0xd75160>, <type at remote 0x7e30e0>: <instancemethod at remote 0xd75060>, <type at remote 0x7e7d20>: <instancemethod at remote 0xd751e0>, <type at remote 0x7f19e0...(truncated)
                 _wait()
 
-.. note:: This is only available for Python 2.7, 3.2 and higher.
-
 
 GDB 6 and earlier
 =================

--- a/getting-started/git-boot-camp.rst
+++ b/getting-started/git-boot-camp.rst
@@ -153,9 +153,9 @@ To switch to a different branch::
    git switch <another-branch-name>
 
 Other releases are just branches in the repository.  For example, to work
-on the 2.7 release from the ``upstream`` remote::
+on the 3.12 release from the ``upstream`` remote::
 
-   git switch -c 2.7 upstream/2.7
+   git switch -c 3.12 upstream/3.12
 
 .. _deleting_branches:
 

--- a/testing/run-write-tests.rst
+++ b/testing/run-write-tests.rst
@@ -166,9 +166,6 @@ using several Python processes so as to speed up things:
 
         .\python.bat -m test -j0
 
-If you are running a version of Python prior to 3.3 you must specify the number
-of processes to run simultaneously (e.g. ``-j2``).
-
 .. _strenuous_testing:
 
 Finally, if you want to run tests under a more strenuous set of settings, you


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Fixes https://github.com/python/devguide/issues/661.

We've already removed quite a few other old ones, such as instructions for building older Python versions.

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1227.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->