### PR TITLE
Add a fragment about translating code examples

### DIFF
--- a/documentation/translating.rst
+++ b/documentation/translating.rst
@@ -234,8 +234,9 @@ style.
 How should I translate code examples?
 -------------------------------------
 
-Translate values (i.e. string literals) and comments.
-Don't translate keywords and names, e.g. of variables, functions, classes, arguments and attributes.
+Translate values in code examples (i.e. string literals) and comments.
+Don't translate keywords or names,
+including variable, function, class, argument, and attribute names.
 
 .. _translation_wg: https://wiki.python.org/psf/TranslationWG/Charter
 .. _translation_ml: https://mail.python.org/mailman3/lists/translation.python.org/

--- a/documentation/translating.rst
+++ b/documentation/translating.rst
@@ -230,5 +230,12 @@ As for every project, we have a *branch* per version.  We store ``.po``
 files in the root of the repository using the ``gettext_compact=0``
 style.
 
+
+How should I translate code examples?
+-------------------------------------
+
+Translate values (i.e. string literals) and comments.
+Don't translate keywords and names, e.g. of variables, functions, classes, arguments and attributes.
+
 .. _translation_wg: https://wiki.python.org/psf/TranslationWG/Charter
 .. _translation_ml: https://mail.python.org/mailman3/lists/translation.python.org/


### PR DESCRIPTION
Adding guidance about how to translate code blocks. Related to https://github.com/python/cpython/pull/123408 CPython PR (issue https://github.com/python/cpython/issues/123407).

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1382.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->