### PR TITLE
Remove extra whitespace

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -740,7 +740,7 @@ some of CPython's modules (for example, ``zlib``).
       $ sudo dnf install \
             gcc gcc-c++ gdb lzma glibc-devel libstdc++-devel openssl-devel \
             readline-devel zlib-devel libzstd-devel libffi-devel bzip2-devel \
-            xz-devel  sqlite sqlite-devel sqlite-libs libuuid-devel gdbm-libs \
+            xz-devel sqlite sqlite-devel sqlite-libs libuuid-devel gdbm-libs \
             perf expat expat-devel mpdecimal python3-pip
 
 


### PR DESCRIPTION
This PR removes a recently introduced (#1558) spurious whitespace in a code block.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1560.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->