### PR TITLE
Add section on obtaining a python.org email address for core team members

### DIFF
--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -104,7 +104,6 @@ The important options in the poll builder set to get this result:
     }
     </script>
 
-
 .. _Code of Conduct: https://policies.python.org/python.org/code-of-conduct/
 .. _Committers category: https://discuss.python.org/c/committers/5
 .. _Python Discourse: https://discuss.python.org

--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -63,7 +63,7 @@ are granted through these steps:
 Getting a python.org Email Address
 ----------------------------------
 
-Members of the core team can get an email address on the python.org domain. For more details, please refer to the `PSF Board Policies on Email Addresses <https://www.python.org/psf/records/board/policies/email/>`_.
+Members of the core team can get an email address on the python.org domain. For more details refer to the `PSF Board Policies on Email Addresses <https://www.python.org/psf/records/board/policies/email/>`_.
 
 
 Poll template

--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -60,6 +60,12 @@ are granted through these steps:
      were in the form of a separate post on the already open topic with
      the poll.
 
+Getting a python.org Email Address
+----------------------------------
+
+Members of the core team can get an email address on the python.org domain. For more details, please refer to the `PSF Board Policies on Email Addresses <https://www.python.org/psf/records/board/policies/email/>`_.
+
+
 Poll template
 =============
 
@@ -97,6 +103,7 @@ The important options in the poll builder set to get this result:
       }
     }
     </script>
+
 
 .. _Code of Conduct: https://policies.python.org/python.org/code-of-conduct/
 .. _Committers category: https://discuss.python.org/c/committers/5

--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -63,7 +63,9 @@ are granted through these steps:
 Getting a python.org email address
 ----------------------------------
 
-Members of the core team can get an email address on the python.org domain. For more details refer to the `PSF Board Policies on Email Addresses <https://www.python.org/psf/records/board/policies/email/>`_.
+Members of the core team can get an email address on the python.org domain.
+For more details refer to the `python.org email policy
+<https://www.python.org/psf/records/board/policies/email/>`_.
 
 
 Poll template

--- a/core-developers/become-core-developer.rst
+++ b/core-developers/become-core-developer.rst
@@ -60,7 +60,7 @@ are granted through these steps:
      were in the form of a separate post on the already open topic with
      the poll.
 
-Getting a python.org Email Address
+Getting a python.org email address
 ----------------------------------
 
 Members of the core team can get an email address on the python.org domain. For more details refer to the `PSF Board Policies on Email Addresses <https://www.python.org/psf/records/board/policies/email/>`_.


### PR DESCRIPTION
# Pull Request title

Mention getting a python.org email address #1449

# Description

Added a section to the "How to become a core developer" document to inform core team members about how they can get a python.org email address. The new section includes a link to the PSF Board Policies on Email Addresses.

# Issue Number

Fixes #1449

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1495.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->