### PR TITLE
Clarify the documentation update process

### DIFF
--- a/documentation/devguide.rst
+++ b/documentation/devguide.rst
@@ -19,10 +19,12 @@ main Python documentation, except for some small differences.  The source
 lives in a `separate repository`_ and bug reports should be submitted to the
 `devguide GitHub tracker`_.
 
-Our devguide follows a continuous integration and deployment workflow, with changes published when pull requests are merged.
-CPython documentation is updated regularly, typically within a day or two, depending on the build process.
-The documentation is versioned for each CPython release, and updates are continuosly incorporated, though with some delay due the build time.
-Aditionally, each CPython release includes a corresponding version of the documentation, which may also be used by redistributors.
+Changes to the Developer's Guide are published when pull requests are merged.
+
+Changes to the Python documentation are published regularly,
+ususally within 48 hours of the change being committed.
+The documentation is also `published for each release <https://docs.python.org/release/>`_,
+which may also be used by redistributors.
 
 
 Developer's Guide workflow

--- a/documentation/devguide.rst
+++ b/documentation/devguide.rst
@@ -19,10 +19,8 @@ main Python documentation, except for some small differences.  The source
 lives in a `separate repository`_ and bug reports should be submitted to the
 `devguide GitHub tracker`_.
 
-Our devguide workflow uses continuous integration and deployment so changes to
-the devguide are normally published when the pull request is merged. Changes
-to CPython documentation follow the workflow of a CPython release and are
-published in the release.
+Our devguide follows a continuous integration and deployment workflow, with changes published when pull requests are merged.
+CPython documentation, on the other hand, is updated daily and aligns with the CPython release workflow, with changes being included in each release.
 
 
 Developer's Guide workflow

--- a/documentation/devguide.rst
+++ b/documentation/devguide.rst
@@ -20,7 +20,9 @@ lives in a `separate repository`_ and bug reports should be submitted to the
 `devguide GitHub tracker`_.
 
 Our devguide follows a continuous integration and deployment workflow, with changes published when pull requests are merged.
-CPython documentation, on the other hand, is updated daily and aligns with the CPython release workflow, with changes being included in each release.
+CPython documentation is updated regularly, typically within a day or two, depending on the build process.
+The documentation is versioned for each CPython release, and updates are continuosly incorporated, though with some delay due the build time.
+Aditionally, each CPython release includes a corresponding version of the documentation, which may also be used by redistributors.
 
 
 Developer's Guide workflow


### PR DESCRIPTION
- update the documentation to specify that cpython docs are updated daily

- removed the previous implication that updates occur only with cpython releases

- clarified the connection between daily updates and the cpython release workflow

### Description

This PR updates the documentation to clarify the update workflow for the CPython documentation. The previous text implied that updates only occurred with CPython releases, but the documentation is actually updated on a daily basis. This change ensures accurate and up-to-date information about the documentation workflow.

### Changes Made

- Revised the description of the CPython documentation update process.

### Reason for Change

The original text did not fully reflect the frequency of CPython documentation updates. By specifying that updates occur daily, this pull request provides a more accurate representation of the documentation workflow.

### Impact

This change will ensure that users are correctly informed about the update schedule for CPython documentation, enhancing transparency and understanding of the documentation process.


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1395.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->