### PR TITLE
gh-1463: Added Refleak Checker Option under testing.

### DIFF
--- a/testing/run-write-tests.rst
+++ b/testing/run-write-tests.rst
@@ -86,8 +86,8 @@ if the failures are transient or consistent.
 The ``-uall`` flag allows the use of all available
 resources so as to not skip tests requiring, e.g., Internet access.
 
-To check for reference leaks (only needed if you modified C code), 
-you can enable reference leak checking during testing using the ``-R`` flag.  
+To check for reference leaks (only needed if you modified C code),
+you can enable reference leak checking during testing using the ``-R`` flag.
 For example, using the command::
 
     python -m test <test_name> -R <warmups>:<repeats>

--- a/testing/run-write-tests.rst
+++ b/testing/run-write-tests.rst
@@ -90,6 +90,14 @@ To check for reference leaks (only needed if you modified C code),
 you can enable reference leak checking during testing using the ``-R`` flag.
 For example, using the command::
 
+    python -m test <test_name> -R :
+
+This default setting performs a few initial warm-up runs to stabilize the reference count,
+followed by additional runs to check for leaks.
+
+If you want more control over the number of runs, you can specify ``warmups`` and ``repeats`` explicitly
+For example::
+
     python -m test <test_name> -R <warmups>:<repeats>
 
 This enables the refleak checker option, allowing you to perform warm-up runs

--- a/testing/run-write-tests.rst
+++ b/testing/run-write-tests.rst
@@ -86,10 +86,16 @@ if the failures are transient or consistent.
 The ``-uall`` flag allows the use of all available
 resources so as to not skip tests requiring, e.g., Internet access.
 
-To check for reference leaks (only needed if you modified C code), use the
-``-R`` flag.  For example, ``-R 3:2`` will first run the test 3 times to settle
-down the reference count, and then run it 2 more times to verify if there are
-any leaks.
+To check for reference leaks (only needed if you modified C code), 
+you can enable reference leak checking during testing using the ``-R`` flag.  
+For example, using the command::
+
+    python -m test <test_name> -R <warmups>:<repeats>
+
+This enables the refleak checker option, allowing you to perform warm-up runs
+to stabilize reference counts followed by additional runs to verify any leaks.
+For instance, ``-R 3:2`` will first run the test 3 times to settle down the
+reference count, and then run it 2 more times to check for leaks.
 
 You can also execute the ``Tools/scripts/run_tests.py`` script as  found in a
 CPython checkout. The script tries to balance speed with thoroughness. But if

--- a/testing/run-write-tests.rst
+++ b/testing/run-write-tests.rst
@@ -95,13 +95,10 @@ For example, using the command::
 This default setting performs a few initial warm-up runs to stabilize the reference count,
 followed by additional runs to check for leaks.
 
-If you want more control over the number of runs, you can specify ``warmups`` and ``repeats`` explicitly
-For example::
+If you want more control over the number of runs, you can specify ``warmups`` and ``repeats`` explicitly::
 
     python -m test <test_name> -R <warmups>:<repeats>
 
-This enables the refleak checker option, allowing you to perform warm-up runs
-to stabilize reference counts followed by additional runs to verify any leaks.
 For instance, ``-R 3:2`` will first run the test 3 times to settle down the
 reference count, and then run it 2 more times to check for leaks.
 


### PR DESCRIPTION
This pull request adds documentation for the -R flag in the python -m test command, enabling reference leak checking. This feature helps developers identify memory leaks when modifying C code.


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1468.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->