### PR TITLE
Add Rafael Fontenelle as a contact for pt_BR translations

### DIFF
--- a/documentation/translating.rst
+++ b/documentation/translating.rst
@@ -73,7 +73,8 @@ details.
      - Gustavo Toffo
      -
    * - `Portuguese as spoken in Brasil (pt-br) <https://docs.python.org/pt-br/>`__
-     - Marco Rougeth
+     - Rafael Fontenelle (:github-user:`rffontenelle`),
+       Marco Rougeth (:github-user:`rougeth`)
      - :github:`GitHub <python/python-docs-pt-br>`,
        `wiki <https://python.org.br/traducao/>`__,
        `Telegram <https://t.me/pybr_i18n>`__,


### PR DESCRIPTION
Just adding @rffontenelle as the main contact for the Brazilian translation community.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1514.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->