### PR TITLE
Removed the retired Mailing list of the devguide.

### DIFF
--- a/documentation/devguide.rst
+++ b/documentation/devguide.rst
@@ -14,16 +14,7 @@ Helping with the Developer's Guide
 
 .. highlight:: console
 
-The Developer's Guide (what you're reading now) uses the same process as the
-main Python documentation, except for some small differences.  The source
-lives in a `separate repository`_ and bug reports should be submitted to the
-`devguide GitHub tracker`_.
-
-Our devguide workflow uses continuous integration and deployment so changes to
-the devguide are normally published when the pull request is merged. Changes
-to CPython documentation follow the workflow of a CPython release and are
-published in the release.
-
+# deleted the retired ML in the devguide
 
 Developer's Guide workflow
 ==========================


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Removed the retired Mailing list of the devguide

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1265.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->