### PR TITLE
Remove link to decommissioned Python Cookbook

### DIFF
--- a/developer-workflow/stdlib.rst
+++ b/developer-workflow/stdlib.rst
@@ -30,9 +30,6 @@ You have a several options for this:
 * Open a new thread in the `Ideas Discourse category`_
   to gather feedback directly from the Python core developers and community.
 * Write a blog post about the code, which may also help gather useful feedback.
-* Post it to the `Python Cookbook`_.
-  Based on feedback and reviews of the recipe,
-  you can see if others find the functionality as useful as you do.
 
 If you have found general acceptance and usefulness for your code from people,
 you can open an issue on the `issue tracker`_ with the code attached as a
@@ -47,7 +44,6 @@ for it you at least can know that others will come across it who may find it
 useful.
 
 .. _Ideas Discourse category: https://discuss.python.org/c/ideas/6
-.. _Python Cookbook: https://code.activestate.com/recipes/langs/python/
 
 
 Adding a new module


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

The "Python Cookbook" hasn't had a new recipe since July 2017, which is also the last time any recipe was added:

* https://code.activestate.com/recipes/langs/python/new/
* https://code.activestate.com/recipes/new/

Turns out code.activestate.com was decommissioned in 2018 and "shouldn’t be accessible at all", but they've not made that clear on the site itself:

* https://community.activestate.com/t/status-of-code-activestate-com/6028/2

It's been replaced by the https://github.com/ActiveState/code repo but that's not been updated in four years.

In summary, let's not suggest people try and post a recipe to gauge usefulness of an idea.


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1481.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->