### PR TITLE
Fix reference warnings caused by removal of __file__ from cpython docs

### DIFF
--- a/developer-workflow/extension-modules.rst
+++ b/developer-workflow/extension-modules.rst
@@ -31,7 +31,7 @@ Extension modules can be classified into two categories:
 
 * A *built-in* extension module is a module built and shipped with
   the Python interpreter. A built-in module is *statically* linked
-  into the interpreter, thereby lacking a :attr:`__file__` attribute.
+  into the interpreter, thereby lacking a :attr:`!__file__` attribute.
 
   .. seealso:: :data:`sys.builtin_module_names` --- names of built-in modules.
 
@@ -41,7 +41,7 @@ Extension modules can be classified into two categories:
 * A *shared* (or *dynamic*) extension module is built as a shared library
   (``.so`` or ``.dll`` file) and is *dynamically* linked into the interpreter.
 
-  In particular, the module's :attr:`__file__` attribute contains the path
+  In particular, the module's :attr:`!__file__` attribute contains the path
   to the ``.so`` or ``.dll`` file.
 
   Shared modules are built with the :c:macro:`!Py_BUILD_CORE_MODULE`


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1438.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->