### PR TITLE
the prerealse text is now pointing to the documentation

### DIFF
--- a/include/release-cycle.json
+++ b/include/release-cycle.json
@@ -2,7 +2,7 @@
   "3.13": {
     "branch": "main",
     "pep": 719,
-    "status": "feature",
+    "status": "<a href=\"https://docs.python.org/3.13/whatsnew/3.13.html">prerelease</a>",
     "first_release": "2024-10-01",
     "end_of_life": "2029-10",
     "release_manager": "Thomas Wouters"


### PR DESCRIPTION
I have now linked the prerelease text to the new documentation


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1342.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->