### PR TITLE
Remove outdated reference to note about 3.5 branch

### DIFF
--- a/developer-workflow/development-cycle.rst
+++ b/developer-workflow/development-cycle.rst
@@ -178,9 +178,6 @@ and beta releases.
 Being in beta can be viewed much like being in RC_ but without the extra
 overhead of needing commit reviews.
 
-Please see the note in the `In-development (main) branch`_ section above for
-new information about the creation of the 3.5 maintenance branch during beta.
-
 
 .. _rc:
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

This note added in https://github.com/python/devguide/commit/ca1c216999b7d49f7a6f8a84c1b49a5575adef5a :

```rst
.. note::
  For the 3.5 release we're trying something new. We're creating the 3.5
  maintenance branch at the time we enter beta (3.5.0 beta 1).  This will
  allow feature development for 3.6 to occur alongside the beta and release
  candidate stabilization periods for 3.5.
```

It was rewritten in https://github.com/python/devguide/commit/ab247321b031f80895c98b67ee88c10e49f5a5df and removed in https://github.com/python/devguide/pull/1434.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1546.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->