### PR TITLE
Change reference in GC design doc

### DIFF
--- a/internals/garbage-collector.rst
+++ b/internals/garbage-collector.rst
@@ -167,7 +167,7 @@ C APIs
 
 Specific APIs are offered to allocate, deallocate, initialize, track, and untrack
 objects with GC support. These APIs can be found in the `Garbage Collector C API
-documentation <https://docs.python.org/3.8/c-api/gcsupport.html>`_.
+documentation <https://docs.python.org/dev/c-api/gcsupport.html>`_.
 
 Apart from this object structure, the type object for objects supporting garbage
 collection must include the ``Py_TPFLAGS_HAVE_GC`` in its ``tp_flags`` slot and


### PR DESCRIPTION
Prior to the change, the link led to a fixed version 3.8. Currently, it's not the latest version.

As the time passes by, it's going to be outdated further and further.

It might be the best solution to refer to the latest dev version of the doc, this way we can ensure that reader will access the latest data.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1424.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->