### PR TITLE
Shorten names of country-specific languages

### DIFF
--- a/documentation/translating.rst
+++ b/documentation/translating.rst
@@ -72,7 +72,7 @@ details.
    * - Portuguese (pt)
      - Gustavo Toffo
      -
-   * - `Brasilian Portuguese (pt-br) <https://docs.python.org/pt-br/>`__
+   * - `Brazilian Portuguese (pt-br) <https://docs.python.org/pt-br/>`__
      - Marco Rougeth
      - :github:`GitHub <python/python-docs-pt-br>`,
        `wiki <https://python.org.br/traducao/>`__,

--- a/documentation/translating.rst
+++ b/documentation/translating.rst
@@ -23,7 +23,7 @@ details.
    * - Arabic (ar)
      - Abdur-Rahmaan Janhangeer (:github-user:`Abdur-rahmaanJ`)
      - :github:`GitHub <Abdur-rahmaanJ/python-docs-ar>`
-   * - Indian Bengali (bn_IN)
+   * - Bengali (bn_IN)
      - Kushal Das (:github-user:`Kushal997-das`)
      - :github:`GitHub <python/python-docs-bn-in>`
    * - `French (fr) <https://docs.python.org/fr/>`__
@@ -34,7 +34,7 @@ details.
        Fanis Petkos (:github-user:`thepetk`),
        Panagiotis Skias (:github-user:`skpanagiotis`)
      - :github:`GitHub <pygreece/python-docs-gr>`
-   * - Indian Hindi (hi_IN)
+   * - Hindi (hi_IN)
      - Sanyam Khurana (:github-user:`CuriousLearner`)
      - :github:`GitHub <CuriousLearner/python-docs-hi-in>`
    * - Hungarian (hu)

--- a/documentation/translating.rst
+++ b/documentation/translating.rst
@@ -72,7 +72,7 @@ details.
    * - Portuguese (pt)
      - Gustavo Toffo
      -
-   * - `Portuguese as spoken in Brasil (pt-br) <https://docs.python.org/pt-br/>`__
+   * - `Brasilian Portuguese (pt-br) <https://docs.python.org/pt-br/>`__
      - Marco Rougeth
      - :github:`GitHub <python/python-docs-pt-br>`,
        `wiki <https://python.org.br/traducao/>`__,

--- a/documentation/translating.rst
+++ b/documentation/translating.rst
@@ -23,7 +23,7 @@ details.
    * - Arabic (ar)
      - Abdur-Rahmaan Janhangeer (:github-user:`Abdur-rahmaanJ`)
      - :github:`GitHub <Abdur-rahmaanJ/python-docs-ar>`
-   * - Bengali as spoken in India (bn_IN)
+   * - Indian Bengali (bn_IN)
      - Kushal Das (:github-user:`Kushal997-das`)
      - :github:`GitHub <python/python-docs-bn-in>`
    * - `French (fr) <https://docs.python.org/fr/>`__
@@ -34,7 +34,7 @@ details.
        Fanis Petkos (:github-user:`thepetk`),
        Panagiotis Skias (:github-user:`skpanagiotis`)
      - :github:`GitHub <pygreece/python-docs-gr>`
-   * - Hindi as spoken in India (hi_IN)
+   * - Indian Hindi (hi_IN)
      - Sanyam Khurana (:github-user:`CuriousLearner`)
      - :github:`GitHub <CuriousLearner/python-docs-hi-in>`
    * - Hungarian (hu)


### PR DESCRIPTION
The “Brasilian Portuguese” is commonly used as a language name, also it looks like the Hindi and Bengali doesn't need to be country-specific: Hindi is India-only language, Bengali is [the same](https://www.reddit.com/r/kolkata/comments/1e5exb1/guys_whats_the_difference_between_indian_bengali/) in both India and Bangladesh.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1492.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->