### PR TITLE
Python 3.14 now is the main branch

### DIFF
--- a/core-developers/experts.rst
+++ b/core-developers/experts.rst
@@ -225,6 +225,7 @@ traceback             iritkatriel
 tracemalloc           vstinner
 tty                   Yhg1s*
 turtle                gregorlingl^, willingc
+turtledemo            terryjreedy*
 types                 1st1
 typing                gvanrossum, JelleZijlstra*, AlexWaygood*, carljm, sobolevn*
 unicodedata           malemburg, ezio-melotti

--- a/versions.rst
+++ b/versions.rst
@@ -5,7 +5,7 @@
 Status of Python versions
 =========================
 
-The ``main`` branch is currently the future Python 3.13, and is the only
+The ``main`` branch is currently the future Python 3.14, and is the only
 branch that accepts new features.  The latest release for each Python
 version can be found on the `download page <https://www.python.org/downloads/>`_.
 


### PR DESCRIPTION
Also add turtledemo expert (Today new codeowner) https://github.com/python/cpython/commit/1ce9e5880347346105693aba211f4c378f5a9b6a

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1383.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->