### PR TITLE
Add inline tabs on Increase Test Coverage page for commands on different systems

### DIFF
--- a/testing/coverage.rst
+++ b/testing/coverage.rst
@@ -4,6 +4,14 @@
 Increase test coverage
 ======================
 
+.. raw:: html
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      activateTab(getOS());
+    });
+    </script>
+
 Python development follows a practice that all semantic changes and additions
 to the language and :abbr:`stdlib (standard library)` are accompanied by
 appropriate unit tests. Unfortunately Python was in existence for a long time

--- a/testing/coverage.rst
+++ b/testing/coverage.rst
@@ -87,23 +87,31 @@ just built, and this built version of Python will not see packages installed
 into your default version of Python. One option is to use a virtual environment
 to install coverage.
 
-On Unix run::
+.. tab:: Unix
 
-    ./python -m venv ../cpython-venv
-    source ../cpython-venv/bin/activate
-    pip install coverage
+    .. code-block:: shell
 
-On :ref:`most <mac-python.exe>` macOS systems run::
+        ./python -m venv ../cpython-venv
+        source ../cpython-venv/bin/activate
+        pip install coverage
 
-    ./python.exe -m venv ../cpython-venv
-    source ../cpython-venv/bin/activate
-    pip install coverage
+.. tab:: macOS
 
-On Windows run::
+    On :ref:`most <mac-python.exe>` macOS systems run:
 
-    python.bat -m venv ..\\cpython-venv
-    ..\\cpython-venv\\Scripts\\activate.bat
-    pip install coverage
+    .. code-block:: shell
+
+        ./python.exe -m venv ../cpython-venv
+        source ../cpython-venv/bin/activate
+        pip install coverage
+
+.. tab:: Windows
+
+    .. code-block:: dosbatch
+
+        python.bat -m venv ..\\cpython-venv
+        ..\\cpython-venv\\Scripts\\activate.bat
+        pip install coverage
 
 You can now use python without the ./ for the rest of these instructions, as
 long as your venv is activated. For more info on venv see `Virtual Environment

--- a/testing/coverage.rst
+++ b/testing/coverage.rst
@@ -89,6 +89,8 @@ to install coverage.
 
 .. tab:: Unix
 
+    Run:
+
     .. code-block:: shell
 
         ./python -m venv ../cpython-venv
@@ -106,6 +108,8 @@ to install coverage.
         pip install coverage
 
 .. tab:: Windows
+
+    Run:
 
     .. code-block:: dosbatch
 

--- a/testing/coverage.rst
+++ b/testing/coverage.rst
@@ -251,19 +251,49 @@ Measuring coverage of C code with gcov and lcov
 
 It's also possible to measure the function, line and branch coverage of
 Python's C code. Right now only GCC with `gcov`_ is supported. In order to
-create an instrumented build of Python with gcov, run::
+create an instrumented build of Python with gcov, run:
 
-    make coverage
+.. tab:: Unix/macOS
+
+    .. code-block:: shell
+
+        make coverage
+
+.. tab:: Windows
+
+    .. code-block:: dosbatch
+
+        .\make coverage
 
 Then run some code and gather coverage data with the ``gcov`` command. In
-order to create a HTML report you can install `lcov`_. The command::
+order to create a HTML report you can install `lcov`_. The command:
 
-    make coverage-lcov
+.. tab:: Unix/macOS
+
+    .. code-block:: shell
+
+        make coverage-lcov
+
+.. tab:: Windows
+
+    .. code-block:: dosbatch
+
+        .\make coverage-lcov
 
 assembles coverage data, removes 3rd party and system libraries and finally
-creates a report. You can skip both steps and just run::
+creates a report. You can skip both steps and just run:
 
-    make coverage-report
+.. tab:: Unix/macOS
+
+    .. code-block:: shell
+
+        make coverage-report
+
+.. tab:: Windows
+
+    .. code-block:: dosbatch
+
+        .\make coverage-report
 
 if you like to generate a coverage report for Python's stdlib tests. It takes
 about 20 to 30 minutes on a modern computer.


### PR DESCRIPTION
This PR should close a single TODO in https://github.com/python/devguide/issues/1196.

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1228.org.readthedocs.build/testing/coverage/

<!-- readthedocs-preview cpython-devguide end -->