### PR TITLE
Linux: Remove outdated `yum` instructions

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -619,49 +619,55 @@ on Linux, macOS and iOS.
    distribution, but the appropriate commands for some popular distributions
    are below.
 
-   On **Fedora**, **Red Hat Enterprise Linux** and other ``yum`` based systems::
+   .. tab:: ``yum``
 
-      $ sudo yum install yum-utils
-      $ sudo yum-builddep python3
+      On **Fedora**, **Red Hat Enterprise Linux** and other ``yum`` based systems::
 
-   On **Fedora** and other ``DNF`` based systems::
+         $ sudo yum install yum-utils
+         $ sudo yum-builddep python3
 
-      $ sudo dnf install dnf-plugins-core  # install this to use 'dnf builddep'
-      $ sudo dnf builddep python3
+   .. tab:: ``DNF``
 
-   On **Debian**, **Ubuntu**, and other ``apt`` based systems, try to get the
-   dependencies for the Python you're working on by using the ``apt`` command.
+      On **Fedora** and other ``DNF`` based systems::
 
-   First, make sure you have enabled the source packages in the sources list.
-   You can do this by adding the location of the source packages, including
-   URL, distribution name and component name, to ``/etc/apt/sources.list``.
-   Take Ubuntu 22.04 LTS (Jammy Jellyfish) for example::
+         $ sudo dnf install dnf-plugins-core  # install this to use 'dnf builddep'
+         $ sudo dnf builddep python3
 
-      deb-src http://archive.ubuntu.com/ubuntu/ jammy main
+   .. tab:: ``apt``
 
-   Alternatively, uncomment lines with ``deb-src`` using an editor, e.g.::
+      On **Debian**, **Ubuntu**, and other ``apt`` based systems, try to get the
+      dependencies for the Python you're working on by using the ``apt`` command.
 
-      sudo nano /etc/apt/sources.list
+      First, make sure you have enabled the source packages in the sources list.
+      You can do this by adding the location of the source packages, including
+      URL, distribution name and component name, to ``/etc/apt/sources.list``.
+      Take Ubuntu 22.04 LTS (Jammy Jellyfish) for example::
 
-   For other distributions, like Debian, change the URL and names to correspond
-   with the specific distribution.
+         deb-src http://archive.ubuntu.com/ubuntu/ jammy main
 
-   Then you should update the packages index::
+      Alternatively, uncomment lines with ``deb-src`` using an editor, e.g.::
 
-      $ sudo apt-get update
+         sudo nano /etc/apt/sources.list
 
-   Now you can install the build dependencies via ``apt``::
+      For other distributions, like Debian, change the URL and names to correspond
+      with the specific distribution.
 
-      $ sudo apt-get build-dep python3
-      $ sudo apt-get install pkg-config
+      Then you should update the packages index::
 
-   If you want to build all optional modules, install the following packages and
-   their dependencies::
+         $ sudo apt-get update
 
-      $ sudo apt-get install build-essential gdb lcov pkg-config \
-            libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev \
-            libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev \
-            lzma lzma-dev tk-dev uuid-dev zlib1g-dev libmpdec-dev
+      Now you can install the build dependencies via ``apt``::
+
+         $ sudo apt-get build-dep python3
+         $ sudo apt-get install pkg-config
+
+      If you want to build all optional modules, install the following packages and
+      their dependencies::
+
+         $ sudo apt-get install build-essential gdb lcov pkg-config \
+               libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev \
+               libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev \
+               lzma lzma-dev tk-dev uuid-dev zlib1g-dev libmpdec-dev
 
 
 .. tab:: macOS

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -619,14 +619,14 @@ on Linux, macOS and iOS.
    distribution, but the appropriate commands for some popular distributions
    are below.
 
-   .. tab:: ``DNF``
+   .. tab:: Fedora
 
       On **Fedora** and other ``dnf``-based systems::
 
          $ sudo dnf install dnf-plugins-core  # install this to use 'dnf builddep'
          $ sudo dnf builddep python3
 
-   .. tab:: ``apt``
+   .. tab:: Debian & Ubuntu
 
       On **Debian**, **Ubuntu**, and other ``apt``-based systems, try to get the
       dependencies for the Python you're working on by using the ``apt`` command.

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -619,48 +619,45 @@ on Linux, macOS and iOS.
    distribution, but the appropriate commands for some popular distributions
    are below.
 
-   .. tab:: Fedora
+   On **Fedora** and other ``dnf``-based systems::
 
-      On **Fedora** and other ``dnf``-based systems::
+      $ sudo dnf install dnf-plugins-core  # install this to use 'dnf builddep'
+      $ sudo dnf builddep python3
 
-         $ sudo dnf install dnf-plugins-core  # install this to use 'dnf builddep'
-         $ sudo dnf builddep python3
 
-   .. tab:: Debian & Ubuntu
+   On **Debian**, **Ubuntu**, and other ``apt``-based systems, try to get the
+   dependencies for the Python you're working on by using the ``apt`` command.
 
