### PR TITLE
Clarify CPython Documentation Update Intervals

### DIFF
--- a/documentation/devguide.rst
+++ b/documentation/devguide.rst
@@ -19,10 +19,7 @@ main Python documentation, except for some small differences.  The source
 lives in a `separate repository`_ and bug reports should be submitted to the
 `devguide GitHub tracker`_.
 
-Our devguide workflow uses continuous integration and deployment so changes to
-the devguide are normally published when the pull request is merged. Changes
-to CPython documentation follow the workflow of a CPython release and are
-published in the release.
+While our devguide undergoes continuous integration and deployment, ensuring that changes are promptly reflected upon merging pull requests, updates to the CPython documentation occur on a daily basis. Additionally, the documentation aligns with the workflow of a CPython release, with corresponding changes being included in the release
 
 
 Developer's Guide workflow


### PR DESCRIPTION
## Description:
The proposed change clarifies that the CPython documentation is updated on a daily basis.

## Changes:
Modified the relevant section in the devguide to include information about daily updates to the CPython documentation in addition to changes published upon merging pull requests.

## Location:

https://github.com/python/devguide/blob/5c6a0c1c878af5b58bf95a2f6786a1c510b19c31/documentation/devguide.rst?plain=1#L22

Fixes: #1315

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1316.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->