### PR TITLE
Add compiler warning tracking tooling failure remediation guidance

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -110,7 +110,6 @@ rediraffe_redirects = {
     "clang.rst": "development-tools/clang.rst",
     "coverity.rst": "development-tools/coverity.rst",
     "gdb.rst": "development-tools/gdb.rst",
-    "warnings.rst": "development-tools/warnings.rst",
     # Advanced Tools was renamed Development Tools in gh-1149
     "advanced-tools/clang.rst": "development-tools/clang.rst",
     "advanced-tools/coverity.rst": "development-tools/coverity.rst",

--- a/conf.py
+++ b/conf.py
@@ -114,7 +114,6 @@ rediraffe_redirects = {
     "advanced-tools/clang.rst": "development-tools/clang.rst",
     "advanced-tools/coverity.rst": "development-tools/coverity.rst",
     "advanced-tools/gdb.rst": "development-tools/gdb.rst",
-    "advanced-tools/warnings.rst": "development-tools/warnings.rst",
     # Core Developers
     "coredev.rst": "core-developers/become-core-developer.rst",
     "committing.rst": "core-developers/committing.rst",

--- a/conf.py
+++ b/conf.py
@@ -110,10 +110,12 @@ rediraffe_redirects = {
     "clang.rst": "development-tools/clang.rst",
     "coverity.rst": "development-tools/coverity.rst",
     "gdb.rst": "development-tools/gdb.rst",
+    "warnings.rst": "development-tools/warnings.rst",
     # Advanced Tools was renamed Development Tools in gh-1149
     "advanced-tools/clang.rst": "development-tools/clang.rst",
     "advanced-tools/coverity.rst": "development-tools/coverity.rst",
     "advanced-tools/gdb.rst": "development-tools/gdb.rst",
+    "advanced-tools/warnings.rst": "development-tools/warnings.rst",
     # Core Developers
     "coredev.rst": "core-developers/become-core-developer.rst",
     "committing.rst": "core-developers/committing.rst",

--- a/development-tools/index.rst
+++ b/development-tools/index.rst
@@ -9,3 +9,4 @@ Development tools
    gdb
    clang
    coverity
+   warnings

--- a/development-tools/warnings.rst
+++ b/development-tools/warnings.rst
@@ -47,7 +47,7 @@ If a warning check fails with:
       reasonable to ignore and add the warning to the platform-specific
       warning ignore file. If the file exists in the warning ignore file
       increment the count by the number of newly introduced warnings.
-* Unexpected Improvements (less warnings)
+* Unexpected improvements (less warnings)
     * Document in the PR that the change reduces the number of compiler
       warnings. Decrement the count in the platform-specific warning
       ignore file or remove the file if the count is now zero.

--- a/development-tools/warnings.rst
+++ b/development-tools/warnings.rst
@@ -1,0 +1,69 @@
+.. warnings:
+
+=================================
+Compiler Warning Tracking Tooling
+=================================
+
+The compiler warning tracking tooling is intended to alert developers to new
+compiler warnings introduced by their contributions. The tooling consists of
+python script which is ran by a few GitHub Actions worksflows. Currently these
+GitHub Actions jobs run the warning checking tooling:
+
+- Ubuntu/Build and Test
+- macOS/Build and Test
+
+The help text for the `Tools/build/check_warnings.py` is as follows:
+::
+
+    usage: check_warnings.py [-h]
+           -c COMPILER_OUTPUT_FILE_PATH
+           [-i WARNING_IGNORE_FILE_PATH] [-x] [-X] -t {json,clang}
+
+    options:
+        -h, --help            show this help message and exit
+        -c COMPILER_OUTPUT_FILE_PATH, --compiler-output-file-path COMPILER_OUTPUT_FILE_PATH
+                                                    Path to the compiler output file
+        -i WARNING_IGNORE_FILE_PATH, --warning-ignore-file-path WARNING_IGNORE_FILE_PATH
+                                                    Path to the warning ignore file
+        -x, --fail-on-regression
+                                                    Flag to fail if new warnings are found
+        -X, --fail-on-improvement
+                                                    Flag to fail if files that were expected to have warnings have no warnings
+        -t {json,clang}, --compiler-output-type {json,clang}
+                                                    Type of compiler output file (json or clang)
+
+The script can be run locally by providing the compiler output and the
+compiler output type to see a list of unique warnings.
+
+::
+
+        $ python Tools/build/check_warnings.py -c <compiler_output_file> -t <compiler_output_type>
+
+..
+
+    Note: `-fdiagnostics-format=json` flag is required when compiling with GCC
+           for the script to properly parse the compiler output.
+
+.. _warning-check-failure:
+
+What To Do If Warning Check Fails GitHub CI
+-------------------------------------------
+
+The warning check tooling will fail if the compiler generates more or less
+warnings than expected for a given source file as defined in the platform
+specific warning ignore file. The warning ignore file is either
+`Tools/build/.warningignore_ubuntu` or `Tools/build/.warningignore_macos`
+depending on the platform.
+
+If warning check fails with:
+
+1. Unexpected Warnings
+    a. Attempt to refactor the code to avoid the warning.
+    b. If it is not possible to avoid the warning document in the PR why it is
+       reasonable to ignore and add the warning to the platform specific
+       warning ignore file. If the file exists in the warning ignore file
+       increment the count by the number of new introduced warnings.
+2. Unexpected Imrpovements (Less Warnings)
+    a. Document in the PR that the change reduces the number of compiler
+       warnings. Decrement the count in the platform specific warning
+       ignore file or remove the file if the count is now zero.

--- a/development-tools/warnings.rst
+++ b/development-tools/warnings.rst
@@ -14,6 +14,7 @@ a Python script which is ran by the following GitHub workflows:
 
 You can check the documentation for the :cpy-file:`Tools/build/check_warnings.py` tool
 by running::
+
    python Tools/build/check_warnings.py --help
 
 The script can be run locally by providing the compiler output and the

--- a/development-tools/warnings.rst
+++ b/development-tools/warnings.rst
@@ -1,19 +1,19 @@
 .. warnings:
 
-=================================
-Compiler Warning Tracking Tooling
-=================================
+Tools for tracking compiler warnings
+====================================
 
 The compiler warning tracking tooling is intended to alert developers to new
 compiler warnings introduced by their contributions. The tooling consists of
-python script which is ran by a few GitHub Actions worksflows. Currently these
+Python script which is ran by a few GitHub Actions workflows. These
 GitHub Actions jobs run the warning checking tooling:
 
 - Ubuntu/Build and Test
 - macOS/Build and Test
 
-The help text for the `Tools/build/check_warnings.py` is as follows:
-::
+The help text for the :cpy-file:`Tools/build/check_warnings.py` is as follows:
+
+.. code-block:: text
 
     usage: check_warnings.py [-h]
            -c COMPILER_OUTPUT_FILE_PATH
@@ -46,24 +46,24 @@ compiler output type to see a list of unique warnings.
 
 .. _warning-check-failure:
 
-What To Do If Warning Check Fails GitHub CI
+What to do if a warning check fails GitHub CI
 -------------------------------------------
 
 The warning check tooling will fail if the compiler generates more or less
-warnings than expected for a given source file as defined in the platform
-specific warning ignore file. The warning ignore file is either
-`Tools/build/.warningignore_ubuntu` or `Tools/build/.warningignore_macos`
+warnings than expected for a given source file as defined in the
+platform-specific warning ignore file. The warning ignore file is either
+:cpy-file:`Tools/build/.warningignore_ubuntu` or :cpy-file:`Tools/build/.warningignore_macos`
 depending on the platform.
 
-If warning check fails with:
+If a warning check fails with:
 
-1. Unexpected Warnings
-    a. Attempt to refactor the code to avoid the warning.
-    b. If it is not possible to avoid the warning document in the PR why it is
+* Unexpected Warnings
+    * Attempt to refactor the code to avoid the warning.
+    * If it is not possible to avoid the warning document in the PR why it is
        reasonable to ignore and add the warning to the platform specific
        warning ignore file. If the file exists in the warning ignore file
        increment the count by the number of new introduced warnings.
-2. Unexpected Imrpovements (Less Warnings)
-    a. Document in the PR that the change reduces the number of compiler
+* Unexpected Imrpovements (Less Warnings)
+    * Document in the PR that the change reduces the number of compiler
        warnings. Decrement the count in the platform specific warning
        ignore file or remove the file if the count is now zero.

--- a/development-tools/warnings.rst
+++ b/development-tools/warnings.rst
@@ -3,34 +3,18 @@
 Tools for tracking compiler warnings
 ====================================
 
-The compiler warning tracking tooling is intended to alert developers to new
+.. highlight:: bash
+
+The compiler warning tracking tooling is intended to alert developers about new
 compiler warnings introduced by their contributions. The tooling consists of
-Python script which is ran by a few GitHub Actions workflows. These
-GitHub Actions jobs run the warning checking tooling:
+a Python script which is ran by the following GitHub workflows:
 
-- Ubuntu/Build and Test
-- macOS/Build and Test
+* Ubuntu/build and test (:cpy-file:`.github/workflows/reusable-ubuntu.yml`)
+* macOS/build and test (:cpy-file:`.github/workflows/reusable-macos.yml`)
 
-The help text for the :cpy-file:`Tools/build/check_warnings.py` is as follows:
-
-.. code-block:: text
-
-    usage: check_warnings.py [-h]
-           -c COMPILER_OUTPUT_FILE_PATH
-           [-i WARNING_IGNORE_FILE_PATH] [-x] [-X] -t {json,clang}
-
-    options:
-        -h, --help            show this help message and exit
-        -c COMPILER_OUTPUT_FILE_PATH, --compiler-output-file-path COMPILER_OUTPUT_FILE_PATH
-                                                    Path to the compiler output file
-        -i WARNING_IGNORE_FILE_PATH, --warning-ignore-file-path WARNING_IGNORE_FILE_PATH
-                                                    Path to the warning ignore file
-        -x, --fail-on-regression
-                                                    Flag to fail if new warnings are found
-        -X, --fail-on-improvement
-                                                    Flag to fail if files that were expected to have warnings have no warnings
-        -t {json,clang}, --compiler-output-type {json,clang}
-                                                    Type of compiler output file (json or clang)
+You can check the documentation for the :cpy-file:`Tools/build/check_warnings.py` tool
+by running::
+   python Tools/build/check_warnings.py --help
 
 The script can be run locally by providing the compiler output and the
 compiler output type to see a list of unique warnings.
@@ -49,21 +33,21 @@ compiler output type to see a list of unique warnings.
 What to do if a warning check fails GitHub CI
 ---------------------------------------------
 
-The warning check tooling will fail if the compiler generates more or less
-warnings than expected for a given source file as defined in the
+The :cpy-file:`Tools/build/check_warnings.py` tool will fail if the compiler generates
+more or less warnings than expected for a given source file as defined in the
 platform-specific warning ignore file. The warning ignore file is either
-:cpy-file:`Tools/build/.warningignore_ubuntu` or :cpy-file:`Tools/build/.warningignore_macos`
-depending on the platform.
+:cpy-file:`Tools/build/.warningignore_ubuntu` or
+:cpy-file:`Tools/build/.warningignore_macos` depending on the platform.
 
 If a warning check fails with:
 
-* Unexpected Warnings
+* Unexpected warnings
     * Attempt to refactor the code to avoid the warning.
     * If it is not possible to avoid the warning document in the PR why it is
-       reasonable to ignore and add the warning to the platform specific
-       warning ignore file. If the file exists in the warning ignore file
-       increment the count by the number of new introduced warnings.
-* Unexpected Imrpovements (Less Warnings)
+      reasonable to ignore and add the warning to the platform-specific
+      warning ignore file. If the file exists in the warning ignore file
+      increment the count by the number of newly introduced warnings.
+* Unexpected Improvements (less warnings)
     * Document in the PR that the change reduces the number of compiler
-       warnings. Decrement the count in the platform specific warning
-       ignore file or remove the file if the count is now zero.
+      warnings. Decrement the count in the platform-specific warning
+      ignore file or remove the file if the count is now zero.

--- a/development-tools/warnings.rst
+++ b/development-tools/warnings.rst
@@ -17,17 +17,14 @@ by running::
 
    python Tools/build/check_warnings.py --help
 
-The script can be run locally by providing the compiler output and the
-compiler output type to see a list of unique warnings.
+The script can be run locally by providing the compiler output file
+(where the output is saved) and the compiler output type
+(either ``json`` or ``clang``) to see a list of unique warnings::
 
-::
+   python Tools/build/check_warnings.py --compiler-output-file-path=compiler_output.txt --compiler-output-type=json
 
-        $ python Tools/build/check_warnings.py -c <compiler_output_file> -t <compiler_output_type>
-
-..
-
-    Note: `-fdiagnostics-format=json` flag is required when compiling with GCC
-           for the script to properly parse the compiler output.
+.. note:: The ``-fdiagnostics-format=json`` flag is required when compiling with GCC
+          for the script to properly parse the compiler output.
 
 .. _warning-check-failure:
 

--- a/development-tools/warnings.rst
+++ b/development-tools/warnings.rst
@@ -47,7 +47,7 @@ compiler output type to see a list of unique warnings.
 .. _warning-check-failure:
 
 What to do if a warning check fails GitHub CI
--------------------------------------------
+---------------------------------------------
 
 The warning check tooling will fail if the compiler generates more or less
 warnings than expected for a given source file as defined in the


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
New warning tracking tooling was introduced to CPython GitHub Actions jobs for Ubuntu with https://github.com/python/cpython/pull/121730.

It was then added for macOS build and test jobs with https://github.com/python/cpython/pull/122211

New compiler options that will emit warnings for potential security issues are going to be introduced to CPython. This addition to the developers guide is intended to be a reference for developers if the warning tracking tooling fails GitHub Actions CI.

I intend further expand on this documentation with examples based on the warning flags that we introduce to CPython, how developers can attempt to refactor to avoid these warnings, and finer details on how to modify warning ignore files.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1364.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->