### PR TITLE
Rework the docs for NEWS/What's New entries

### DIFF
--- a/core-developers/committing.rst
+++ b/core-developers/committing.rst
@@ -80,21 +80,14 @@ to enter the public source tree. Ask yourself the following questions:
 Updating NEWS and What's New in Python
 --------------------------------------
 
+Changes that entail NEWS entries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Almost all changes made to the code base deserve an entry in ``Misc/NEWS.d``.
-If the change is particularly interesting for end users (e.g. new features,
-significant improvements, or backwards-incompatible changes), then an entry in
-the ``What's New in Python`` document (in ``Doc/whatsnew/``) should be added
-as well. Changes that affect documentation only generally do not require
-a ``NEWS`` entry.
-
 There are two notable exceptions to this general principle, and they
-both relate to changes that:
-
-* Already have a ``NEWS`` entry
-* Have not yet been included in any formal release (including alpha
-  and beta releases)
-
-These are the two exceptions:
+both relate to changes that already have a ``NEWS`` entry,
+or changes that have not yet been included in any formal release
+(including alpha and beta releases):
 
 #. **If a change is reverted prior to release**, then the corresponding
    entry is simply removed. Otherwise, a new entry must be added noting
@@ -105,8 +98,27 @@ These are the two exceptions:
    change and the original** ``NEWS`` **entry remains valid**, then no additional
    entry is needed.
 
-If a change needs an entry in ``What's New in Python``, then it is very
-likely not suitable for including in a maintenance release.
+Other changes that generally do not require ``NEWS`` entries are documentation changes,
+test changes, and strictly internal changes with no user-visible effects.
+
+Changes that entail What's New in Python entries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If a change is particularly interesting for end users (e.g. new features,
+significant improvements, or backwards-incompatible changes), an entry in
+the ``What's New in Python`` document (in ``Doc/whatsnew/``) should be added
+in addition to the ``NEWS`` entry.
+
+In most cases, it is sufficient to reuse the wording from the ``NEWS`` entry
+in the ``What's New in Python`` entry.
+
+.. note::
+
+    A change that needs an entry in ``What's New in Python``,
+    is very likely not suitable for inclusion in a maintenance release.
+
+How to add a NEWS entry
+^^^^^^^^^^^^^^^^^^^^^^^
 
 ``NEWS`` entries go into the ``Misc/NEWS.d`` directory as individual files. The
 ``NEWS`` entry can be created by using `blurb-it <https://blurb-it.herokuapp.com/>`_,
@@ -132,6 +144,17 @@ to the standard library). The file name itself should be in the format
 As a result, a file name can look something like
 ``Misc/NEWS.d/next/Library/2017-05-27-16-46-23.gh-issue-12345.Yl4gI2.rst``.
 
+How to write a NEWS entry
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+All ``NEWS`` entries end up being part of the changelog.
+The changelog contains *a lot* of entries,
+and its intended audience is mainly users, not core devs and contributors.
+Take this into consideration when wording your ``NEWS`` entry.
+Describe the user-visible effects of your change succinctly and accurately;
+avoid long technical elaborations, digressions, and do not expect or require
+the reader to have read the actuall diff for the change.
+
 The contents of a ``NEWS`` file should be valid reStructuredText. An 80 character
 column width should be used. There is no indentation or leading marker in the
 file (e.g. ``-``). There is also no need to start the entry with the issue
@@ -145,9 +168,6 @@ entry::
 The inline Sphinx roles like ``:func:`` can be used help readers
 find more information. You can build HTML and verify that the
 link target is appropriate by using :ref:`make html <building-using-make>`.
-
-While Sphinx roles can be beneficial to readers, they are not required.
-Inline ````code blocks```` can be used instead.
 
 
 Working with Git_

--- a/core-developers/committing.rst
+++ b/core-developers/committing.rst
@@ -83,11 +83,17 @@ Updating NEWS and What's New in Python
 Changes that require NEWS entries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Almost all changes made to the code base deserve an entry in ``Misc/NEWS.d``.
-There are two notable exceptions to this general principle, and they
-both relate to changes that already have a ``NEWS`` entry,
-or changes that have not yet been included in any formal release
-(including alpha and beta releases):
+Most changes made to the code base deserve an entry in :cpy-file:`Misc/NEWS.d`,
+except for the following:
+
+* documentation changes in general
+* test changes in general
+* strictly internal changes with no user-visible effects
+* changes that already have a ``NEWS`` entry
+* changes that have not yet been included in any formal release
+  (including alpha and beta releases)
+
+For the latter two exceptions, note the following:
 
 #. **If a change is reverted prior to release**, then the corresponding
    entry is simply removed. Otherwise, a new entry must be added noting

--- a/core-developers/committing.rst
+++ b/core-developers/committing.rst
@@ -83,7 +83,7 @@ Updating NEWS and What's New in Python
 Changes that require NEWS entries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Most changes made to the code base deserve an entry in :cpy-file:`Misc/NEWS.d`,
+Most changes made to the codebase deserve an entry in :cpy-file:`Misc/NEWS.d`,
 except for the following:
 
 * documentation changes