-      On **Debian**, **Ubuntu**, and other ``apt``-based systems, try to get the
-      dependencies for the Python you're working on by using the ``apt`` command.
+   First, make sure you have enabled the source packages in the sources list.
+   You can do this by adding the location of the source packages, including
+   URL, distribution name and component name, to ``/etc/apt/sources.list``.
+   Take Ubuntu 22.04 LTS (Jammy Jellyfish) for example::
 
-      First, make sure you have enabled the source packages in the sources list.
-      You can do this by adding the location of the source packages, including
-      URL, distribution name and component name, to ``/etc/apt/sources.list``.
-      Take Ubuntu 22.04 LTS (Jammy Jellyfish) for example::
+      $ deb-src http://archive.ubuntu.com/ubuntu/ jammy main
 
-         $ deb-src http://archive.ubuntu.com/ubuntu/ jammy main
+   Alternatively, uncomment lines with ``deb-src`` using an editor, e.g.::
 
-      Alternatively, uncomment lines with ``deb-src`` using an editor, e.g.::
+      $ sudo nano /etc/apt/sources.list
 
-         $ sudo nano /etc/apt/sources.list
+   For other distributions, like Debian, change the URL and names to correspond
+   with the specific distribution.
 
-      For other distributions, like Debian, change the URL and names to correspond
-      with the specific distribution.
+   Then you should update the packages index::
 
-      Then you should update the packages index::
+      $ sudo apt-get update
 
-         $ sudo apt-get update
+   Now you can install the build dependencies via ``apt``::
 
-      Now you can install the build dependencies via ``apt``::
+      $ sudo apt-get build-dep python3
+      $ sudo apt-get install pkg-config
 
-         $ sudo apt-get build-dep python3
-         $ sudo apt-get install pkg-config
+   If you want to build all optional modules, install the following packages and
+   their dependencies::
 
-      If you want to build all optional modules, install the following packages and
-      their dependencies::
-
-         $ sudo apt-get install build-essential gdb lcov pkg-config \
-               libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev \
-               libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev \
-               lzma lzma-dev tk-dev uuid-dev zlib1g-dev libmpdec-dev
+      $ sudo apt-get install build-essential gdb lcov pkg-config \
+            libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev \
+            libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev \
+            lzma lzma-dev tk-dev uuid-dev zlib1g-dev libmpdec-dev
 
 
 .. tab:: macOS

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -619,13 +619,6 @@ on Linux, macOS and iOS.
    distribution, but the appropriate commands for some popular distributions
    are below.
 
-   .. tab:: ``yum``
-
-      On **Fedora**, **Red Hat Enterprise Linux** and other ``yum`` based systems::
-
-         $ sudo yum install yum-utils
-         $ sudo yum-builddep python3
-
    .. tab:: ``DNF``
 
       On **Fedora** and other ``dnf``-based systems::

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -619,7 +619,7 @@ on Linux, macOS and iOS.
    distribution, but the appropriate commands for some popular distributions
    are below.
 
-   On **Fedora** and other ``dnf``-based systems::
+   On **Fedora**, **RHEL**, **CentOS** and other ``dnf``-based systems::
 
       $ sudo dnf install dnf-plugins-core  # install this to use 'dnf builddep'
       $ sudo dnf builddep python3

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -643,11 +643,11 @@ on Linux, macOS and iOS.
       URL, distribution name and component name, to ``/etc/apt/sources.list``.
       Take Ubuntu 22.04 LTS (Jammy Jellyfish) for example::
 
-         deb-src http://archive.ubuntu.com/ubuntu/ jammy main
+         $ deb-src http://archive.ubuntu.com/ubuntu/ jammy main
 
       Alternatively, uncomment lines with ``deb-src`` using an editor, e.g.::
 
-         sudo nano /etc/apt/sources.list
+         $ sudo nano /etc/apt/sources.list
 
       For other distributions, like Debian, change the URL and names to correspond
       with the specific distribution.

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -628,14 +628,14 @@ on Linux, macOS and iOS.
 
    .. tab:: ``DNF``
 
-      On **Fedora** and other ``DNF`` based systems::
+      On **Fedora** and other ``dnf``-based systems::
 
          $ sudo dnf install dnf-plugins-core  # install this to use 'dnf builddep'
          $ sudo dnf builddep python3
 
    .. tab:: ``apt``
 
-      On **Debian**, **Ubuntu**, and other ``apt`` based systems, try to get the
+      On **Debian**, **Ubuntu**, and other ``apt``-based systems, try to get the
       dependencies for the Python you're working on by using the ``apt`` command.
 
       First, make sure you have enabled the source packages in the sources list.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Similar to https://github.com/python/devguide/pull/1317.

For example, `yum` has short instructions:

![image](https://github.com/python/devguide/assets/1324225/230e8146-a0dd-4f7d-a17a-0bf8bab06dac)

As does `DNF`:

![image](https://github.com/python/devguide/assets/1324225/2581e87c-283a-4171-ae48-ca06cbe1e10f)

But `apt` is much longer, so it's good to tidy it away when not relevant:

![image](https://github.com/python/devguide/assets/1324225/29c5dfc5-46a2-4afa-8bbf-f89b68339d0b)


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1318.org.readthedocs.build/getting-started/setup-building/#install-dependencies

<!-- readthedocs-preview cpython-devguide end -->