### PR TITLE
Python 3.14 is now `main`

### DIFF
--- a/include/release-cycle.json
+++ b/include/release-cycle.json
@@ -1,8 +1,16 @@
 {
-  "3.13": {
+  "3.14": {
     "branch": "main",
-    "pep": 719,
+    "pep": 745,
     "status": "feature",
+    "first_release": "2025-10-01",
+    "end_of_life": "2030-10",
+    "release_manager": "Hugo van Kemenade"
+  },
+  "3.13": {
+    "branch": "3.13",
+    "pep": 719,
+    "status": "prerelease",
     "first_release": "2024-10-01",
     "end_of_life": "2029-10",
     "release_manager": "Thomas Wouters"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Set 3.14 to "feature" and 3.13 to "prerelease".


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1319.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->