### PR TITLE
Add note to remind contributors to update "What's New" section

### DIFF
--- a/contrib/doc/start-documenting.rst
+++ b/contrib/doc/start-documenting.rst
@@ -10,3 +10,7 @@ Getting started
 
 
 [This is the existing documentation :ref:`start-documenting` page from the devguide.]
+
+.. note::
+
+   When adding new features, improvements, or major changes, please also update the "What's New" section in ``whatsnew/README.rst``.

--- a/whatsnew/README.rst
+++ b/whatsnew/README.rst
@@ -1,0 +1,4 @@
+What's New
+==========
+
+This section will keep track of major updates and changes.


### PR DESCRIPTION
This PR adds a reminder under the "Start Documenting" section to prompt contributors to update the "What's New" documentation when making changes.

