### PR TITLE
Document style on naming env vars

### DIFF
--- a/developer-workflow/stdlib.rst
+++ b/developer-workflow/stdlib.rst
@@ -142,8 +142,8 @@ once the authors of the module sign
 Adding a new environment variable
 ---------------------------------
 
-From Python 3.13 onwards, name environment variables with underscores for
-readability and accessibility.
+Names of environment variables should be uppercase and, from Python 3.13
+onwards, use underscores for readability and accessibility.
 
 For example, use ``PYTHON_CPU_COUNT`` instead of ``PYTHONCPUCOUNT``.
 

--- a/developer-workflow/stdlib.rst
+++ b/developer-workflow/stdlib.rst
@@ -139,8 +139,8 @@ once the authors of the module sign
 
 .. _issue tracker: https://github.com/python/cpython/issues
 
-Adding a new env var
---------------------
+Adding a new environment variable
+---------------------------------
 
 From Python 3.13 onwards, name environment variables with underscores for
 readability and accessibility.
@@ -150,5 +150,5 @@ For example, use ``PYTHON_CPU_COUNT`` instead of ``PYTHONCPUCOUNT``.
 See also:
 
 * :ref:`python:using-on-envvars`
-* `Discourse discussion
+* `"Change environment variable style" Discourse discussion
   <https://discuss.python.org/t/change-environment-variable-style/35180>`__

--- a/developer-workflow/stdlib.rst
+++ b/developer-workflow/stdlib.rst
@@ -52,6 +52,7 @@ useful.
 
 Adding a new module
 -------------------
+
 It must be stated upfront that getting a new module into the stdlib is very
 difficult. Adding any significant amount of code to the stdlib increases the
 burden placed upon core developers. It also means that the module somewhat
@@ -137,3 +138,17 @@ once the authors of the module sign
 :ref:`contributor agreements <contributor_agreement>`.
 
 .. _issue tracker: https://github.com/python/cpython/issues
+
+Adding a new env var
+--------------------
+
+From Python 3.13 onwards, name environment variables with underscores for
+readability and accessibility.
+
+For example, use ``PYTHON_CPU_COUNT`` instead of ``PYTHONCPUCOUNT``.
+
+See also:
+
+* :ref:`python:using-on-envvars`
+* `Discourse discussion
+  <https://discuss.python.org/t/change-environment-variable-style/35180>`__


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Fixes https://github.com/python/devguide/issues/1285.

I wasn't sure where to put it, so went for `developer-workflow/stdlib.html`.

Is there a better place?


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1300.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->