### PR TITLE
Remove GNU make-specific directive from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,11 +198,6 @@ _ensure-pre-commit:
 lint: _ensure-pre-commit
 	$(VENVDIR)/bin/python3 -m pre_commit run --all-files
 
-.PHONY: serve
-serve:
-	@echo "The 'serve' target was removed, use 'htmlview' instead" \
-	      "(see https://github.com/python/cpython/issues/80510)"
-
 include/branches.csv: include/release-cycle.json
 	$(VENVDIR)/bin/python3 _tools/generate_release_cycle.py
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Like https://github.com/python/cpython/pull/122662 and https://github.com/python/peps/pull/3891.

This is mostly to keep the `Makefile`s similar in each repo to ease maintenance.

Also remove the `make serve` stub, the target was removed in April 2022 in https://github.com/python/devguide/pull/826.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1362.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->