### PR TITLE
gh-1309: Document how to selectively build RST pages

### DIFF
--- a/documentation/start-documenting.rst
+++ b/documentation/start-documenting.rst
@@ -153,6 +153,25 @@ To build the docs as HTML, run:
            start a local server, and automatically reload the page in your
            browser when you make changes to reST files (Unix only).
 
+It is also possible to build only certain pages of the documentation in order
+to save time during the build process. Following is an example for building two
+pages:
+
+.. tab:: Unix/macOS
+
+   .. code-block:: shell
+
+      make html SOURCES="tutorial/classes.rst tutorial/inputoutput.rst"
+
+.. tab:: Windows
+
+   See :ref:`using-sphinx-build`. When invoking ``sphinx-build``, pass the
+   desired pages as the final parameter, like so:
+
+   .. code-block:: dosbatch
+
+      python -m sphinx -b html . build/html tutorial/classes.rst tutorial/inputoutput.rst
+
 To check the docs for common errors with `Sphinx Lint`_
 (which is run on all :ref:`pull requests <pullrequest>`), use:
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

This PR adds a small section to `documentation/start-documenting` that informs the reader of how to build only certain documentation pages. I tested my instructions on Linux and Windows. Please let me know if any changes are needed!

Thanks,
Micha

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1562.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->