### PR TITLE
Use `make -j8` for macOS

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -874,7 +874,7 @@ some of CPython's modules (for example, ``zlib``).
 
    And finally, run ``make``::
 
-      $ make -s -j $(nproc)
+      $ make -s -j8
 
    There will sometimes be optional modules added for a new release which
    won't yet be identified in the OS-level build dependencies. In those cases,

--- a/index.rst
+++ b/index.rst
@@ -49,7 +49,7 @@ instructions please see the :ref:`setup guide <setup>`.
 
       .. code-block:: shell
 
-         ./configure --with-pydebug && make -j $(nproc)
+         ./configure --with-pydebug && make -j8
 
    .. tab:: Windows
 
@@ -74,7 +74,7 @@ instructions please see the :ref:`setup guide <setup>`.
 
       .. code-block:: shell
 
-         ./python.exe -m test -j3
+         ./python.exe -m test -j8
 
       Note: :ref:`Most <mac-python.exe>` macOS systems use
       :file:`./python.exe` in order to avoid filename conflicts with


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Follow on from https://github.com/python/devguide/pull/1541.

If a macOS user does not have coreutils installed (for example, via Homebrew) then `$(nproc)` can fail:

```console
❯ make -j $(nproc)
zsh: command not found: nproc
./python.exe -E ./Tools/build/generate-build-details.py `cat pybuilddir.txt`/build-details.json
Checked 113 modules (35 built-in, 78 shared, 0 n/a on macosx-15.4-arm64, 0 disabled, 0 missing, 0 failed on import)
```

We want these instructions to work without further assistance for a beginner.

And I do have coreutils installed on my other machine, but not on this one.

`j8` seems a reasonable number for macOS, all new Macs seem to be at least 10, and the M1 was at least 8.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1545.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->