### PR TITLE
Remove obsolete `serve` target from `make.bat`.

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -218,11 +218,6 @@ rem Ignore the tools and venv dirs and check that the default role is not used.
 cmd /S /C "%SPHINXLINT% -i tools -i venv --enable default-role"
 goto end
 
-:serve
-	echo.The serve target was removed, use htmlview instead ^
-(see https://github.com/python/cpython/issues/80510)
-goto end
-
 if "%1" == "versions" (
 	%PYTHON% _tools/generate_release_cycle.py
 	if errorlevel 1 exit /b 1


### PR DESCRIPTION
This is a follow-up of:
* #1362 

The PR removed the `make serve` target from the `Makefile` but not from `make.bat`.

---

Slightly unrelated, but I noticed that the `serve` replacement -- `htmllive` -- seems to be missing from `make.bat`.  `htmllive` (formerly known as `autobuild`) was introduced in:
* #1208 
`sphinx-autobuild` seems to be multiplat, so it should be possible to add it for Windows too.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1365.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->