### PR TITLE
Request 'sethmlarson' be added as repo admin

### DIFF
--- a/developer-workflow/development-cycle.rst
+++ b/developer-workflow/development-cycle.rst
@@ -356,6 +356,8 @@ Current administrators
 +-------------------+----------------------------------------------------------+-----------------+
 | Mariatta Wijaya   | Maintainer of bedevere, blurb_it and miss-islington      | Mariatta        |
 +-------------------+----------------------------------------------------------+-----------------+
+| Seth Larson       | PSF Security Developer-in-Residence                      | sethmlarson     |
++-------------------+----------------------------------------------------------------------------+
 
 Repository release manager role policy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This is a request to add myself as a repository admin to the python/cpython repository to be able to evaluate GitHub Security Advisories (GHSA) for a Python Security Response Team ticketing system.

GHSA is a strange feature, where only admins have the ability to "accept" reports and close tickets, even when other users and teams are added as "Collaborators" to a specific ticket (from what I can see, collaborators only have the ability to edit an advisory but not)

I wanted to add bedevere-like commands to the [PSRT GitHub bot](https://github.com/python/psrt-ghsa-bot) that collaborators could type in comments in order to change the state of GHSAs, but there is no API to retrieve the comments of an advisory. This means that for now if we're going to migrate to GHSA we need an admin clicking a button sometimes. This might be okay, since it's not a departure from what PSRT admins deal with today with the PSRT mailing list (needing to accept a report before it's sent to the wider team).

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1363.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->