### PR TITLE
NIS optional module dependency

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -638,7 +638,7 @@ some of CPython's modules (for example, ``zlib``).
             gcc gcc-c++ gdb lzma glibc-devel libstdc++-devel openssl-devel \
             readline-devel zlib-devel libffi-devel bzip2-devel xz-devel \
             sqlite sqlite-devel sqlite-libs libuuid-devel gdbm-libs perf \
-            expat expat-devel mpdecimal python3-pip
+            expat expat-devel mpdecimal python3-pip libnsl2-devel
 
 
    On **Debian**, **Ubuntu**, and other ``apt``-based systems, try to get the
@@ -674,7 +674,7 @@ some of CPython's modules (for example, ``zlib``).
       $ sudo apt-get install build-essential gdb lcov pkg-config \
             libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev \
             libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev \
-            lzma lzma-dev tk-dev uuid-dev zlib1g-dev libmpdec-dev
+            lzma lzma-dev tk-dev uuid-dev zlib1g-dev libmpdec-dev libnsl-dev
 
    Note that Debian 12 and Ubuntu 24.04 do not have the ``libmpdec-dev`` package.  You can safely
    remove it from the install list above and the Python build will use a bundled version.


### PR DESCRIPTION
NIS optional module build seems to fail if libnsl is missing. Installing libnsl-dev on Ubuntu/Debian or libnsl2-devel on Fedora based distros fixes the dependency issue.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1444.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->