--- a/core-developers/committing.rst
+++ b/core-developers/committing.rst
@@ -86,14 +86,14 @@ Changes that require NEWS entries
 Most changes made to the code base deserve an entry in :cpy-file:`Misc/NEWS.d`,
 except for the following:
 
-* documentation changes in general
-* test changes in general
+* documentation changes
+* test changes
 * strictly internal changes with no user-visible effects
 * changes that already have a ``NEWS`` entry
 * changes that have not yet been included in any formal release
   (including alpha and beta releases)
 
-For the latter two exceptions, note the following:
+For the last two, note the following:
 
 #. **If a change is reverted prior to release**, then the corresponding
    entry is simply removed. Otherwise, a new entry must be added noting
@@ -103,9 +103,6 @@ For the latter two exceptions, note the following:
 #. **If a change is a fix (or other adjustment) to an earlier unreleased
    change and the original** ``NEWS`` **entry remains valid**, then no additional
    entry is needed.
-
-Other changes that generally do not require ``NEWS`` entries are documentation changes,
-test changes, and strictly internal changes with no user-visible effects.
 
 Changes that require "What's New in Python" entries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/core-developers/committing.rst
+++ b/core-developers/committing.rst
@@ -90,7 +90,7 @@ except for the following:
 * test changes
 * strictly internal changes with no user-visible effects
 * changes that already have a ``NEWS`` entry
-* changes that have not yet been included in any formal release
+* reverts that have not yet been included in any formal release
   (including alpha and beta releases)
 
 For the last two, note the following:

--- a/core-developers/committing.rst
+++ b/core-developers/committing.rst
@@ -80,8 +80,8 @@ to enter the public source tree. Ask yourself the following questions:
 Updating NEWS and What's New in Python
 --------------------------------------
 
-Changes that entail NEWS entries
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changes that require NEWS entries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Almost all changes made to the code base deserve an entry in ``Misc/NEWS.d``.
 There are two notable exceptions to this general principle, and they
@@ -101,12 +101,12 @@ or changes that have not yet been included in any formal release
 Other changes that generally do not require ``NEWS`` entries are documentation changes,
 test changes, and strictly internal changes with no user-visible effects.
 
-Changes that entail What's New in Python entries
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changes that require "What's New in Python" entries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If a change is particularly interesting for end users (e.g. new features,
 significant improvements, or backwards-incompatible changes), an entry in
-the ``What's New in Python`` document (in ``Doc/whatsnew/``) should be added
+the ``What's New in Python`` document (in :cpy-file:`Doc/whatsnew/`) should be added
 in addition to the ``NEWS`` entry.
 
 In most cases, it is sufficient to reuse the wording from the ``NEWS`` entry
@@ -153,7 +153,7 @@ and its intended audience is mainly users, not core devs and contributors.
 Take this into consideration when wording your ``NEWS`` entry.
 Describe the user-visible effects of your change succinctly and accurately;
 avoid long technical elaborations, digressions, and do not expect or require
-the reader to have read the actuall diff for the change.
+the reader to have read the actual diff for the change.
 
 The contents of a ``NEWS`` file should be valid reStructuredText. An 80 character
 column width should be used. There is no indentation or leading marker in the

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -513,27 +513,19 @@ After editing :file:`configure.ac`, run ``make regen-configure`` to generate
 When submitting a pull request with changes made to :file:`configure.ac`,
 make sure you also commit the changes in the generated files.
 
-The recommended and by far the easiest way to regenerate :file:`configure` is::
-
-   $ make regen-configure
-
-If you are regenerating :file:`configure` in a clean repo,
-run one of the following containers instead::
-
-   $ podman run --rm --pull=always -v $(pwd):/src:Z quay.io/tiran/cpython_autoconf:271
-
-::
-
-   $ docker run --rm --pull=always -v $(pwd):/src quay.io/tiran/cpython_autoconf:271
-
-Notice that the images are tagged with ``271``.
 Python's :file:`configure.ac` script requires a specific version of
 GNU Autoconf.
 For Python 3.12 and newer, GNU Autoconf v2.71 is required.
 For Python 3.11 and earlier, GNU Autoconf v2.69 is required.
-For GNU Autoconf v2.69, change the ``:271`` tag to ``:269``.
 
-If you cannot (or don't want to) use the ``cpython_autoconf`` containers,
+The recommended and by far the easiest way to regenerate :file:`configure` is::
+
+   $ make regen-configure
+
+This will use Podman or Docker to do the regeneration with the proper version
+of GNU Autoconf.
+
+If you cannot (or don't want to) use ``make regen-configure``,
 install the :program:`autoconf-archive` and :program:`pkg-config` utilities,
 and make sure the :file:`pkg.m4` macro file located in the appropriate
 :program:`aclocal` location::


### PR DESCRIPTION
- Add subsubsections instead of keeping all the text in a single large subsection
- Add some text about how to word NEWS entries
- Mention that test and strictly internal changes seldom require NEWS entries

(Some minor wording changes might have snuck in, but largely, I kept the existing text.)

<!-- readthedocs-preview cpython-devguide start -->
----
:books: Documentation preview :books:: https://cpython-devguide--1238.org.readthedocs.build/core-developers/committing/#updating-news-and-what-s-new-in-python

<!-- readthedocs-preview cpython-devguide end -->