### PR TITLE
Update setup-building.rst with a note about libmpdec-dev missing from some Debian versions

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -660,9 +660,8 @@ on Linux, macOS and iOS.
             libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev \
             lzma lzma-dev tk-dev uuid-dev zlib1g-dev libmpdec-dev
 
-   Note that recent Debian distributions do not have the ``libmpdec-dev`` package.
-   You can safely remove it from the install list above and the Python build will
-   use a bundled version.
+   Note that Debian 12 and Ubuntu 24.04 do not have the ``libmpdec-dev`` package.  You can safely
+   remove it from the install list above and the Python build will use a bundled version.
 
 .. tab:: macOS
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -660,6 +660,9 @@ on Linux, macOS and iOS.
             libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev \
             lzma lzma-dev tk-dev uuid-dev zlib1g-dev libmpdec-dev
 
+   Note that recent Debian distributions do not have the ``libmpdec-dev`` package.
+   You can safely remove it from the install list above and the Python build will
+   use a bundled version.
 
 .. tab:: macOS
 


### PR DESCRIPTION
Add a note to the linux/debian instructions for building all optional packages.  libmpdec-dev is removed from recent Debian and can safely be dropped from list of packages to install.

See: https://github.com/python/cpython/issues/119114
See: https://github.com/python/cpython/pull/119196

See also #1338 

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1371.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->