### PR TITLE
Remove extra indentations in `triage/issue-tracker.rst`

### DIFF
--- a/triage/issue-tracker.rst
+++ b/triage/issue-tracker.rst
@@ -57,10 +57,10 @@ will ask you to do so now.
 First you need to select what kind of problem you want to report. The
 available choices include, for example:
 
- * **Bug report**: an existing feature isn't working as expected.
- * **Documentation**: there is missing, invalid, or misleading documentation.
- * **Feature or enhancement**: suggest a new feature for Python.
- * **Report a security vulnerability**: privately report a security vulnerability.
+* **Bug report**: an existing feature isn't working as expected.
+* **Documentation**: there is missing, invalid, or misleading documentation.
+* **Feature or enhancement**: suggest a new feature for Python.
+* **Report a security vulnerability**: privately report a security vulnerability.
 
 Depending on your choice, a dedicated form template will appear.
 In particular, you'll notice that the last button actually takes you to


### PR DESCRIPTION
Fixed the format so it renders correctly.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1520.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->