### PR TITLE
Add beta release dates to JSON

### DIFF
--- a/include/release-cycle.json
+++ b/include/release-cycle.json
@@ -3,6 +3,7 @@
     "branch": "main",
     "pep": 790,
     "status": "feature",
+    "beta_release": "2026-05-05",
     "first_release": "2026-10-01",
     "end_of_life": "2031-10",
     "release_manager": "Hugo van Kemenade"
@@ -11,6 +12,7 @@
     "branch": "3.14",
     "pep": 745,
     "status": "prerelease",
+    "beta_release": "2025-05-07",
     "first_release": "2025-10-01",
     "end_of_life": "2030-10",
     "release_manager": "Hugo van Kemenade"
@@ -19,6 +21,7 @@
     "branch": "3.13",
     "pep": 719,
     "status": "bugfix",
+    "beta_release": "2024-05-08",
     "first_release": "2024-10-07",
     "end_of_life": "2029-10",
     "release_manager": "Thomas Wouters"
@@ -27,6 +30,7 @@
     "branch": "3.12",
     "pep": 693,
     "status": "security",
+    "beta_release": "2023-05-22",
     "first_release": "2023-10-02",
     "end_of_life": "2028-10",
     "release_manager": "Thomas Wouters"
@@ -35,6 +39,7 @@
     "branch": "3.11",
     "pep": 664,
     "status": "security",
+    "beta_release": "2022-05-08",
     "first_release": "2022-10-24",
     "end_of_life": "2027-10",
     "release_manager": "Pablo Galindo Salgado"
@@ -43,6 +48,7 @@
     "branch": "3.10",
     "pep": 619,
     "status": "security",
+    "beta_release": "2021-05-03",
     "first_release": "2021-10-04",
     "end_of_life": "2026-10",
     "release_manager": "Pablo Galindo Salgado"
@@ -51,6 +57,7 @@
     "branch": "3.9",
     "pep": 596,
     "status": "security",
+    "beta_release": "2020-05-18",
     "first_release": "2020-10-05",
     "end_of_life": "2025-10",
     "release_manager": "Łukasz Langa"
@@ -59,6 +66,7 @@
     "branch": "3.8",
     "pep": 569,
     "status": "end-of-life",
+    "beta_release": "2019-06-04",
     "first_release": "2019-10-14",
     "end_of_life": "2024-10-07",
     "release_manager": "Łukasz Langa"
@@ -67,6 +75,7 @@
     "branch": "3.7",
     "pep": 537,
     "status": "end-of-life",
+    "beta_release": "2018-01-31",
     "first_release": "2018-06-27",
     "end_of_life": "2023-06-27",
     "release_manager": "Ned Deily"
@@ -75,6 +84,7 @@
     "branch": "3.6",
     "pep": 494,
     "status": "end-of-life",
+    "beta_release": "2016-09-12",
     "first_release": "2016-12-23",
     "end_of_life": "2021-12-23",
     "release_manager": "Ned Deily"
@@ -83,6 +93,7 @@
     "branch": "3.5",
     "pep": 478,
     "status": "end-of-life",
+    "beta_release": "2015-05-24",
     "first_release": "2015-09-13",
     "end_of_life": "2020-09-30",
     "release_manager": "Larry Hastings"
@@ -91,6 +102,7 @@
     "branch": "3.4",
     "pep": 429,
     "status": "end-of-life",
+    "beta_release": "2013-11-24",
     "first_release": "2014-03-16",
     "end_of_life": "2019-03-18",
     "release_manager": "Larry Hastings"
@@ -99,6 +111,7 @@
     "branch": "3.3",
     "pep": 398,
     "status": "end-of-life",
+    "beta_release": "2012-06-27",
     "first_release": "2012-09-29",
     "end_of_life": "2017-09-29",
     "release_manager": "Georg Brandl, Ned Deily (3.3.7+)"
@@ -107,6 +120,7 @@
     "branch": "3.2",
     "pep": 392,
     "status": "end-of-life",
+    "beta_release": "2010-12-06",
     "first_release": "2011-02-20",
     "end_of_life": "2016-02-20",
     "release_manager": "Georg Brandl"
@@ -115,6 +129,7 @@
     "branch": "2.7",
     "pep": 373,
     "status": "end-of-life",
+    "beta_release": "2010-04-03",
     "first_release": "2010-07-03",
     "end_of_life": "2020-01-01",
     "release_manager": "Benjamin Peterson"
@@ -123,6 +138,7 @@
     "branch": "3.1",
     "pep": 375,
     "status": "end-of-life",
+    "beta_release": "2009-05-06",
     "first_release": "2009-06-27",
     "end_of_life": "2012-04-09",
     "release_manager": "Benjamin Peterson"
@@ -131,6 +147,7 @@
     "branch": "3.0",
     "pep": 361,
     "status": "end-of-life",
+    "beta_release": "2008-06-18",
     "first_release": "2008-12-03",
     "end_of_life": "2009-06-27",
     "release_manager": "Barry Warsaw"
@@ -139,6 +156,7 @@
     "branch": "2.6",
     "pep": 361,
     "status": "end-of-life",
+    "beta_release": "2008-06-18",
     "first_release": "2008-10-01",
     "end_of_life": "2013-10-29",
     "release_manager": "Barry Warsaw"

--- a/include/release-cycle.json
+++ b/include/release-cycle.json
@@ -13,7 +13,7 @@
     "pep": 745,
     "status": "prerelease",
     "beta_release": "2025-05-07",
-    "first_release": "2025-10-01",
+    "first_release": "2025-10-07",
     "end_of_life": "2030-10",
     "release_manager": "Hugo van Kemenade"
   },


### PR DESCRIPTION
Ref. #999 (and #998).
* Add beta release dates to JSON
* Fix Python 3.14 first release date

Not adding the beta release dates in Status of Python versions page, though this data would be useful in translations automations. The translation teams start to translate a version after the beta release. It would be used in [transifex-automations](https://github.com/python-docs-translations/transifex-automations) (which now [scrapes](https://github.com/python-docs-translations/transifex-automations/blob/551f59359b8d42e198be07f3e2ce7b91a38cedae/scripts/manage_versions.py#L49-L86) Python.org downloads page to get the data) and [dashboard](https://github.com/python-docs-translations/dashboard) projects.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->