### PR TITLE
Add PSRT coordination process and messaging templates

### DIFF
--- a/developer-workflow/index.rst
+++ b/developer-workflow/index.rst
@@ -14,3 +14,4 @@ Development workflow
    grammar
    porting
    sbom
+   psrt

--- a/developer-workflow/psrt.rst
+++ b/developer-workflow/psrt.rst
@@ -96,7 +96,7 @@ please feel free to adapt them as needed for the current context.
 
 **Directing to GitHub Security Advisories:**
 
-::
+.. highlight:: none
 
    Thanks for submitting this report.
    We now use GitHub Security Advisories for triaging vulnerability reports,
@@ -111,7 +111,7 @@ please feel free to adapt them as needed for the current context.
 
 **Rejecting a vulnerability report:**
 
-::
+.. highlight:: none
 
    Thanks for your report. We've determined that the report doesn't constitute
    a vulnerability. Let us know if you disagree with this determination.
@@ -120,7 +120,7 @@ please feel free to adapt them as needed for the current context.
 
 **Accepting a vulnerability report:**
 
-::
+.. highlight:: none
 
    Thanks for your report. We've determined that the report
    is a vulnerability. We've assigned {CVE-YYYY-XXXX} and determined
@@ -136,7 +136,7 @@ please feel free to adapt them as needed for the current context.
 
 **Advisory email:**
 
-::
+.. highlight:: none
 
    Title: [{CVE-YYYY-XXXX}] {title}
 

--- a/developer-workflow/psrt.rst
+++ b/developer-workflow/psrt.rst
@@ -32,7 +32,8 @@ vacation, etc.) they must find a replacement coordinator in the PSRT
 and reassign the vulnerability report appropriately.
 
 Coordinators are expected to collaborate with other PSRT members and core developers
-when needed for guidance on affect-ness, severity, advisory text, and fixes.
+when needed for guidance on whether the report is an actual vulnerability,
+severity, advisory text, and fixes.
 
 **The vulnerability coordination process is:**
 

--- a/developer-workflow/psrt.rst
+++ b/developer-workflow/psrt.rst
@@ -14,7 +14,7 @@ of GitHub Security Advisories.
 
 For reports sent to ``security@python.org``, a PSRT admin
 will triage the report and if the report seems plausible
-(i.e., not spam and for the correct project) will reply with
+(that is, not spam and for the correct project) will reply with
 instructions on how to report the vulnerability on GitHub.
 
 If the reporter doesn't want to use GitHub's Security Advisories feature
@@ -28,7 +28,7 @@ The coordinator will be responsible for following the below process and
 will be publicly credited on vulnerability records post-publication.
 
 If a coordinator can't complete the process for any reason (time obligation,
-vacation, etc) they must find a replacement coordinator in the PSRT
+vacation, etc.) they must find a replacement coordinator in the PSRT
 and reassign the vulnerability report appropriately.
 
 Coordinators are expected to collaborate with other PSRT members and core developers
@@ -55,13 +55,14 @@ when needed for guidance on affect-ness, severity, advisory text, and fixes.
 
 * Author the vulnerability advisory text. The advisory must include the following information:
 
-  * Title should be a brief description of the vulnerability and affected component (e.g "Buffer over-read in SSLContext.set_npn_protocols()")
+  * Title should be a brief description of the vulnerability and affected component
+    (for example, "Buffer over-read in SSLContext.set_npn_protocols()")
 
   * Short description of the vulnerability, impact, and the conditions where the affected component is vulnerable, if applicable.
 
   * Affected versions. This could be "all versions", but if the vulnerability exists in a new feature
     or removed feature then this could be different. Include versions that are end-of-life in this calculation.
-    (e.g. "Python 3.9 and earlier", "Python 3.10 and later", "all versions of Python")
+    (for example, "Python 3.9 and earlier", "Python 3.10 and later", "all versions of Python")
 
   * Affected components and APIs. The module, function, class, or method must be specified so users can
     search their codebase for usage. For issues affecting the entire project, this can be omitted.
@@ -91,7 +92,7 @@ Template responses
 
 These template responses should be used as guidance for messaging
 in various points in the process above. They're not required to be sent as-is,
