### PR TITLE
Remove the inactionable TODO

### DIFF
--- a/getting-started/fixing-issues.rst
+++ b/getting-started/fixing-issues.rst
@@ -23,5 +23,3 @@ you can also always provide useful comments if you do attempt a fix, successful
 or not.
 
 .. _"easy" issues: https://github.com/python/cpython/issues?q=is%3Aissue+is%3Aopen+label%3Aeasy
-
-.. TODO: add something about no active core developer for the area?


### PR DESCRIPTION
The TODO has been there for 14 years.
Closes #1409 

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1412.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->