### PR TITLE
Mention sphinx-lint in the translation tools

### DIFF
--- a/documentation/translating.rst
+++ b/documentation/translating.rst
@@ -213,6 +213,8 @@ Here's what we're using:
 - `powrap <https://pypi.org/project/powrap/>`__ to rewrap the ``.po`` files
   before committing. This helps keep Git diffs short.
 - `potodo <https://pypi.org/project/potodo/>`__ to list what needs to be translated.
+- `sphinx-lint <https://pypi.org/project/sphinx-lint/>`__ to validate reST syntax in
+  translation files.
 
 
 How is a coordinator elected?


### PR DESCRIPTION
This adds sphinx-lint to the list of tools used for translation. It is useful to find reST syntax issues in translation files that not reported by sphinx-build output.

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1230.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->