### PR TITLE
Update repo RM role policy regarding EOL branches

### DIFF
--- a/developer-workflow/development-cycle.rst
+++ b/developer-workflow/development-cycle.rst
@@ -363,9 +363,9 @@ Repository release manager role policy
 Release Managers for :ref:`in-development <indevbranch>`, :ref:`maintenance
 <maintbranch>`, and :ref:`security mode <secbranch>` Python releases are
 granted Administrator privileges on the repository. Once a release branch has
-entered :ref:`end-of-life <eolbranch>`, the Release Manager for that branch is
-removed as an Administrator and granted sole privileges (out side of repository
-administrators) to merge changes to that branch.
+entered :ref:`end-of-life <eolbranch>`, the Release Manager for that branch
+creates a tag from the branch and deletes the branch. After this, they are
+removed as an Administrator.
 
 Multi-Factor Authentication must be enabled by the user in order to retain
 access as a Release Manager of the branch.

--- a/developer-workflow/development-cycle.rst
+++ b/developer-workflow/development-cycle.rst
@@ -364,7 +364,7 @@ Release Managers for :ref:`in-development <indevbranch>`, :ref:`maintenance
 <maintbranch>`, and :ref:`security mode <secbranch>` Python releases are
 granted Administrator privileges on the repository. Once a release branch has
 entered :ref:`end-of-life <eolbranch>`, the Release Manager for that branch
-creates a tag from the branch and deletes the branch. After this, they are
+creates a final tag and deletes the branch. After this, they are
 removed as an Administrator.
 
 Multi-Factor Authentication must be enabled by the user in order to retain


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

As detailed in [PEP 101](https://peps.python.org/pep-0101/#moving-to-end-of-life):

> * Freeze the state of the release branch by creating a tag of its current HEAD and then deleting the branch from the CPython repo. The current HEAD should be at or beyond the final security release for the branch: [...]
> 
> * If all looks good, delete the branch. [...]

Let's update the policy to match.




<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1483.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->