### PR TITLE
Use --with-dbmliborder or macOS+Homebrew on 3.10 and below

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -739,7 +739,12 @@ some of CPython's modules (for example, ``zlib``).
                ./configure --with-pydebug \
                            --with-openssl="$(brew --prefix openssl@3)" \
                            --with-tcltk-libs="$(pkg-config --libs tcl tk)" \
-                           --with-tcltk-includes="$(pkg-config --cflags tcl tk)"
+                           --with-tcltk-includes="$(pkg-config --cflags tcl tk)" \
+                           --with-dbmliborder=gdbm:ndbm
+
+         (``--with-dbmliborder`` is a workaround for a Homebrew-specific change
+         to ``gdbm``; see `#89452 <https://github.com/python/cpython/issues/89452>`_
+         for details.)
 
    .. tab:: MacPorts
 


### PR DESCRIPTION
As detailed in https://github.com/python/cpython/issues/89452#issuecomment-1115525666, Homebrew makes a specific change to `gdbm` that confuses the build of 3.10 and below into picking incompatible headers/libs, so `dbm` segfaults at runtime.

It's fixed in 3.11; older source-only releases only get a workaround: pass `--with-dbmliborder=gdbm:ndbm` to `configure`.

---

(3.8 is now EOL, but I don't want to remove mentions of it in *this* PR, even if it's textually nearby.)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1433.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->