### PR TITLE
Update the link to the buildbot docs about setting up the worker as a Windows service

### DIFF
--- a/testing/new-buildbot-worker.rst
+++ b/testing/new-buildbot-worker.rst
@@ -179,7 +179,7 @@ For Windows:
 
 * Alternatively (note: don't do both!), set up the worker
   service as described in the `buildbot documentation
-  <https://docs.buildbot.net/current/manual/installation/requirements.html#windows-support>`_.
+  <https://docs.buildbot.net/current/manual/installation/misc.html#launching-worker-as-windows-service>`_.
 
 To start the worker running for your initial testing, you can do::
 


### PR DESCRIPTION
looks like this link became style, and the relevant information in the buildbot docs moved around.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1422.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->