### PR TITLE
#1115 Updated Issue : documents updated accordingly : setup.rst , ext…

### DIFF
--- a/contrib/code/setup.rst
+++ b/contrib/code/setup.rst
@@ -10,3 +10,23 @@ Setup and building
 
 [More setup and build instructions specifically for code contributors, building
 on the basics from the :ref:`Getting Started <getting-started>` section.]
+
+.. _configure-cache:
+
+Using Configure Cache (`configure -C`)
+--------------------------------------
+
+### Overview  
+When running `./configure`, CPython performs a series of system checks to detect platform-specific settings. These checks can be time-consuming, especially for repeated builds.  
+
+By using **configure cache (`-C`)**, you can store previous configuration results, reducing redundant checks and **significantly speeding up build times**.  
+
+### Benefits of `configure -C`  
+- **Faster rebuilds**: Skips redundant system checks, improving efficiency.  
+- **Improves development workflow**: Optimizes the edit-configure-build-test cycle.  
+- **Reduces system load**: Avoids unnecessary reconfigurations.  
+
+### How to Use `configure -C`  
+To enable caching, run:  
+```sh
+./configure -C

--- a/developer-workflow/extension-modules.rst
+++ b/developer-workflow/extension-modules.rst
@@ -275,6 +275,27 @@ Now that we have added our extension module to the CPython source tree,
 we need to update some configuration files in order to compile the CPython
 project on different platforms.
 
+-------------------------------------
+
+.. _configure-cache:
+
+Using Configure Cache (`configure -C`)
+--------------------------------------
+
+### Overview  
+When running `./configure`, CPython performs a series of system checks to detect platform-specific settings. These checks can be time-consuming, especially for repeated builds.  
+
+By using **configure cache (`-C`)**, you can store previous configuration results, reducing redundant checks and **significantly speeding up build times**.  
+
+### Benefits of `configure -C`  
+- **Faster rebuilds**: Skips redundant system checks, improving efficiency.  
+- **Improves development workflow**: Optimizes the edit-configure-build-test cycle.  
+- **Reduces system load**: Avoids unnecessary reconfigurations.  
+
+### How to Use `configure -C`  
+To enable caching, run:  
+```sh
+./configure -C
 Updating ``Modules/Setup.{bootstrap,stdlib}.in``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Pull Request Title: Improve Documentation on configure -C Usage for Faster Builds (#1115)

Description:
This PR enhances the documentation by adding a section on using the configure cache (-C) option in setup.rst and extension-modules.rst. The update explains how caching improves build efficiency, reduces redundant system checks, and optimizes the development workflow.

Clarifies the benefits of using configure -C for repeated builds.
Provides best practices to prevent stale configurations.
Adds instructions on clearing the cache when system dependencies change.
These improvements align with the guidelines by ensuring documentation remains clear, useful, and directly relevant to developers working with CPython’s build system.









<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1519.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->