### PR TITLE
Add htmllive to make.bat 

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -86,6 +86,7 @@ if "%1" == "htmllive" (
     if errorlevel 1 exit /b 1
     goto end
 )
+
 %SPHINXBUILD% -M %1 "." %BUILDDIR% %_ALL_SPHINX_OPTS%
 goto end
 

--- a/make.bat
+++ b/make.bat
@@ -73,6 +73,7 @@ if not defined SPHINXBUILD (
 	)
 	set PYTHON=venv\Scripts\python
 	set SPHINXBUILD=venv\Scripts\sphinx-build
+	set SPHIXAUTOBUILD=venv\Scripts\sphinx-autobuild
 )
 
 if "%1" == "html" (
@@ -91,6 +92,12 @@ if "%1" == "htmlview" (
         start "" "%BUILDDIR%\html\index.html"
     )
 
+    goto end
+)
+
+if "%1" == "htmllive" (
+    %SPHIXAUTOBUILD% --re-ignore="/\.idea/|/venv/" --open-browser --delay 0 --port 55301 . %BUILDDIR%/html
+    if errorlevel 1 exit /b 1
     goto end
 )
 

--- a/make.bat
+++ b/make.bat
@@ -73,7 +73,7 @@ if not defined SPHINXBUILD (
 	)
 	set PYTHON=venv\Scripts\python
 	set SPHINXBUILD=venv\Scripts\sphinx-build
-	set SPHIXAUTOBUILD=venv\Scripts\sphinx-autobuild
+	set SPHINXAUTOBUILD=venv\Scripts\sphinx-autobuild
 )
 
 if "%1" == "html" (
@@ -96,7 +96,7 @@ if "%1" == "htmlview" (
 )
 
 if "%1" == "htmllive" (
-    %SPHIXAUTOBUILD% --re-ignore="/\.idea/|/venv/" --open-browser --delay 0 --port 55301 . %BUILDDIR%/html
+    %SPHINXAUTOBUILD% --re-ignore="/\.idea/|/venv/" --open-browser --delay 0 --port 55301 . %BUILDDIR%/html
     if errorlevel 1 exit /b 1
     goto end
 )


### PR DESCRIPTION
This pull request fixes #1366 issue by adding the `htmllive` command to the `make.bat` script.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1373.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->