### PR TITLE
Fix link in interpreter.rst

### DIFF
--- a/internals/interpreter.rst
+++ b/internals/interpreter.rst
@@ -5,4 +5,4 @@ The bytecode interpreter
 ========================
 
 This document is now part of the
-`CPython Internals Docs <https://github.com/python/cpython/blob/main/InternalDocs/compiler.md>`_.
+`CPython Internals Docs <https://github.com/python/cpython/blob/main/InternalDocs/interpreter.md>`_.


### PR DESCRIPTION
The link to internal docs currently points to [compiler.md](https://github.com/python/cpython/blob/main/InternalDocs/compiler.md), I've changed it to point to [interpreter.md](https://github.com/python/cpython/blob/main/InternalDocs/interpreter.md) as I assume was intended.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1458.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->