### PR TITLE
Describe GC for free-threaded build in the GC design doc

### DIFF
--- a/internals/garbage-collector.rst
+++ b/internals/garbage-collector.rst
@@ -147,8 +147,8 @@ and, during garbage collection, differentiate reachable vs. unreachable objects.
 
 
 The garbage collector also temporarily repurposes the ``ob_tid`` (thread ID)
-and ``ob_ref_local`` (local reference count) fields temporarily for other
-purposes during collections.
+and ``ob_ref_local`` (local reference count) fields for other purposes during
+collections.
 
 
 C APIs
@@ -216,7 +216,7 @@ unreachable:
     2
 
 The GC starts with a set of candidate objects it wants to scan.  In the
-default build, theese "objects to scan" might be all container objects or a
+default build, these "objects to scan" might be all container objects or a
 smaller subset (or "generation").  In the free-threaded build, the collector
 always operates scans all container objects.
 


### PR DESCRIPTION
This updates the garbage collector design page to describe the implementation of the GC for Python 3.13's free-threaded build.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1263.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->