### PR TITLE
Add governance contact

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -8,6 +8,7 @@ sys.path.insert(0, os.path.abspath(".") + "/_extensions")
 extensions = [
     'custom_roles',
     'notfound.extension',
+    'sphinx.ext.extlinks',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx_copybutton',
@@ -169,6 +170,14 @@ todo_include_todos = True
 
 # sphinx-notfound-page
 notfound_urls_prefix = "/"
+
+# sphinx.ext.extlinks
+# This config is a dictionary of external sites,
+# mapping unique short aliases to a base URL and a prefix.
+# https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html
+extlinks = {
+    "github": ("https://github.com/%s/", "%s"),
+}
 
 # sphinxext-opengraph config
 ogp_site_url = "https://devguide.python.org/"

--- a/developer-workflow/development-cycle.rst
+++ b/developer-workflow/development-cycle.rst
@@ -373,7 +373,7 @@ Multi-Factor Authentication must be enabled by the user in order to retain
 access as a Release Manager of the branch.
 
 Governance
-==========
+----------
 
 The Python Steering Council has overall authority over Python and has delegated
 some of its responsibilities to other groups.

--- a/developer-workflow/development-cycle.rst
+++ b/developer-workflow/development-cycle.rst
@@ -371,3 +371,35 @@ administrators) to merge changes to that branch.
 
 Multi-Factor Authentication must be enabled by the user in order to retain
 access as a Release Manager of the branch.
+
+Governance
+==========
+
+The Python Steering Council has overall authority over Python and has delegated
+some of its responsibilities to other groups.
+
+This table lists the PEPs defining each group's responsibilities,
+and the repository where you can open an issue to ask for a decision.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - PEP
+     - Contact repo
+   * - Steering Council
+     - :pep:`13`
+     - :github:`python/steering-council`
+   * - C API Working Group
+     - :pep:`731`
+     - :github:`capi-workgroup/decisions`
+   * - Documentation Editorial Board
+     - :pep:`732`
+     - :github:`python/editorial-board`
+   * - Typing Council
+     - :pep:`729`
+     - :github:`python/typing-council`
+
+.. seealso::
+
+   All governance PEPs: https://peps.python.org/topic/governance/


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
I wasn't sure which page to put this, this one seems as good as any because there's also info about GitHub org owners and admins.

Maybe we should move it up the page too?

![image](https://github.com/python/devguide/assets/1324225/30ab9938-afb5-4f9d-8bd7-7fccc86173e9)

---

Related: https://github.com/capi-workgroup/decisions/ sticks out -- would the C API Working Group like to move inside the https://github.com/python/ org? (re: https://devguide.python.org/developer-workflow/development-cycle/#organization-owner-policy)


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1260.org.readthedocs.build/developer-workflow/development-cycle/#governance

<!-- readthedocs-preview cpython-devguide end -->