### PR TITLE
gh-1542: Do not suggest `make -j` 

### DIFF
--- a/developer-workflow/extension-modules.rst
+++ b/developer-workflow/extension-modules.rst
@@ -547,8 +547,11 @@ Now that the configuration is in place, it remains to compile the project:
 
 .. tip::
 
-   Use ``make -j`` to speed-up compilation by utilizing as many CPU cores
-   as possible or ``make -jN`` to allow at most *N* concurrent jobs.
+   Use ``make -jN`` to speed-up compilation by utilizing as many CPU cores
+   as possible, where *N* is as many CPU cores you want to spare (and have
+   memory for). Be careful using ``make -j`` with no argument, as this puts
+   no limit on the number of jobs, and compilation can sometimes use up a
+   lot of memory (like when building with LTO).
 
 * ``make regen-configure`` updates the :cpy-file:`configure` script.
 

--- a/index.rst
+++ b/index.rst
@@ -43,13 +43,13 @@ instructions please see the :ref:`setup guide <setup>`.
 
       .. code-block:: shell
 
-         ./configure --with-pydebug && make -j
+         ./configure --with-pydebug && make -j4
 
    .. tab:: macOS
 
       .. code-block:: shell
 
-         ./configure --with-pydebug && make -j
+         ./configure --with-pydebug && make -j4
 
    .. tab:: Windows
 


### PR DESCRIPTION
Do not suggest `make -j` for building CPython. `make -j` means _no_ limit on

the number of concurrent jobs, not "a sensible limit considering the available memory and CPU cores". With LTO it's easy to run out of memory when too many jobs run at the same time.