-please feel free adapt them as needed for the current context.
+please feel free to adapt them as needed for the current context.
 
 **Directing to GitHub Security Advisories:**
 
@@ -126,7 +127,7 @@ please feel free adapt them as needed for the current context.
    with the determined severity.
 
    If you'd like to be publicly credited for this vulnerability as the reporter,
-   please indicate that along with how you'd like to be credited (ie, name or organization).
+   please indicate that, along with how you would like to be credited (name or organization).
 
    Please keep this vulnerability report private until we've published
    an advisory to ``security-announce@python.org``.
@@ -137,8 +138,7 @@ please feel free adapt them as needed for the current context.
 
    Title: [{CVE-YYYY-XXXX}] {title}
 
-   There is a new vulnerability affecting {project}.
-   The severity of this vulnerability is: {LOW, MEDIUM, HIGH, CRITICAL}.
+   There is a {LOW, MEDIUM, HIGH, CRITICAL} severity vulnerability affecting {project}.
 
    {description}
 

--- a/developer-workflow/psrt.rst
+++ b/developer-workflow/psrt.rst
@@ -10,7 +10,7 @@ Vulnerability report triage
 Vulnerability reports are sent to one of two locations,
 the long-standing ``security@python.org`` mailing list
 or using the private vulnerability reporting feature
-of GitHub Security Advisories.
+of GitHub Security Advisories (GHSA).
 
 For reports sent to ``security@python.org``, a PSRT admin
 will triage the report and if the report seems plausible
@@ -38,15 +38,15 @@ when needed for guidance on affect-ness, severity, advisory text, and fixes.
 
 * Coordinator will determine whether the report constitutes a vulnerability. If the report isn't a vulnerability,
   the reporter should be notified appropriately. Close the GHSA report, the report can be reopened if
-  sufficient evidence that the report is a vulnerability is later obtained.
+  sufficient evidence is later obtained that the report is a vulnerability.
 
-* After a vulnerability report is accepted, a CVE ID must be assigned. If this is not done
+* After a vulnerability report is accepted, a Common Vulnerabilities and Exposures (CVE) ID must be assigned. If this is not done
   automatically, then a CVE ID can be obtained by the coordinator sending an email to ``cna@python.org``.
-  No details about the vulnerability report need to be shared with the PSF CNA for a CVE ID to be reserved.
+  No details about the vulnerability report need to be shared with the PSF CVE Numbering Authority (CNA) for a CVE ID to be reserved.
 
 * If the report is a vulnerability, the coordinator will determine the severity of the vulnerability. Severity is one of:
   **Low**, **Medium**, **High**, and **Critical**. Coordinators can use their knowledge of the code, how the code is likely used,
-  or another mechanism like CVSS for determining a severity. Add this information to the GitHub Security Advisory.
+  or another mechanism like Common Vulnerability Scoring System (CVSS) for determining a severity. Add this information to the GitHub Security Advisory.
 
 * Once a CVE ID is assigned, the coordinator will share the acceptance and CVE ID with the reporter.
   Use this CVE ID for referencing the vulnerability. The coordinator will ask the reporter
@@ -61,8 +61,8 @@ when needed for guidance on affect-ness, severity, advisory text, and fixes.
   * Short description of the vulnerability, impact, and the conditions where the affected component is vulnerable, if applicable.
 
   * Affected versions. This could be "all versions", but if the vulnerability exists in a new feature
-    or removed feature then this could be different. Include versions that are end-of-life in this calculation.
-    (for example, "Python 3.9 and earlier", "Python 3.10 and later", "all versions of Python")
+    or removed feature then this could be different. Include versions that are end-of-life in this calculation
+    (for example, "Python 3.9 and earlier", "Python 3.10 and later", "all versions of Python").
 
   * Affected components and APIs. The module, function, class, or method must be specified so users can
     search their codebase for usage. For issues affecting the entire project, this can be omitted.
@@ -71,17 +71,22 @@ when needed for guidance on affect-ness, severity, advisory text, and fixes.
 
   This can all be done within the GitHub Security Advisory UI for easier collaboration between reporter and coordinator.
 
