### PR TITLE
Remove HTTPS-based suggestion for cloning cpython

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -82,8 +82,6 @@ You will only need to execute these steps once per machine:
 
       $ git clone git@github.com:<username>/cpython.git
 
-   (You can use both SSH-based or HTTPS-based URLs.)
-
 .. Step 6 and 7 are are duplicated in bootcamp as well.
    Please update these steps in both places.
 


### PR DESCRIPTION
Github removed support for password authentication through HTTPS on August 13, 2021. We shouldn't recommend that users use an HTTPS clone when an SSH-based `git@github.com:<username>/cypthon.git` connection is necessary.

This small change removes a comment that suggests that one *could* use HTTPS-based URLs.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1287.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->