### PR TITLE
Fix typo in documentation/style-guide.rst: Correct "knoweldge" to "knowledge"

### DIFF
--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -132,7 +132,7 @@ explanation.
   designed to guide a user through a problem-field.
   Both tutorials and how-to guides are instructional rather than explanatory
   and should provide logical steps on how to complete a task. However,
-  how-to guides make more assumptions about the user's knoweldge and
+  how-to guides make more assumptions about the user's knowledge and
   focus on the user finding the best way to solve their own
   particular problem.
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

This pull request fixes a typographical error in the `documentation/style-guide.rst` file. The word "knoweldge" has been corrected to "knowledge".

## Details

- **File Changed:** `documentation/style-guide.rst`
- **Correction:** The term "knoweldge" was incorrectly spelled and has been updated to "knowledge" to ensure clarity and accuracy in the documentation.

## Checklist

- [x] Verified that the typo correction does not alter the meaning of the text.
- [x] Documentation builds successfully with no issues after the change.

Thank you for reviewing this PR!



<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1368.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->