-* The coordinator determines the fix approach and who will provide a patch. Some reporters are willing to provide or collaborate to create a
-  patch, otherwise relevant core developers can be invited to collaborate by the coordinator.
+* The coordinator determines the fix approach and who will provide a patch.
+  Some reporters are willing to provide or collaborate to create a patch,
+  otherwise relevant core developers can be invited to collaborate by
+  the coordinator.
 
-   * For **Low** and **Medium** severity vulnerabilities it is acceptable to develop a patch in public.
-     The pull request must be marked with the ``security`` and ``release-blocker`` labels so that a release
-     is not created without including the patch.
+  * For **Low** and **Medium** severity vulnerabilities it is acceptable
+    to develop a patch in public.
+    The pull request must be marked with the ``security`` and ``release-blocker``
+    labels so that a release is not created without including the patch.
 
-   * For **High** and **Critical** severity vulnerabilities the patch must be developed privately using GitHub Security Advisories'
-     "Private Forks" feature. Core developers can be added to the GitHub Security Advisory via "collaborators" to work
-     on the fix together. Once a patch is approved privately and tested, a public issue and pull request can be created
-     with the ``security`` and ``release-blocker`` labels.
+  * For **High** and **Critical** severity vulnerabilities the patch must be
+    developed privately using GitHub Security Advisories' "Private Forks" feature.
+    Core developers can be added to the GitHub Security Advisory via "collaborators"
+    to work on the fix together. Once a patch is approved privately and tested,
+    a public issue and pull request can be created with
+    the ``security`` and ``release-blocker`` labels.
 
 * Once the pull request is merged the advisory can be published. The coordinator will send the advisory by email
   to ``security-announce@python.org`` using the below template. Backport labels must be added as appropriate.
@@ -101,7 +106,7 @@ please feel free to adapt them as needed for the current context.
 ::
 
    Thanks for submitting this report.
-   We now use GitHub Security Advisories for triaging vulnerability reports,
+   We use GitHub Security Advisories for triaging vulnerability reports,
    are you able to submit your report directly to GitHub?
 
    https://github.com/python/cpython/security/advisories/new

