### PR TITLE
Python 3.12 is now in security-only

### DIFF
--- a/include/release-cycle.json
+++ b/include/release-cycle.json
@@ -18,7 +18,7 @@
   "3.12": {
     "branch": "3.12",
     "pep": 693,
-    "status": "bugfix",
+    "status": "security",
     "first_release": "2023-10-02",
     "end_of_life": "2028-10",
     "release_manager": "Thomas Wouters"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

* https://discuss.python.org/t/python-3-14-0a7-3-13-3-3-12-10-3-11-12-3-10-17-and-3-9-22-are-now-available/87580
* https://www.python.org/downloads/release/python-31210/
* https://peps.python.org/pep-0693/

cc @Yhg1s 