### PR TITLE
Use latest version of OpenSSL

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -691,7 +691,7 @@ on Linux, macOS and iOS.
 
       For **Homebrew**, install dependencies using ``brew``::
 
-         $ brew install pkg-config openssl@3.0 xz gdbm tcl-tk mpdecimal
+         $ brew install pkg-config openssl@3 xz gdbm tcl-tk mpdecimal
 
       .. tab:: Python 3.13+
 
@@ -701,7 +701,7 @@ on Linux, macOS and iOS.
                GDBM_LIBS="-L$(brew --prefix gdbm)/lib -lgdbm" \
                ./configure --with-pydebug \
                            --with-system-libmpdec \
-                           --with-openssl="$(brew --prefix openssl@3.0)"
+                           --with-openssl="$(brew --prefix openssl@3)"
 
       .. tab:: Python 3.11-3.12
 
@@ -710,7 +710,7 @@ on Linux, macOS and iOS.
             $ GDBM_CFLAGS="-I$(brew --prefix gdbm)/include" \
                GDBM_LIBS="-L$(brew --prefix gdbm)/lib -lgdbm" \
                ./configure --with-pydebug \
-                           --with-openssl="$(brew --prefix openssl@3.0)"
+                           --with-openssl="$(brew --prefix openssl@3)"
 
       .. tab:: Python 3.8-3.10
 
@@ -719,7 +719,7 @@ on Linux, macOS and iOS.
             $ CPPFLAGS="-I$(brew --prefix gdbm)/include -I$(brew --prefix xz)/include" \
                LDFLAGS="-L$(brew --prefix gdbm)/lib -L$(brew --prefix xz)/lib" \
                ./configure --with-pydebug \
-                           --with-openssl="$(brew --prefix openssl@3.0)" \
+                           --with-openssl="$(brew --prefix openssl@3)" \
                            --with-tcltk-libs="$(pkg-config --libs tcl tk)" \
                            --with-tcltk-includes="$(pkg-config --cflags tcl tk)"
 


### PR DESCRIPTION
The dev guide pins the version of OpenSSL to version 3.0, but the current latest version i 3.3.1 (July 2024).

This change pins the OpenSSL version to 3.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1349.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->