--- a/developer-workflow/psrt.rst
+++ b/developer-workflow/psrt.rst
@@ -1,0 +1,148 @@
+Python Security Response Team (PSRT)
+====================================
+
+The Python Security Response Team (PSRT) is responsible for handling
+vulnerability reports for CPython and pip.
+
+Vulnerability report triage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Vulnerability reports are sent to one of two locations,
+the long-standing ``security@python.org`` mailing list
+or using the private vulnerability reporting feature
+of GitHub Security Advisories.
+
+For reports sent to ``security@python.org``, a PSRT admin
+will triage the report and if the report seems plausible
+(ie, not spam and for the correct project) will reply with
+instructions on how to report the vulnerability on GitHub.
+
+If the reporter doesn't want to use GitHub's Security Advisories feature
+then the PSRT admins can create a draft report on behalf of the reporter.
+
+Coordinating a vulnerability report
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Each report will have a member of the PSRT assigned as the "coordinator".
+The coordinator will be responsible for following the below process and
+will be publicly credited on vulnerability records post-publication.
+
+If a coordinator can't complete the process for any reason (time obligation,
+vacation, etc) they must find a replacement coordinator in the PSRT
+and reassign the vulnerability report appropriately.
+
+Coordinators are expected to collaborate with other PSRT members and core developers
+when needed for guidance on affect-ness, severity, advisory text, and fixes.
+
+**The vulnerability coordination process is:**
+
+* Determine whether the report constitutes a vulnerability. If the report isn't a vulnerability,
+  the reporter should be notified appropriately. Close the GHSA report, the report can be reopened if
+  sufficient evidence that the report is a vulnerability is later obtained.
+
+* After a vulnerability report is accepted, a CVE ID must be assigned. If this is not done
+  automatically, then a CVE ID can be obtained by sending an email to ``cna@python.org``.
+  No details about the vulnerability report need to be shared with the PSF CNA for a CVE ID to be reserved.
+
+* Once a CVE ID is assigned, the CVE ID and acceptance can be shared with the reporter.
+  Use this CVE ID for referencing the vulnerability. Ask the reporter
+  if they'd like to be credited publicly for the report and if so, how they'd like to be credited.
+  Add this information to the GitHub Security Advisory.
+
+* If the report is a vulnerability, determine the severity of the vulnerability. Severity is one of:
+  **Low**, **Medium**, **High**, and **Critical**. Coordinators can use their knowledge of the code, how the code is likely used,
+  or another mechanism like CVSS for determining a severity. Add this information to the GitHub Security Advisory.
+
+* Author the vulnerability advisory text. The advisory must include the following information:
+
+  * Title should be a brief description of the vulnerability and affected component (e.g "Buffer over-read in SSLContext.set_npn_protocols()")
+
+  * Short description of the vulnerability, impact, and the conditions where the affected component is vulnerable, if applicable.
+
+  * Affected versions. This could be "all versions", but if the vulnerability exists in a new feature
+    or removed feature then this could be different. Include versions that are end-of-life in this calculation.
+    (e.g. "Python 3.9 and earlier", "Python 3.10 and later", "all versions of Python")
+
+  * Affected components and APIs. The module, function, class, or method must be specified so users can
+    search their codebase for usage. For issues affecting the entire project, this can be omitted.
+
+  * Mitigations for the vulnerability beyond upgrading to a patched version, if applicable.
+
+  This can all be done within the GitHub Security Advisory UI for easier collaboration between reporter and coordinator.
+
+* Determine the fix approach and who will provide a patch. Some reporters are willing to provide or collaborate to create a
+  patch, otherwise relevant core developers can be invited to collaborate.
+
+* For **Low** and **Medium** severity vulnerabilities it is acceptable to develop a patch in public.
+  The pull request must be marked with the ``security`` and ``release-blocker`` labels so that a release
+  is not created without including the patch.
+
+* For **High** and **Critical** severity vulnerabilities the patch must be developed privately using GitHub Security Advisories'
+  "Private Forks" feature. Core developers can be added to the GitHub Security Advisory via "collaborators" to work
+  on the fix together. Once a patch is approved privately and tested, a public issue and pull request can be created
+  with the ``security`` and ``release-blocker`` labels.
+
+* Once the pull request is merged the advisory can be published. Send an advisory email to ``security-announce@python.org``
+  using the below template. Backport labels must be added as appropriate. After the advisory is published a CVE record
+  can be created.
+
+Template responses
+~~~~~~~~~~~~~~~~~~
+
+These template responses should be used as guidance for messaging
+in various points in the process above. They're not required to be sent as-is,
+please feel free adapt them as needed for the current context.
+
+**Directing to GitHub Security Advisories:**
+
+ .. code-block::
+
+   Thanks for submitting this report.
+   We now use GitHub Security Advisories for triaging vulnerability reports,
+   are you able to submit your report directly to GitHub?
+
+   https://github.com/python/cpython/security/advisories/new
+
+   If you're unable to submit a report to GitHub (due to not having a GitHub account or something else)
+   let me know and I'll create a GitHub Security Advisory on your behalf,
+   although you won't be able to participate directly in discussions.
+
+**Rejecting a vulnerability report:**
+
+ .. code-block::
+
+   Thanks for your report. We've determined that
+   the report doesn't constitute a vulnerability.
+   Let us know if you disagree with this determination. If you're
+   interested in working on this further, you can optionally open a public issue on GitHub.
+
+**Accepting a vulnerability report:**
+
+ .. code-block::
+
+   Thanks for your report. We've determined that the report
+   is a vulnerability. We've assigned {CVE-YYYY-XXXX} and determined
+   a severity of {Low,Medium,High,Critical}. Let us know if you disagree
+   with the determined severity.
+
+   If you'd like to be publicly credited for this vulnerability as the reporter,
+   please indicate that along with how you'd like to be credited (ie, name or organization).
+
+   Please keep this vulnerability report private until we've published
+   an advisory to ``security-announce@python.org``.
+
+**Advisory email:**
+
+ .. code-block::
+
+   Title: [{CVE-YYYY-XXXX}] {title}
+
+   There is a new vulnerability affecting {project}.
+   The severity of this vulnerability is: {LOW, MEDIUM, HIGH, CRITICAL}.
+
+   {description}
+
+   Please see the linked CVE ID for the latest information on affected versions:
+
+   * https://www.cve.org/CVERecord?id={CVE-YYYY-XXXX}
+   * {pull request URL}

