### PR TITLE
Add a guide to deprecating features

### DIFF
--- a/developer-workflow/cpython-deprecation-workflow.rst
+++ b/developer-workflow/cpython-deprecation-workflow.rst
@@ -4,8 +4,9 @@ Workflow for Deprecating Features in CPython
 Deprecation in CPython is a multi-step process that involves notifying users about deprecated functionality, planning its eventual removal, and providing adequate guidance for migration.
 This document outlines the practical steps required for deprecating a feature, supplementing the policy guidelines defined in :pep:`387`.
 
-1. Identify Features for Deprecation
-------------------------------------
+Check prevalence and consider alternatives
+------------------------------------------
+
 Before proposing deprecation:
 
 * **Assess Usage**: Use tools like GitHub search, ``grep``, or ``PyPI statistics`` to determine the extent and context of usage.

--- a/developer-workflow/cpython-deprecation-workflow.rst
+++ b/developer-workflow/cpython-deprecation-workflow.rst
@@ -12,8 +12,9 @@ Before proposing deprecation:
 * **Assess Usage**: Use tools like GitHub search, ``grep``, or ``PyPI statistics`` to determine the extent and context of usage.
 * **Consider Alternatives**: Ensure there are suitable replacements or upgrades available.
 
-2. Open an Issue
-----------------
+Open an issue
+-------------
+
 Start by creating a GitHub issue to propose the deprecation:
 
 * Clearly describe the feature and why deprecation is needed.

--- a/developer-workflow/cpython-deprecation-workflow.rst
+++ b/developer-workflow/cpython-deprecation-workflow.rst
@@ -80,7 +80,8 @@ For gradual deprecations:
   * Mention the pending deprecation in “What’s New.”
   * No ``pending-removal-in`` entry is needed during this stage.
 
-7. References and Templates
----------------------------
-* Use ``.. deprecated::`` and ``.. removed::`` Sphinx roles for documentation.
+References and templates
+------------------------
+
+* Use the ``.. deprecated-removed::`` roles for documentation.
 * Add ``See Also`` links to :pep:`387` and DevGuide for policy and process details.

--- a/developer-workflow/cpython-deprecation-workflow.rst
+++ b/developer-workflow/cpython-deprecation-workflow.rst
@@ -9,8 +9,11 @@ Check prevalence and consider alternatives
 
 Before proposing deprecation:
 
-* **Assess Usage**: Use tools like GitHub search, ``grep``, or ``PyPI statistics`` to determine the extent and context of usage.
+* **Assess Usage**: Use tools like GitHub search, `grep`_, or `PyPI statistics`_ to determine the extent and context of usage.
 * **Consider Alternatives**: Ensure there are suitable replacements or upgrades available.
+
+.. _grep: https://www.gnu.org/software/grep/
+.. _PyPI statistics: https://pypistats.org/
 
 Open an issue
 -------------
@@ -35,7 +38,7 @@ Once approved:
   .. code-block:: python
 
      import warnings
