### PR TITLE
Add Irvan Putra as coordinator of Indonesian translation

### DIFF
--- a/documentation/translating.rst
+++ b/documentation/translating.rst
@@ -42,7 +42,7 @@ details.
      - :github:`GitHub <python/python-docs-hu>`,
        `mailing list <https://mail.python.org/pipermail/python-hu>`__
    * - `Indonesian (id) <https://docs.python.org/id/>`__
-     - Oon Arfiandwi (:github-user:`oonid`),
+     - Irvan Putra (:github-user:`irvan-putra`),
        Jeff Jacobson (:github-user:`jwjacobson`)
      - :github:`GitHub <python/python-docs-id>`
    * - Italian (it)


### PR DESCRIPTION
After discussion with @jwjacobson, there will be at least two coordinating people in charge of Indonesian translation.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1567.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->