### PR TITLE
Add guidance about the 'Update branch' button

### DIFF
--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -542,6 +542,18 @@ If you identify such flaky behavior, look for an issue in the `issue tracker`_
 that describes this particular flakiness. Create a new issue if you can't
 find one.
 
+:guilabel:`Update branch` button
+================================
+
+You can click on the :guilabel:`Update branch` button to merge the latest
+changes from the base branch (usually ``main``) into the PR.
+This is useful to :ref:`keep the CI green <keeping-ci-green>` for old PRs,
+or to check if a CI failure has been fixed in the base branch.
+
+Do not click :guilabel:`Update branch` without a good reason because it notifies
+everyone watching the PR that there are new changes, when there are not,
+and it uses up limited CI resources.
+
 Committing/rejecting
 ====================
 

--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -550,6 +550,10 @@ changes from the base branch (usually ``main``) into the PR.
 This is useful to :ref:`keep the CI green <keeping-ci-green>` for old PRs,
 or to check if a CI failure has been fixed in the base branch.
 
+If the PR is very old, it may be useful to update the branch before merging to
+ensure that the PR does not fail any CI checks that were added or changed since
+CI last ran.
+
 Do not click :guilabel:`Update branch` without a good reason because it notifies
 everyone watching the PR that there are new changes, when there are not,
 and it uses up limited CI resources.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Sometimes contributors click the "Update branch" button to merge in `main` into their PR, which is fine if there's a good reason, but if not, pings anyone subscribed to the PR, and uses up CI limited resources, which can cause delays on other PRs.

Good reasons to click it include wanting to update an old PR, to make sure it still passes CI. Or if the PR is failing, and the some tests/config has been updated in `main`.

I occasionally need to tell contributors this in PRs. Let's add a section to the devguide so we have something handy to link to. Here's some proposed text, happy to change it.

Preview: https://cpython-devguide--1392.org.readthedocs.build/getting-started/pull-request-lifecycle/#update-branch-button