-     warnings.warn(
+     warnings._deprecated(
          "Feature X is deprecated and will be removed in Python 3.Y",
          DeprecationWarning,
          stacklevel=2

--- a/developer-workflow/cpython-deprecation-workflow.rst
+++ b/developer-workflow/cpython-deprecation-workflow.rst
@@ -8,7 +8,7 @@ This document outlines the practical steps required for deprecating a feature, s
 ------------------------------------
 Before proposing deprecation:
 
-* **Assess Usage**: Use tools like GitHub search, `grep`, or PyPI statistics to determine the extent and context of usage.
+* **Assess Usage**: Use tools like GitHub search, ``grep``, or ``PyPI statistics`` to determine the extent and context of usage.
 * **Consider Alternatives**: Ensure there are suitable replacements or upgrades available.
 
 2. Open an Issue

--- a/developer-workflow/cpython-deprecation-workflow.rst
+++ b/developer-workflow/cpython-deprecation-workflow.rst
@@ -20,8 +20,9 @@ Start by creating a GitHub issue to propose the deprecation:
 * Clearly describe the feature and why deprecation is needed.
 * Encourage community feedback and suggestions.
 
-3. Deprecation Implementation
------------------------------
+Deprecation implementation
+--------------------------
+
 Once approved:
 
 * **Raise a Warning**: Use :func:`warnings.warn` with :exc:`DeprecationWarning` for typical cases.

--- a/developer-workflow/cpython-deprecation-workflow.rst
+++ b/developer-workflow/cpython-deprecation-workflow.rst
@@ -47,8 +47,9 @@ Once approved:
   * Include details in the "Porting" section of the "What's New" documentation.
   * Update the ``pending-removal-in-{version}.rst`` file with the deprecation timeline.
 
-4. Track Deprecations
----------------------
+Track deprecations
+------------------
+
 * **Monitor Usage**: After the release, observe community feedback. Deprecations may remain longer than the minimum period if low maintenance overhead is expected or usage is widespread.
 * **Timeline Review**: Use GitHub milestones or specific deprecation tracking issues to manage timelines.
 

--- a/developer-workflow/cpython-deprecation-workflow.rst
+++ b/developer-workflow/cpython-deprecation-workflow.rst
@@ -1,0 +1,80 @@
+Workflow for Deprecating Features in CPython
+==============================================
+
+Deprecation in CPython is a multi-step process that involves notifying users about deprecated functionality, planning its eventual removal, and providing adequate guidance for migration.
+This document outlines the practical steps required for deprecating a feature, supplementing the policy guidelines defined in :pep:`387`.
+
+1. Identify Features for Deprecation
+------------------------------------
+Before proposing deprecation:
+
+* **Assess Usage**: Use tools like GitHub search, `grep`, or PyPI statistics to determine the extent and context of usage.
+* **Consider Alternatives**: Ensure there are suitable replacements or upgrades available.
+
+2. Open an Issue
+----------------
+Start by creating a GitHub issue to propose the deprecation:
+
+* Clearly describe the feature and why deprecation is needed.
+* Encourage community feedback and suggestions.
+
+3. Deprecation Implementation
+-----------------------------
+Once approved:
+
+* **Raise a Warning**: Use :func:`warnings.warn` with :exc:`DeprecationWarning` for typical cases.
+  If the feature is in its early deprecation phase:
+
+  * Use :exc:`PendingDeprecationWarning` initially, which transitions to :exc:`DeprecationWarning` after a suitable period.
+
+  Example:
+
+  .. code-block:: python
+
+     import warnings
+     warnings.warn(
+         "Feature X is deprecated and will be removed in Python 3.Y",
+         DeprecationWarning,
+         stacklevel=2
+     )
+
+* **Update Documentation**:
+
+  * Add a deprecation note in the relevant docstrings.
+  * Include details in the "Porting" section of the "What's New" documentation.
+  * Update the ``pending-removal-in-{version}.rst`` file with the deprecation timeline.
+
+4. Track Deprecations
+---------------------
+* **Monitor Usage**: After the release, observe community feedback. Deprecations may remain longer than the minimum period if low maintenance overhead is expected or usage is widespread.
+* **Timeline Review**: Use GitHub milestones or specific deprecation tracking issues to manage timelines.
+
+5. Plan Removal
+---------------
+After the deprecation period (typically 2+ releases):
+
+* Open a new issue for removal.
+* Follow removal steps:
+
+  * Remove the deprecated code and warnings.
+  * Update documentation, removing references to the deprecated feature.
+  * Include the removal in the "What's New" for the release.
+
+6. PendingDeprecationWarning Workflow
+-------------------------------------
+For gradual deprecations:
+
+* **Use Case**: When you want to signal future deprecation but not yet alert end-users.
+* **Transition Timeline**:
+
+  * Move from :exc:`PendingDeprecationWarning` to :exc:`DeprecationWarning` after one or more releases.
+
+* **Documentation**:
+
+  * Mention the pending deprecation in “What’s New.”
+  * No ``pending-removal-in`` entry is needed during this stage.
+
+7. References and Templates
+---------------------------
+* Use ``.. deprecated::`` and ``.. removed::`` Sphinx roles for documentation.
+* Add ``See Also`` links to :pep:`387` and DevGuide for policy and process details.

--- a/developer-workflow/cpython-deprecation-workflow.rst
+++ b/developer-workflow/cpython-deprecation-workflow.rst
@@ -28,7 +28,7 @@ Deprecation implementation
 
 Once approved:
 
-* **Raise a Warning**: Use :func:`warnings.warn` with :exc:`DeprecationWarning` for typical cases.
+* **Raise a Warning**: Use ``warnings._deprecated`` with :exc:`DeprecationWarning` for typical cases.
   If the feature is in its early deprecation phase:
 
   * Use :exc:`PendingDeprecationWarning` initially, which transitions to :exc:`DeprecationWarning` after a suitable period.

--- a/developer-workflow/cpython-deprecation-workflow.rst
+++ b/developer-workflow/cpython-deprecation-workflow.rst
@@ -64,8 +64,9 @@ After the deprecation period (typically 2+ releases):
   * Update documentation, removing references to the deprecated feature.
   * Include the removal in the "What's New" for the release.
 
-6. PendingDeprecationWarning Workflow
--------------------------------------
+``PendingDeprecationWarning`` workflow
+--------------------------------------
+
 For gradual deprecations:
 
 * **Use Case**: When you want to signal future deprecation but not yet alert end-users.

--- a/developer-workflow/cpython-deprecation-workflow.rst
+++ b/developer-workflow/cpython-deprecation-workflow.rst
@@ -53,9 +53,10 @@ Track deprecations
 * **Monitor Usage**: After the release, observe community feedback. Deprecations may remain longer than the minimum period if low maintenance overhead is expected or usage is widespread.
 * **Timeline Review**: Use GitHub milestones or specific deprecation tracking issues to manage timelines.
 
-5. Plan Removal
----------------
-After the deprecation period (typically 2+ releases):
+Plan removal
+------------
+
+After the deprecation period (not less than two releases):
 
 * Open a new issue for removal.
 * Follow removal steps:

--- a/developer-workflow/index.rst
+++ b/developer-workflow/index.rst
@@ -8,6 +8,7 @@ Development workflow
    :maxdepth: 5
 
    communication-channels
+   cpython-deprecation-workflow
    development-cycle
    stdlib
    extension-modules


### PR DESCRIPTION
This pull request introduces a new section in the Developer Guide to document the practical steps for deprecating features in CPython. It complements the policy guidelines outlined in [PEP 387](https://peps.python.org/pep-0387/) by providing a detailed, actionable workflow for contributors


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1469.org.readthedocs.build/developer-workflow/cpython-deprecation-workflow/

<!-- readthedocs-preview cpython-devguide end -->