### PR TITLE
Typo in markup.rst

### DIFF
--- a/documentation/markup.rst
+++ b/documentation/markup.rst
@@ -22,8 +22,8 @@ Element                 Markup                                      See also
 arguments/parameters    ``*arg*``                                   :ref:`inline-markup`
 variables/literals/code ````foo````, ````42````, ````len(s) - 1```` :ref:`inline-markup`
 True/False/None         ````True````, ````False````, ````None````   :ref:`inline-markup`
-functions definitions   ``.. function:: print(*args)``              :ref:`directives`
-functions references    ``:func:`print```                           :ref:`roles`
+function definitions   ``.. function:: print(*args)``               :ref:`directives`
+function references    ``:func:`print```                            :ref:`roles`
 attribute definitions   ``.. attribute: `attr-name```               :ref:`information-units`
 attribute references    ``:attr:`attr-name```                       :ref:`roles`
 reference labels        ``.. _label-name:``                         :ref:`doc-ref-role`


### PR DESCRIPTION
Found a small typo while reading. The plural is used instead of the singular. The following rows are all singular: "attribute definitions" ,  "attribute references", "reference labels".

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1491.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->