### PR TITLE
Restore support for Python 3.10 to build

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,4 @@
-target-version = "py311"
+target-version = "py310"
 fix = true
 output-format = "full"
 line-length = 88

--- a/_tools/generate_release_cycle.py
+++ b/_tools/generate_release_cycle.py
@@ -45,7 +45,7 @@ class Versions:
 
     def write_csv(self) -> None:
         """Output CSV files."""
-        now_str = str(dt.datetime.now(dt.UTC))
+        now_str = str(dt.datetime.now(dt.timezone.utc))
 
         versions_by_category = {"branches": {}, "end-of-life": {}}
         headers = None


### PR DESCRIPTION
`/usr/bin/python3` is still 3.10 in some widely-used distros and the
support requirement is not onerous, needing only to use a longer-lived
alias for the same object (`assert datetime.UTC is datetime.timezone.utc`
holds where both exist).

See also #1097, #1107.


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1436.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->