### PR TITLE
Fix 'Install dependencies' links

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -455,7 +455,7 @@ Install dependencies
 ====================
 
 This section explains how to install additional extensions (e.g. ``zlib``)
-on :ref:`Linux <deps-on-linux>` and :ref:`macOS`.
+on Linux and macOS.
 
 .. tab:: Linux
 

--- a/index.rst
+++ b/index.rst
@@ -58,7 +58,7 @@ instructions please see the :ref:`setup guide <setup>`.
    See also :ref:`more detailed instructions <compiling>`,
    :ref:`how to install and build dependencies <build-dependencies>`,
    and the platform-specific pages for :ref:`Unix <unix-compiling>`,
-   :ref:`macOS`, and :ref:`Windows <windows-compiling>`.
+   :ref:`macOS <macOS>`, and :ref:`Windows <windows-compiling>`.
 
 4. :ref:`Run the tests <runtests>`:
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
Fixes https://github.com/python/devguide/issues/1275.

# Before

https://devguide.python.org/#quick-reference says:

> See also [more detailed instructions](https://devguide.python.org/getting-started/setup-building/#compiling), [how to install and build dependencies](https://devguide.python.org/getting-started/setup-building/#build-dependencies), and the platform-specific pages for [Unix](https://devguide.python.org/getting-started/setup-building/#unix-compiling), [Install dependencies](https://devguide.python.org/getting-started/setup-building/#macos), and [Windows](https://devguide.python.org/getting-started/setup-building/#windows-compiling).

https://devguide.python.org/getting-started/setup-building/#macos says:

> This section explains how to install additional extensions (e.g. zlib) on [Linux](https://devguide.python.org/getting-started/setup-building/#deps-on-linux) and [Install dependencies](https://devguide.python.org/getting-started/setup-building/#macos).

# After

They say:

> See also [more detailed instructions](http://127.0.0.1:8000/getting-started/setup-building.html#compiling), [how to install and build dependencies](http://127.0.0.1:8000/getting-started/setup-building.html#build-dependencies), and the platform-specific pages for [Unix](http://127.0.0.1:8000/getting-started/setup-building.html#unix-compiling), [macOS](http://127.0.0.1:8000/getting-started/setup-building.html#macos), and [Windows](http://127.0.0.1:8000/getting-started/setup-building.html#windows-compiling).

And:

> This section explains how to install additional extensions (e.g. zlib) on Linux and macOS.



<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1282.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->