### PR TITLE
`make htmllive`: open browser when ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ htmlview: html
 
 .PHONY: htmllive
 htmllive: SPHINXBUILD = $(VENVDIR)/bin/sphinx-autobuild
-htmllive: SPHINXOPTS = --re-ignore="/\.idea/|/venv/"
+htmllive: SPHINXOPTS = --re-ignore="/\.idea/|/venv/" --open-browser --delay 0
 htmllive: html
 
 .PHONY: check


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

When running `make htmllive`, this will open the browser when the docs have been built the first time. 

It means you don't need to hunt around for the link in:

```console
❯ make htmllive
venv already exists.
To recreate it, remove it first with `make clean-venv'.
Release cycle data generated.
./venv/bin/sphinx-autobuild -b html -d _build/doctrees  --re-ignore="/\.idea/|/venv/" . _build/html
[sphinx-autobuild] > sphinx-build -b html -d _build/doctrees /Users/hugo/github/devguide /Users/hugo/github/devguide/_build/html
Running Sphinx v7.2.6
matplotlib is not installed, social cards will not be generated
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
writing output...
building [html]: targets for 0 source files that are out of date
updating environment: 0 added, 0 changed, 0 removed
reading sources...
looking for now-outdated files... none found
no targets are out of date.
Writing redirects...
build succeeded.

The HTML pages are in _build/html.
[I 231129 19:22:56 server:335] Serving on http://127.0.0.1:8000
[I 231129 19:22:56 handlers:62] Start watching changes
[I 231129 19:22:56 handlers:64] Start detecting changes
[I 231129 19:22:58 handlers:135] Browser Connected: http://127.0.0.1:8000/
```

I'll make the same changes for CPython and PEPs repo afterwards.


<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1233.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->