### PR TITLE
makefile/RTD: Use uv if installed

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,5 +14,8 @@ build:
     python: "3"
 
   commands:
+    - asdf plugin add uv
+    - asdf install uv latest
+    - asdf global uv latest
     - make dirhtml BUILDDIR=_readthedocs
     - mv _readthedocs/dirhtml _readthedocs/html


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Using uv to install dependencies is quicker than pip.

On Read the Docs, it adds 1 second to install uv, and then cuts the docs build time from 28s -> 13s, overall halves the time from 28s -> 14s.

pip: https://beta.readthedocs.org/projects/hugovk-devguide/builds/24341331/
uv: https://beta.readthedocs.org/projects/hugovk-devguide/builds/24342365/

Locally, running `make clean; time make venv` with a warm cache:

pip: `make venv  4.05s user 0.92s system 91% cpu 5.451 total`
uv: `make venv  0.03s user 0.19s system 119% cpu 0.179 total`

`make html` is the same for both. 

Overall, `make clean html` goes from 7s -> 3s.


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1320.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->