### PR TITLE
Sphinx 8.1+: remove redundant `--keep-going`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ SPHINXBUILD  = $(VENVDIR)/bin/sphinx-build
 # there are duplicate labels.  These cause warnings, which prevent the
 # build from finishing.  Turn off --fail-on-warning so we can see the
 # finished results.
-#SPHINXOPTS   = --fail-on-warning --keep-going
-SPHINXOPTS   = --keep-going
+#SPHINXOPTS   = --fail-on-warning
+SPHINXOPTS   =
 BUILDDIR     = _build
 BUILDER      = html
 JOBS         = auto

--- a/make.bat
+++ b/make.bat
@@ -11,7 +11,7 @@ if "%PYTHON%" == "" (
 )
 
 set BUILDDIR=_build
-set SPHINXOPTS=--fail-on-warning --keep-going
+set SPHINXOPTS=--fail-on-warning
 set _ALL_SPHINX_OPTS=%SPHINXOPTS%
 
 if "%1" == "check" goto check

--- a/make.ps1
+++ b/make.ps1
@@ -8,7 +8,7 @@ Set-StrictMode -Version 3.0
 $ErrorActionPreference = "Stop"
 
 $BUILDDIR = "_build"
-$SPHINXOPTS = "--fail-on-warning --keep-going"
+$SPHINXOPTS = "--fail-on-warning"
 $_ALL_SPHINX_OPTS = $SPHINXOPTS
 
 $_PYTHON = $Env:PYTHON ?? "py -3"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-keep-going says:

> From Sphinx 8.1, `--keep-going` is always enabled.
> ...
> Changed in version 8.1: `sphinx-build` no longer exits on the first warning, meaning that in effect `--fail-on-warning` is always enabled. The option is retained for compatibility, but may be removed at some later date.

We're using Sphinx 8.2:

https://github.com/python/devguide/blob/f1b7e2505ab681933931c3b32e7db3036fa50039/requirements.txt#L10


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1544.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->