### PR TITLE
Fix table markup to show markup table

### DIFF
--- a/documentation/markup.rst
+++ b/documentation/markup.rst
@@ -22,7 +22,7 @@ Element                 Markup                                      See also
 arguments/parameters    ``*arg*``                                   :ref:`inline-markup`
 variables/literals/code ````foo````, ````42````, ````len(s) - 1```` :ref:`inline-markup`
 True/False/None         ````True````, ````False````, ````None````   :ref:`inline-markup`
-function definitions   ``.. function:: print(*args)``               :ref:`directives`
+function definitions   ``.. function:: print(*args)``              :ref:`directives`
 function references    ``:func:`print```                            :ref:`roles`
 attribute definitions   ``.. attribute: `attr-name```               :ref:`information-units`
 attribute references    ``:attr:`attr-name```                       :ref:`roles`


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

The table at https://devguide.python.org/documentation/markup/#quick-reference is missing:

<img width="761" alt="image" src="https://github.com/user-attachments/assets/cbcac455-fbbc-4598-b519-708ec36a3f2a" />

The warning in the logs:

```
/Users/hugo/github/devguide/documentation/markup.rst:25: ERROR: Malformed table.
Text in column margin in table line 7.

======================= =========================================== ====================
Element                 Markup                                      See also
======================= =========================================== ====================
arguments/parameters    ``*arg*``                                   :ref:`inline-markup`
variables/literals/code ````foo````, ````42````, ````len(s) - 1```` :ref:`inline-markup`
True/False/None         ````True````, ````False````, ````None````   :ref:`inline-markup`
function definitions   ``.. function:: print(*args)``               :ref:`directives`
function references    ``:func:`print```                            :ref:`roles`
attribute definitions   ``.. attribute: `attr-name```               :ref:`information-units`
attribute references    ``:attr:`attr-name```                       :ref:`roles`
reference labels        ``.. _label-name:``                         :ref:`doc-ref-role`
internal references     ``:ref:`label-name```                       :ref:`doc-ref-role`
external links          ```Link text <https://example.com>`_``      :ref:`hyperlinks`
roles w/ custom text    ``:role:`custom text <target>```            :ref:`roles`
roles w/ only last part ``:role:`~hidden.hidden.visible```          :ref:`roles`
roles w/o link          ``:role:`!target```                         :ref:`roles`
issues                  ``:gh:`ID```, ``:issue:`ID```               :ref:`roles`
CPython source          ``:source:`PATH```                          :ref:`roles`
comments                ``.. a comment``                            :ref:`comments`
======================= =========================================== ==================== [docutils]
looking for now-outdated files... none found
```

https://github.com/python/devguide/actions/runs/13209380442/job/36879823502#step:5:94

It was accidentally broken in https://github.com/python/devguide/pull/1491 and not noticed because we temporarily disabled `--fail-on-warning` in https://github.com/python/devguide/pull/1426 as part of the re-org work to prevent errors from duplicate label warnings.
