### PR TITLE
Add experts for mobile platforms.

### DIFF
--- a/core-developers/experts.rst
+++ b/core-developers/experts.rst
@@ -297,12 +297,14 @@ for “their” platform as a third-party project.
 Platform              Maintainers
 ===================   ===========
 AIX                   David.Edelsohn^
+Android               mhsmith, encukou
 Cygwin                jlt63^, stutzbach^
 Emscripten            hoodmane, pmp-p, rdb, rth, ryanking13
 FreeBSD
 HP-UX
+iOS                   freakboy3742, ned-deily
 Linux
-macOS                 ronaldoussoren, ned-deily
+macOS                 ronaldoussoren, ned-deily, freakboy3742
 NetBSD1
 OS2/EMX               aimacintyre^
 Solaris/OpenIndiana   jcea


### PR DESCRIPTION
* Added myself (as the author of PEP 730) and @ned-deily (as the Tier 3 platform sponsor) as experts for iOS
* Added @mhsmith (as the author of PEP 738) and @encukou (as the Tier 3 platform sponsor) as experts for Android.
* Volunteered myself as an expert on macOS


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1330.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->