### PR TITLE
add fix for missing _sqlite problem

### DIFF
--- a/testing/coverage.rst
+++ b/testing/coverage.rst
@@ -158,6 +158,12 @@ such as by venv)::
 
     ./python -m coverage
 
+(If you get the error
+
+    ImportError: No module named _sqlite3
+
+rerun ``configure`` with the ``--enable-loadable-sqlite-extensions`` flag.)
+
 The rest of the examples on how to use coverage.py will assume you are using a
 cloned copy, but you can substitute the above and all instructions should still
 be valid.


### PR DESCRIPTION

When I ran `./python -m coverage` per the instructions, using current development `cpython` (version 3.14.0a0) I got the following strange-seeming error:

    $ python -m coverage
    Traceback (most recent call last):
      File "/home/mjd/pkg/cpython/Lib/runpy.py", line 189, in _run_module_as_main
        mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
                                   ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
      File "/home/mjd/pkg/cpython/Lib/runpy.py", line 148, in _get_module_details
        return _get_module_details(pkg_main_name, error)
      File "/home/mjd/pkg/cpython/Lib/runpy.py", line 112, in _get_module_details
        __import__(pkg_name)
        ~~~~~~~~~~^^^^^^^^^^
      File "/home/mjd/.venv/cpython/lib/python3.14/site-packages/coverage/__init__.py", line 24, in <module>
        from coverage.control import (
        ...<2 lines>...
        )
      File "/home/mjd/.venv/cpython/lib/python3.14/site-packages/coverage/control.py", line 29, in <module>
        from coverage.collector import Collector, HAS_CTRACER
      File "/home/mjd/.venv/cpython/lib/python3.14/site-packages/coverage/collector.py", line 19, in <module>
        from coverage.data import CoverageData
      File "/home/mjd/.venv/cpython/lib/python3.14/site-packages/coverage/data.py", line 24, in <module>
        from coverage.sqldata import CoverageData
      File "/home/mjd/.venv/cpython/lib/python3.14/site-packages/coverage/sqldata.py", line 16, in <module>
        import sqlite3
      File "/home/mjd/pkg/cpython/Lib/sqlite3/__init__.py", line 57, in <module>
        from sqlite3.dbapi2 import *
      File "/home/mjd/pkg/cpython/Lib/sqlite3/dbapi2.py", line 27, in <module>
        from _sqlite3 import *
    ModuleNotFoundError: No module named '_sqlite3'

The suggestion at https://stackoverflow.com/a/24449632/1277934 fixed this for me.


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1325.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->