### PR TITLE
removing `.exe` extension from mac tab

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -72,10 +72,10 @@ instructions please see the :ref:`setup guide <setup>`.
 
       .. code-block:: shell
 
-         ./python.exe -m test -j3
+         ./python -m test -j3
 
-      Note: :ref:`Most <mac-python.exe>` macOS systems use
-      :file:`./python.exe` in order to avoid filename conflicts with
+      Note: :ref:`Most <mac-python>` macOS systems use
+      :file:`./python` in order to avoid filename conflicts with
       the ``Python`` directory.
 
    .. tab:: Windows

--- a/index.rst
+++ b/index.rst
@@ -74,7 +74,7 @@ instructions please see the :ref:`setup guide <setup>`.
 
          ./python -m test -j3
 
-      Note: :ref:`Most <mac-python>` macOS systems use
+      Note: Most :ref:`macOS <macOS>` systems use
       :file:`./python` in order to avoid filename conflicts with
       the ``Python`` directory.
 


### PR DESCRIPTION
# Removing `.exe` extension from Mac tab

in the setup guide section, for Mac users, wrongly used the `.exe` extension for `python`. I just removed that.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1284.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->