### PR TITLE
Python 3.11 is now security-only

### DIFF
--- a/include/release-cycle.json
+++ b/include/release-cycle.json
@@ -18,7 +18,7 @@
   "3.11": {
     "branch": "3.11",
     "pep": 664,
-    "status": "bugfix",
+    "status": "security",
     "first_release": "2022-10-24",
     "end_of_life": "2027-10",
     "release_manager": "Pablo Galindo Salgado"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

3.11.9 was the last bugfix with binary installers.

* https://peps.python.org/pep-0664/


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1303.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->