### PR TITLE
Adopt Ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max_line_length = 88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,33 +1,13 @@
 repos:
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.7
     hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
-
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.12.1
-    hooks:
-      - id: black
-        args: [--skip-string-normalization]
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: [--profile=black]
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          [flake8-2020, flake8-implicit-str-concat]
-
-  - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0
-    hooks:
-      - id: python-check-blanket-noqa
+      - id: ruff-format
+        name: Run Ruff (format)
+        args: [--check]
+      - id: ruff
+        name: Run Ruff (lint)
+        args: [--exit-non-zero-on-fix]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.5.7
     hooks:
-      - id: ruff-format
-        name: Run Ruff (format)
-        args: [--check]
       - id: ruff
         name: Run Ruff (lint)
         args: [--exit-non-zero-on-fix]
+      - id: ruff-format
+        name: Run Ruff (format)
+        args: [--check]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,4 @@
-target-version = "py312"
+target-version = "py311"
 fix = true
 output-format = "full"
 line-length = 88
@@ -23,6 +23,7 @@ select = [
     "TCH",   # flake8-type-checking
     "UP",    # pyupgrade
     "W",     # pycodestyle
+    "YTT",   # flake8-2020
 ]
 ignore = [
     "E501",  # Ignore line length errors (we use auto-formatting)

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,34 @@
+target-version = "py312"
+fix = true
+output-format = "full"
+line-length = 88
+
+[lint]
+preview = true
+select = [
+    "C4",    # flake8-comprehensions
+    "B",     # flake8-bugbear
+    "E",     # pycodestyle
+    "F",     # pyflakes
+    "FA",    # flake8-future-annotations
+    "FLY",   # flynt
+    "FURB",  # refurb
+    "G",     # flake8-logging-format
+    "I",     # isort
+    "ISC",   # flake8-implicit-str-concat
+    "LOG",   # flake8-logging
+    "PERF",  # perflint
+    "PGH",   # pygrep-hooks
+    "PT",    # flake8-pytest-style
+    "TCH",   # flake8-type-checking
+    "UP",    # pyupgrade
+    "W",     # pycodestyle
+]
+ignore = [
+    "E501",  # Ignore line length errors (we use auto-formatting)
+]
+
+[format]
+preview = true
+quote-style = "preserve"
+docstring-code-format = true

--- a/_tools/generate_release_cycle.py
+++ b/_tools/generate_release_cycle.py
@@ -1,11 +1,11 @@
 """Read in a JSON and generate two CSVs and an SVG file."""
+
 from __future__ import annotations
 
 import argparse
 import csv
 import datetime as dt
 import json
-import sys
 
 import jinja2
 
@@ -45,10 +45,7 @@ class Versions:
 
     def write_csv(self) -> None:
         """Output CSV files."""
-        if sys.version_info >= (3, 11):
-            now_str = str(dt.datetime.now(dt.UTC))
-        else:
-            now_str = str(dt.datetime.utcnow())
+        now_str = str(dt.datetime.now(dt.UTC))
 
         versions_by_category = {"branches": {}, "end-of-life": {}}
         headers = None


### PR DESCRIPTION
I've set `target-version = "py312"` as that is what we have in CPython, but we could lower this requirement if wanted.

A


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1372.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->