### PR TITLE
Document the OS-Unsupported label and Platforms experts list

### DIFF
--- a/core-developers/experts.rst
+++ b/core-developers/experts.rst
@@ -289,8 +289,9 @@ Platforms
 
 For official contacts for supported platforms, see :pep:`11`.
 
-Platforms listed here are not necessarily supported by CPython, and
-the maintainers are not necessarily core CPython developers.
+Platforms listed here are not necessarily supported by CPython.
+Some of the experts listed here maintain and distribute Python
+for “their” platform as a third-party project.
 
 ===================   ===========
 Platform              Maintainers

--- a/core-developers/experts.rst
+++ b/core-developers/experts.rst
@@ -282,14 +282,20 @@ PEG Generator       gvanrossum, pablogsal, lysnikolaou
 ==================  ===========
 
 
+.. _platform-experts:
+
 Platforms
 =========
+
+For official contacts for supported platforms, see :pep:`11`.
+
+Platforms listed here are not necessarily supported by CPython, and
+the maintainers are not necessarily core CPython developers.
 
 ===================   ===========
 Platform              Maintainers
 ===================   ===========
 AIX                   David.Edelsohn^
-Android
 Cygwin                jlt63^, stutzbach^
 Emscripten            hoodmane, pmp-p, rdb, rth, ryanking13
 FreeBSD

--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -61,9 +61,14 @@ OS labels
 
 These labels are used to specify which operating systems are affected.
 Since most issues either affect all systems or are specific to Unix,
-the only available labels are :gh-label:`OS-windows`, :gh-label:`OS-mac`,
-and :gh-label:`OS-freebsd`.
+we don't have a dedicated Unix label.
+Use :gh-label:`OS-windows`, :gh-label:`OS-mac`, and :gh-label:`OS-freebsd`.
 
+Use the :gh-label:`OS-unsupported` label for issues on platforms outside the
+support tiers defined in :pep:`11`. Applying this label adds the issue to
+`a project <https://github.com/orgs/python/projects/27/views/1>`_ where
+it can be categorized further.
+See also the :ref:`Platform experts list <platform-experts>`.
 
 .. _Expert labels:
 .. _Topic labels:

--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -66,7 +66,7 @@ Use :gh-label:`OS-windows`, :gh-label:`OS-mac`, and :gh-label:`OS-freebsd`.
 
 Use the :gh-label:`OS-unsupported` label for issues on platforms outside the
 support tiers defined in :pep:`11`. Applying this label adds the issue to
-`a project <https://github.com/orgs/python/projects/27/views/1>`_ where
+`a GitHub project <https://github.com/orgs/python/projects/27/views/1>`_ where
 it can be categorized further.
 See also the :ref:`Platform experts list <platform-experts>`.
 


### PR DESCRIPTION
The experts list is perhaps not the best place for the Platforms table, but moving it is left to another PR.

I've removed the blank Android line in anticipation of PEP-738 getting accepted; if it doesn't make it I'll ask Malcolm to add it back with his name.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1281.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->