### PR TITLE
Use `uv` to install packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,7 @@ jobs:
         with:
           python-version: "3"
       - name: Install uv
-        run: >
-          curl --no-progress-meter --location --fail
-          --proto '=https' --tlsv1.2
-          "https://astral.sh/uv/install.sh"
-          | sh
+        uses: hynek/setup-cached-uv@v2
       - name: Build docs
         run: make html
       - name: Link check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3"
-          cache: pip
+      - name: Install uv
+        run: >
+          curl --no-progress-meter --location --fail
+          --proto '=https' --tlsv1.2
+          "https://astral.sh/uv/install.sh"
+          | sh
       - name: Build docs
         run: make html
       - name: Link check


### PR DESCRIPTION
On a [recent PR](https://github.com/python/devguide/pull/1361), re-packing the cache took more time than the actual job. GHA runners have fast internet connections and we don't use many packages, it probably isn't worth using the cache. Also, we can switch to using `uv` for faster times.

Timings: 

| Timings | [Old](https://github.com/python/devguide/actions/runs/10386392593/job/28757574601?pr=1361) | [New](https://github.com/python/devguide/actions/runs/10386725054/job/28758622281?pr=1369) |
|--------|--------|--------|
| Run actions/checkout@v4          | ~0s    | ~0s    |
| Run actions/setup-python@v4      | ~0s    | ~0s    |
| Install uv                       | N/A    | 1s     |
| Build docs                       | 17s    | 12s    |
| Link check                       | 1m 30s | 1m 22s |
| Post Run actions/setup-python@v4 | 2m 14s | 0s     |
| Post Run actions/checkout@v4     | 0s     | 0s     |
| Total                            | 4m 4s  | 1m 37s |

A

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1369.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->