--- a/developer-workflow/psrt.rst
+++ b/developer-workflow/psrt.rst
@@ -14,7 +14,7 @@ of GitHub Security Advisories.
 
 For reports sent to ``security@python.org``, a PSRT admin
 will triage the report and if the report seems plausible
-(ie, not spam and for the correct project) will reply with
+(i.e., not spam and for the correct project) will reply with
 instructions on how to report the vulnerability on GitHub.
 
 If the reporter doesn't want to use GitHub's Security Advisories feature
@@ -95,7 +95,7 @@ please feel free adapt them as needed for the current context.
 
 **Directing to GitHub Security Advisories:**
 
- .. code-block::
+::
 
    Thanks for submitting this report.
    We now use GitHub Security Advisories for triaging vulnerability reports,
@@ -109,7 +109,7 @@ please feel free adapt them as needed for the current context.
 
 **Rejecting a vulnerability report:**
 
- .. code-block::
+::
 
    Thanks for your report. We've determined that
    the report doesn't constitute a vulnerability.
@@ -118,7 +118,7 @@ please feel free adapt them as needed for the current context.
 
 **Accepting a vulnerability report:**
 
- .. code-block::
+::
 
    Thanks for your report. We've determined that the report
    is a vulnerability. We've assigned {CVE-YYYY-XXXX} and determined
@@ -133,7 +133,7 @@ please feel free adapt them as needed for the current context.
 
 **Advisory email:**
 
- .. code-block::
+::
 
    Title: [{CVE-YYYY-XXXX}] {title}
 

--- a/developer-workflow/psrt.rst
+++ b/developer-workflow/psrt.rst
@@ -98,6 +98,8 @@ please feel free to adapt them as needed for the current context.
 
 .. highlight:: none
 
+..
+
    Thanks for submitting this report.
    We now use GitHub Security Advisories for triaging vulnerability reports,
    are you able to submit your report directly to GitHub?
@@ -111,7 +113,7 @@ please feel free to adapt them as needed for the current context.
 
 **Rejecting a vulnerability report:**
 
-.. highlight:: none
+..
 
    Thanks for your report. We've determined that the report doesn't constitute
    a vulnerability. Let us know if you disagree with this determination.
@@ -120,7 +122,7 @@ please feel free to adapt them as needed for the current context.
 
 **Accepting a vulnerability report:**
 
-.. highlight:: none
+..
 
    Thanks for your report. We've determined that the report
    is a vulnerability. We've assigned {CVE-YYYY-XXXX} and determined
@@ -136,7 +138,7 @@ please feel free to adapt them as needed for the current context.
 
 **Advisory email:**
 
-.. highlight:: none
+..
 
    Title: [{CVE-YYYY-XXXX}] {title}
 

--- a/developer-workflow/psrt.rst
+++ b/developer-workflow/psrt.rst
@@ -98,7 +98,7 @@ please feel free to adapt them as needed for the current context.
 
 .. highlight:: none
 
-..
+::
 
    Thanks for submitting this report.
    We now use GitHub Security Advisories for triaging vulnerability reports,
@@ -113,7 +113,7 @@ please feel free to adapt them as needed for the current context.
 
 **Rejecting a vulnerability report:**
 
-..
+::
 
    Thanks for your report. We've determined that the report doesn't constitute
    a vulnerability. Let us know if you disagree with this determination.
@@ -122,7 +122,7 @@ please feel free to adapt them as needed for the current context.
 
 **Accepting a vulnerability report:**
 
-..
+::
 
    Thanks for your report. We've determined that the report
    is a vulnerability. We've assigned {CVE-YYYY-XXXX} and determined
