### PR TITLE
update python organization owners

### DIFF
--- a/developer-workflow/development-cycle.rst
+++ b/developer-workflow/development-cycle.rst
@@ -301,7 +301,7 @@ Current owners
 +----------------------+--------------------------------+-----------------+
 | Ee Durbin            | PSF Director of Infrastructure | ewdurbin        |
 +----------------------+--------------------------------+-----------------+
-| Van Lindberg         | PSF General Counsel            | VanL            |
+| Jacob Coffee         | PSF Infrastructure Engineer    | JacobCoffee     |
 +----------------------+--------------------------------+-----------------+
 | Łukasz Langa         | CPython Developer in Residence | ambv            |
 +----------------------+--------------------------------+-----------------+


### PR DESCRIPTION
- @JacobCoffee has started as PSF Infrastructure Engineer
- Van is no longer acting as counsel to the PSF and owner role was removed some time ago


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1345.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->