### PR TITLE
Fix linkcheck

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -105,8 +105,10 @@ linkcheck_ignore = [
     r'https://github.com/python/bedevere/#pr-state-machine',
     # "Anchor not found":
     r'https://packaging.python.org/.*#',
+    # "-rate limited-", causing a timeout
+    r'https://stackoverflow.com/.*',
     # Discord doesn't allow robot crawlers: "403 Client Error: Forbidden"
-    r'https://support.discord.com/hc/en-us/articles/219070107-Server-Nicknames',
+    'https://support.discord.com/hc/en-us/articles/219070107-Server-Nicknames',
 ]
 
 rediraffe_redirects = {

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -779,7 +779,7 @@ on Linux, macOS and iOS.
 
    As with CPython itself, the dependencies for CPython must be compiled for
    each of the hardware architectures that iOS supports. Consult the
-   documentation for `XZ <https://xz.tukaani.org/xz-utils/>`__, `bzip2
+   documentation for `XZ <https://tukaani.org/xz/>`__, `bzip2
    <https://sourceware.org/bzip2/>`__, `OpenSSL <https://www.openssl.org>`__ and
    `libffi <https://github.com/libffi/libffi>`__ for details on how to configure
    the project for cross-platform iOS builds.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

We've been getting some rate limiting checking stackoverflow.com, resulting in a 10-minute timeout. Let's ignore it.

Plus fix the XZ link, the old one was removed because it was created by the backdoor author.

```
...
(getting-started/setup-building: line  780) broken    https://xz.tukaani.org/xz-utils/ - HTTPSConnectionPool(host='xz.tukaani.org', port=443): Max retries exceeded with url: /xz-utils/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7f2b90d6b200>: Failed to resolve 'xz.tukaani.org' ([Errno -2] Name or service not known)"))
(developer-workflow/development-cycle: line  234) ok        https://github.com/python/devguide
(   triage/labels: line   33) ok        https://github.com/python/cpython/labels/type-security
(documentation/devguide: line   17) ok        [https://github.com/python/devguide/issues](https://github.com/python/devguide/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen)
(documentation/translating: line    9) ok        https://github.com/python/docsbuild-scripts/
-rate limited-   https://stackoverflow.com/ | sleeping...
-rate limited-   https://stackoverflow.com/ | sleeping...
-rate limited-   https://stackoverflow.com/ | sleeping...
Error: The operation was canceled.
```

https://github.com/python/devguide/actions/runs/10852890901/job/30119946956?pr=1397



<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1398.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->