### PR TITLE
Prefer "feature release"

### DIFF
--- a/developer-workflow/c-api.rst
+++ b/developer-workflow/c-api.rst
@@ -174,7 +174,7 @@ Unstable C API
 
 The unstable C API tier is meant for extensions that need tight integration
 with the interpreter, like debuggers and JIT compilers.
-Users of this tier may need to change their code with every minor release.
+Users of this tier may need to change their code with every feature release.
 
 In many ways, this tier is like the general C API:
 
@@ -189,7 +189,7 @@ The differences are:
 
 - Names of functions structs, macros, etc. start with the ``PyUnstable_``
   prefix. This defines what's in the unstable tier.
-- The unstable API can change in minor versions, without any deprecation
+- The unstable API can change in feature releases, without any deprecation
   period.
 - A stability note appears in the docs.
   This happens automatically, based on the name
@@ -198,7 +198,7 @@ The differences are:
 Despite being “unstable”, there are rules to make sure third-party code can
 use this API reliably:
 
-* Changes and removals can be done in minor releases
+* Changes and removals can be done in feature releases
   (:samp:`3.{x}.0`, including Alphas and Betas for :samp:`3.{x}.0`).
 * Adding a new unstable API *for an existing feature* is allowed even after
   Beta feature freeze, up until the first Release Candidate.

--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -553,7 +553,7 @@ Python is tricky and we simply cannot accept everyone's contributions.
 
 But if your pull request is merged it will then go into Python's
 :abbr:`VCS (version control system)` to be released
-with the next major release of Python. It may also be backported to older
+with the next feature release of Python. It may also be backported to older
 versions of Python as a bugfix if the core developer doing the merge believes
 it is warranted.
 

--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -95,7 +95,7 @@ Version labels
 
 These labels are used to indicate which versions of Python are affected.
 The available version labels (with the form :samp:`3.{N}`) are updated
-whenever new major releases are created or retired.
+whenever new feature releases are created or retired.
 
 See also :ref:`the branch status page <branchstatus>`
 for a list of active branches.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

"Feature release/version" is the terminology used at https://devguide.python.org/developer-workflow/development-cycle/#devcycle and for example [PEP 602](https://peps.python.org/pep-0602/) (Annual Release Cycle for Python).

* Fix 'major release' -> 'feature release'
  These used major release when they really meant feature release.

* Prefer 'feature release' over 'minor release/version'
  Minor release is fine, but feature release is clearer.



<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1328.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->