### PR TITLE
Documentation/Translating: add a link to docs translations dashboard

### DIFF
--- a/documentation/translating.rst
+++ b/documentation/translating.rst
@@ -10,7 +10,9 @@ Python documentation translations are governed by :PEP:`545`.
 They are built by `docsbuild-scripts
 <https://github.com/python/docsbuild-scripts/>`__ and hosted on
 docs.python.org. There are several documentation translations already
-in production; others are works in progress.
+in production; others are works in progress. See `the dashboard
+<https://m-aciek.github.io/pydocs-translation-dashboard/>`__ for
+details.
 
 .. list-table::
    :header-rows: 1


### PR DESCRIPTION
Refs https://github.com/python/docs-community/issues/143.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1488.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->