### PR TITLE
Exploring: Python Extension Patterns v0.2.1 now supports Python 3.9 to Python 3.13.

### DIFF
--- a/internals/exploring.rst
+++ b/internals/exploring.rst
@@ -60,7 +60,7 @@ building your understanding of CPython internals and its evolution:
     "`Green Tree Snakes`_", "The missing Python AST docs", Thomas Kluyver, 3.6
     "`Yet another guided tour of CPython`_", "A guide for how CPython REPL works", Guido van Rossum, 3.5
     "`Python Asynchronous I/O Walkthrough`_", "How CPython async I/O, generator and coroutine works", Philip Guo, 3.5
-    "`Coding Patterns for Python Extensions`_", "Reliable patterns of coding Python Extensions in C", Paul Ross, 3.4
+    "`Coding Patterns for Python Extensions`_", "Reliable patterns of coding Python Extensions in C", Paul Ross, 3.9+
     "`Your Guide to the CPython Source Code`_", "Your Guide to the CPython Source Code", Anthony Shaw, 3.8
 
 .. csv-table:: **Historical references**


### PR DESCRIPTION
https://github.com/paulross/PythonExtensionPatterns http://pythonextensionpatterns.readthedocs.org/en/latest/index.html

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1367.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->