### PR TITLE
Exclude https://www.gnu.org/software/autoconf/ in linkcheck

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -87,6 +87,7 @@ linkcheck_anchors_ignore = [
 linkcheck_ignore = [
     # Checks fail due to rate limits
     r'https://github.com/.*',
+    r'https://www.gnu.org/software/autoconf/',
     # The Discourse groups are private unless you are logged in
     'https://discuss.python.org/groups/staff',
     'https://discuss.python.org/groups/moderators',


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

We're getting rate limited on another link in the CI linkcheck, which causes the CI to timeout and fail:

```
(internals/exploring: line    1) ok        https://www.youtube.com/playlist?list=PLzV58Zm8FuBL6OAv1Yu6AwXZrnsFbbR0S
(developer-workflow/communication-channels: line  245) ok        https://www.youtube.com/watch?v=-Nk-8fSJM6I
(contrib/core-team/motivations: line  178) ok        https://www.murrayandwalker.com/
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
-rate limited-   https://www.gnu.org/software/autoconf/ | sleeping...
Error: The operation was canceled.
```

https://github.com/python/devguide/actions/runs/15486356033/job/43601817396

Let's exclude it like https://github.com/python/devguide/pull/1556.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1572.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->