### PR TITLE
Python version status: show when bugfix releases become security releases.

### DIFF
--- a/_tools/generate_release_cycle.py
+++ b/_tools/generate_release_cycle.py
@@ -35,7 +35,8 @@ class Versions:
         # Generate a few additional fields
         for key, version in self.versions.items():
             version["key"] = key
-            version["first_release_date"] = parse_date(version["first_release"])
+            version["first_release_date"] = r1 = parse_date(version["first_release"])
+            version["start_security_date"] = r1 + dt.timedelta(days=2 * 365)
             version["end_of_life_date"] = parse_date(version["end_of_life"])
         self.sorted_versions = sorted(
             self.versions.values(),

--- a/_tools/release_cycle_template.svg.jinja
+++ b/_tools/release_cycle_template.svg.jinja
@@ -58,25 +58,87 @@
         <!-- Colourful blob with a label -->
         {% set start_x = date_to_x(version.first_release_date) %}
         {% set end_x = date_to_x(version.end_of_life_date) %}
-        {% set mid_x = (start_x + end_x) / 2 %}
-        <rect
-            class="release-cycle-blob release-cycle-blob-{{ version.status }}"
-            x="{{ start_x * SCALE }}"
-            y="{{ (y - 1) * SCALE }}"
-            width="{{ (end_x - start_x) * SCALE }}"
-            height="{{ 1.25 * SCALE }}"
-            rx="0.25em"
-            ry="0.25em"
-        />
-        <text
-            class="release-cycle-blob-label release-cycle-blob-{{ version.status }}"
-            x="{{ mid_x * SCALE }}"
-            y="{{ (y - 0.1) * SCALE }}"
-            font-size="{{ SCALE * 0.75 }}"
-            text-anchor="middle"
-        >
-            {{ version.status }}
-        </text>
+
+        {% if version.status == "bugfix" %}
+            <!-- bugfix status needs a security tail.
+                Draw the rectangle with two path elements instead.
+                Thanks Claude.ai for the conversion.
+            -->
+            {% set half_x = date_to_x(version.start_security_date) %}
+            {% set height = 1.25 * SCALE %}
+            {% set left_width = (half_x - start_x) * SCALE %}
+            {% set right_width = (end_x - half_x) * SCALE %}
+            {% set left_x = start_x * SCALE %}
+            {% set middle_x = half_x * SCALE %}
+            {% set right_x = half_x * SCALE %}
+            {% set recty = (y - 1) * SCALE %}
+            {% set radius_value = 0.25 * SCALE %}
+
+            <path
+                class="release-cycle-blob release-cycle-blob-bugfix"
+                d="
+                    M{{ left_x + radius_value }},{{ recty }}
+                    Q{{ left_x }},{{ recty }} {{ left_x }},{{ recty + radius_value }}
+                    V{{ recty + height - radius_value }}
+                    Q{{ left_x }},{{ recty + height }} {{ left_x + radius_value }},{{ recty + height }}
+                    H{{ middle_x }}
+                    V{{ recty }}
+                    Z
+                "
+            />
+            <text
+                class="release-cycle-blob-label release-cycle-blob-bugfix"
+                x="{{ (start_x + half_x) / 2 * SCALE }}"
+                y="{{ (y - 0.1) * SCALE }}"
+                font-size="{{ SCALE * 0.75 }}"
+                text-anchor="middle"
+            >
+                bugfix
+            </text>
+
+            <path
+                class="release-cycle-blob release-cycle-blob-security"
+                d="
+                    M{{ right_x }},{{ recty }}
+                    H{{ right_x + right_width - radius_value }}
+                    Q{{ right_x + right_width }},{{ recty }} {{ right_x + right_width }},{{ recty + radius_value }}
+                    V{{ recty + height - radius_value }}
+                    Q{{ right_x + right_width }},{{ recty + height }} {{ right_x + right_width - radius_value }},{{ recty + height }}
+                    H{{ right_x }}
+                    V{{ recty }}
+                    Z
+                "
+            />
+            <text
+                class="release-cycle-blob-label release-cycle-blob-security"
+                x="{{ (half_x + end_x) / 2 * SCALE }}"
+                y="{{ (y - 0.1) * SCALE }}"
+                font-size="{{ SCALE * 0.75 }}"
+                text-anchor="middle"
+            >
+                security
+            </text>
+        {% else %}
+            <!-- Most statuses only need a simple rectangle with text. -->
+            <rect
+                class="release-cycle-blob release-cycle-blob-{{ version.status }}"
+                x="{{ start_x * SCALE }}"
+                y="{{ (y - 1) * SCALE }}"
+                width="{{ (end_x - start_x) * SCALE }}"
+                height="{{ 1.25 * SCALE }}"
+                rx="0.25em"
+                ry="0.25em"
+            />
+            <text
+                class="release-cycle-blob-label release-cycle-blob-{{ version.status }}"
+                x="{{ (start_x + end_x) / 2 * SCALE }}"
+                y="{{ (y - 0.1) * SCALE }}"
+                font-size="{{ SCALE * 0.75 }}"
+                text-anchor="middle"
+            >
+                {{ version.status }}
+            </text>
+        {% endif %}
     {% endfor %}
 
     <!-- A line for today -->


### PR DESCRIPTION
This adds a yellow security tail to the green bugfix bars:
<img width="450" alt="image" src="https://github.com/user-attachments/assets/5a4e6557-1b90-4817-bdd3-ff3ebd565df0" />

The transition date is a fixed two years after the first release.  The release schedule PEPs don't indicate a specific date.


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1529.org.readthedocs.build/versions/

<!-- readthedocs-preview cpython-devguide end -->