### PR TITLE
Add more packages to CentOS setup instructions

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -627,8 +627,17 @@ some of CPython's modules (for example, ``zlib``).
 
    On **Fedora**, **RHEL**, **CentOS** and other ``dnf``-based systems::
 
+      $ sudo dnf install git pkg-config
       $ sudo dnf install dnf-plugins-core  # install this to use 'dnf builddep'
       $ sudo dnf builddep python3
+
+   Some optional development dependencies are not included in the above.
+   To install some additional dependencies for optional build and test components::
+
+      $ sudo dnf install \
+            gcc gcc-c++ gdb lzma glibc-devel libstdc++-devel openssl-devel \
+            readline-devel zlib-devel libffi-devel bzip2-devel xz-devel \
+            sqlite sqlite-devel sqlite-libs libuuid-devel gdbm-libs perf python3-pip
 
 
    On **Debian**, **Ubuntu**, and other ``apt``-based systems, try to get the

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -637,7 +637,8 @@ some of CPython's modules (for example, ``zlib``).
       $ sudo dnf install \
             gcc gcc-c++ gdb lzma glibc-devel libstdc++-devel openssl-devel \
             readline-devel zlib-devel libffi-devel bzip2-devel xz-devel \
-            sqlite sqlite-devel sqlite-libs libuuid-devel gdbm-libs perf python3-pip
+            sqlite sqlite-devel sqlite-libs libuuid-devel gdbm-libs perf \
+            expat expat-devel mpdecimal python3-pip
 
 
    On **Debian**, **Ubuntu**, and other ``apt``-based systems, try to get the


### PR DESCRIPTION
I found that I needed all of these to get a CentOS-based buildbot worker to build most optional modules and pass all tests

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1423.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->