### PR TITLE
No need for old redirect sections

### DIFF
--- a/documentation/start-documenting.rst
+++ b/documentation/start-documenting.rst
@@ -215,15 +215,3 @@ replace ``html`` above with the desired builder ``name``.
 .. _Sphinx Lint: https://github.com/sphinx-contrib/sphinx-lint
 .. _venv-activate: https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#activating-a-virtual-environment
 .. _venv-create: https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment
-
-
-Style guide
-===========
-
-Moved to :doc:`style-guide`.
-
-
-Translating
-===========
-
-Moved to :doc:`translating`.


### PR DESCRIPTION
The Style Guide and Translating sections I guess used to be on this page, but were moved.  We don't need these old placeholders anymore.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1295.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->