### PR TITLE
Update Persian Translation Entry to Reflect New Maintainer

### DIFF
--- a/documentation/translating.rst
+++ b/documentation/translating.rst
@@ -62,7 +62,7 @@ details.
      - Albertas Gimbutas (:github-user:`albertas`, `email <mailto:albertasgim@gmail.com>`__)
      - `Original mail <https://mail.python.org/pipermail/doc-sig/2019-July/004138.html>`__
    * - Persian (fa)
-     - Revisto (:github-user:`revisto`)
+     - Alireza Shabani (:github-user:`revisto`)
      - :github:`GitHub <revisto/python-docs-fa>`
    * - `Polish (pl) <https://docs.python.org/pl/>`__
      - Maciej Olko (:github-user:`m-aciek`)

--- a/documentation/translating.rst
+++ b/documentation/translating.rst
@@ -62,8 +62,8 @@ details.
      - Albertas Gimbutas (:github-user:`albertas`, `email <mailto:albertasgim@gmail.com>`__)
      - `Original mail <https://mail.python.org/pipermail/doc-sig/2019-July/004138.html>`__
    * - Persian (fa)
-     - Komeil Parseh (:github-user:`mmdbalkhi`)
-     - :github:`GitHub <mmdbalkhi/python-docs-fa>`
+     - Revisto (:github-user:`revisto`)
+     - :github:`GitHub <revisto/python-docs-fa>`
    * - `Polish (pl) <https://docs.python.org/pl/>`__
      - Maciej Olko (:github-user:`m-aciek`)
      - :github:`GitHub <python/python-docs-pl>`,


### PR DESCRIPTION
This PR updates the Persian translation entry in `documentation/translating.rst` to reflect the change in maintainer from Komeil Parseh to Revisto and updates the repository link accordingly.

This change reflects the transfer of coordination for the Persian translation, as discussed on the Python Docs Discord server.

CC @JulienPalard for approval.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1512.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->