### PR TITLE
Fixup in "Explain how to add an extension module" PR.

### DIFF
--- a/developer-workflow/extension-modules.rst
+++ b/developer-workflow/extension-modules.rst
@@ -275,8 +275,8 @@ Now that we have added our extension module to the CPython source tree,
 we need to update some configuration files in order to compile the CPython
 project on different platforms.
 
-Updating :cpy-file:`!Modules/Setup.{bootstrap,stdlib}.in`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Updating ``Modules/Setup.{bootstrap,stdlib}.in``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Depending on whether the extension module is required to get a functioning
 interpreter or not, we update :cpy-file:`Modules/Setup.bootstrap.in` or


### PR DESCRIPTION
I missed this one (I should have looked at the rendering before...)

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1391.org.readthedocs.build/developer-workflow/extension-modules/#updating-modules-setup-bootstrap-stdlib-in
<!-- readthedocs-preview cpython-devguide end -->