@@ -138,7 +138,7 @@ please feel free to adapt them as needed for the current context.
 
 **Advisory email:**
 
-..
+::
 
    Title: [{CVE-YYYY-XXXX}] {title}
 

--- a/developer-workflow/psrt.rst
+++ b/developer-workflow/psrt.rst
@@ -5,7 +5,7 @@ The Python Security Response Team (PSRT) is responsible for handling
 vulnerability reports for CPython and pip.
 
 Vulnerability report triage
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
 
 Vulnerability reports are sent to one of two locations,
 the long-standing ``security@python.org`` mailing list
@@ -21,7 +21,7 @@ If the reporter doesn't want to use GitHub's Security Advisories feature
 then the PSRT admins can create a draft report on behalf of the reporter.
 
 Coordinating a vulnerability report
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------
 
 Each report will have a member of the PSRT assigned as the "coordinator".
 The coordinator will be responsible for following the below process and
@@ -36,24 +36,24 @@ when needed for guidance on affect-ness, severity, advisory text, and fixes.
 
 **The vulnerability coordination process is:**
 
-* Determine whether the report constitutes a vulnerability. If the report isn't a vulnerability,
+* Coordinator will determine whether the report constitutes a vulnerability. If the report isn't a vulnerability,
   the reporter should be notified appropriately. Close the GHSA report, the report can be reopened if
   sufficient evidence that the report is a vulnerability is later obtained.
 
 * After a vulnerability report is accepted, a CVE ID must be assigned. If this is not done
-  automatically, then a CVE ID can be obtained by sending an email to ``cna@python.org``.
+  automatically, then a CVE ID can be obtained by the coordinator sending an email to ``cna@python.org``.
   No details about the vulnerability report need to be shared with the PSF CNA for a CVE ID to be reserved.
 
-* Once a CVE ID is assigned, the CVE ID and acceptance can be shared with the reporter.
-  Use this CVE ID for referencing the vulnerability. Ask the reporter
-  if they'd like to be credited publicly for the report and if so, how they'd like to be credited.
-  Add this information to the GitHub Security Advisory.
-
-* If the report is a vulnerability, determine the severity of the vulnerability. Severity is one of:
+* If the report is a vulnerability, the coordinator will determine the severity of the vulnerability. Severity is one of:
   **Low**, **Medium**, **High**, and **Critical**. Coordinators can use their knowledge of the code, how the code is likely used,
   or another mechanism like CVSS for determining a severity. Add this information to the GitHub Security Advisory.
 
-* Author the vulnerability advisory text. The advisory must include the following information:
+* Once a CVE ID is assigned, the coordinator will share the acceptance and CVE ID with the reporter.
+  Use this CVE ID for referencing the vulnerability. The coordinator will ask the reporter
+  if the reporter would like to be credited publicly for the report and if so, how they would like to be credited.
+  Add this information to the GitHub Security Advisory.
+
+* The coordinator authors the vulnerability advisory text. The advisory must include the following information:
 
   * Title should be a brief description of the vulnerability and affected component
     (for example, "Buffer over-read in SSLContext.set_npn_protocols()")
@@ -71,27 +71,27 @@ when needed for guidance on affect-ness, severity, advisory text, and fixes.
 
   This can all be done within the GitHub Security Advisory UI for easier collaboration between reporter and coordinator.
 
-* Determine the fix approach and who will provide a patch. Some reporters are willing to provide or collaborate to create a
-  patch, otherwise relevant core developers can be invited to collaborate.
+* The coordinator determines the fix approach and who will provide a patch. Some reporters are willing to provide or collaborate to create a
+  patch, otherwise relevant core developers can be invited to collaborate by the coordinator.
 
-* For **Low** and **Medium** severity vulnerabilities it is acceptable to develop a patch in public.
-  The pull request must be marked with the ``security`` and ``release-blocker`` labels so that a release
-  is not created without including the patch.
+   * For **Low** and **Medium** severity vulnerabilities it is acceptable to develop a patch in public.
+     The pull request must be marked with the ``security`` and ``release-blocker`` labels so that a release
+     is not created without including the patch.
 
