### PR TITLE
conf.py: Update copyright date

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -14,7 +14,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = "Python Developer's Guide"
-copyright = '2011 Python Software Foundation'
+copyright = '2011-2025, Python Software Foundation'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Current:
![image](https://github.com/user-attachments/assets/93231533-3120-4ae5-b55f-d62bd9ca8f31)

`2011 Python Software Foundation`

Proposed:
![image](https://github.com/user-attachments/assets/93c498cb-d55e-4cf3-b97f-6c6a2df9b57a)

`2011-2025 Python Software Foundation`

The content of most of the pages has been updated since 2011. This is consistent with the format of the docs.python.org footer:
![image](https://github.com/user-attachments/assets/4e686861-caad-45b0-8efe-4e8f502f9483)


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1497.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->