-* For **High** and **Critical** severity vulnerabilities the patch must be developed privately using GitHub Security Advisories'
-  "Private Forks" feature. Core developers can be added to the GitHub Security Advisory via "collaborators" to work
-  on the fix together. Once a patch is approved privately and tested, a public issue and pull request can be created
-  with the ``security`` and ``release-blocker`` labels.
+   * For **High** and **Critical** severity vulnerabilities the patch must be developed privately using GitHub Security Advisories'
+     "Private Forks" feature. Core developers can be added to the GitHub Security Advisory via "collaborators" to work
+     on the fix together. Once a patch is approved privately and tested, a public issue and pull request can be created
+     with the ``security`` and ``release-blocker`` labels.
 
-* Once the pull request is merged the advisory can be published. Send an advisory email to ``security-announce@python.org``
-  using the below template. Backport labels must be added as appropriate. After the advisory is published a CVE record
-  can be created.
+* Once the pull request is merged the advisory can be published. The coordinator will send the advisory by email
+  to ``security-announce@python.org`` using the below template. Backport labels must be added as appropriate.
+  After the advisory is published a CVE record can be created.
 
 Template responses
-~~~~~~~~~~~~~~~~~~
+------------------
 
 These template responses should be used as guidance for messaging
-in various points in the process above. They're not required to be sent as-is,
+in various points in the process above. They are not required to be sent as-is,
 please feel free to adapt them as needed for the current context.
 
 **Directing to GitHub Security Advisories:**
@@ -104,18 +104,19 @@ please feel free to adapt them as needed for the current context.
 
    https://github.com/python/cpython/security/advisories/new
 
-   If you're unable to submit a report to GitHub (due to not having a GitHub account or something else)
-   let me know and I'll create a GitHub Security Advisory on your behalf,
-   although you won't be able to participate directly in discussions.
+   If you're unable to submit a report to GitHub (due to not having a GitHub
+   account or something else) let me know and I will create a GitHub Security
+   Advisory on your behalf, although you won't be able to participate directly
+   in discussions.
 
 **Rejecting a vulnerability report:**
 
 ::
 
-   Thanks for your report. We've determined that
-   the report doesn't constitute a vulnerability.
-   Let us know if you disagree with this determination. If you're
-   interested in working on this further, you can optionally open a public issue on GitHub.
+   Thanks for your report. We've determined that the report doesn't constitute
+   a vulnerability. Let us know if you disagree with this determination.
+   If you are interested in working on this further, you can optionally open a
+   public issue on GitHub.
 
 **Accepting a vulnerability report:**
 
@@ -126,8 +127,9 @@ please feel free to adapt them as needed for the current context.
    a severity of {Low,Medium,High,Critical}. Let us know if you disagree
    with the determined severity.
 
-   If you'd like to be publicly credited for this vulnerability as the reporter,
-   please indicate that, along with how you would like to be credited (name or organization).
+   If you would like to be publicly credited for this vulnerability as the
+   reporter, please indicate that, along with how you would like to be
+   credited (name or organization).
 
    Please keep this vulnerability report private until we've published
    an advisory to ``security-announce@python.org``.
@@ -138,11 +140,13 @@ please feel free to adapt them as needed for the current context.
 
    Title: [{CVE-YYYY-XXXX}] {title}
 
-   There is a {LOW, MEDIUM, HIGH, CRITICAL} severity vulnerability affecting {project}.
+   There is a {LOW, MEDIUM, HIGH, CRITICAL} severity vulnerability
+   affecting {project}.
 
    {description}
 
-   Please see the linked CVE ID for the latest information on affected versions:
+   Please see the linked CVE ID for the latest information on
+   affected versions:
 
    * https://www.cve.org/CVERecord?id={CVE-YYYY-XXXX}
    * {pull request URL}


### PR DESCRIPTION
This documents the process for PSRT coordination which matches the proposal sent to the Python Security Response Team. Note that GitHub Security Advisories are not yet active for the CPython repository, but this process works mostly the same just without a canonical place to record the information and collaborate.

cc @zooba @gpshead @ned-deily @warsaw 

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1348.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->