### PR TITLE
Add instructions on how to use the dev container image from GHCR

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -1226,6 +1226,7 @@ Note that the container has read/write access to the working directory.
 You may want to use a separate clone of CPython, or run ``make clean``
 to remove caches and build output generated for your host OS.
 
+.. _building-the-container-locally
 .. _devcontainer-build:
 
 Building yourself

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -1259,7 +1259,7 @@ in a clone of the CPython repository.
 
 The same caveats outlined above when running from a container image from GHCR
 also apply here.
-
+.. c_codespaces_end
 
 
 .. include:: ../links.rst

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -1213,14 +1213,6 @@ Using the pre-built container image
 are available from the
 `GitHub Container Registry (GHCR) account for the Python org <https://github.com/orgs/python/packages>`__ .
 
-You can download the latest version of the container image via:
-
-.. code-block:: bash
-
-   docker pull ghcr.io/python/devcontainer:latest
-
-(Substitute ``podman`` for ``docker`` if you use Podman.)
-
 To run the container and launch a Bash shell, run one of the following commands
 in a clone of the CPython repository.
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -1188,8 +1188,6 @@ select the option ``Open in VS Code``. You will still be working on the remote
 codespace instance, thus using the remote instance's compute power. The compute
 power may be a much higher spec than your local machine which can be helpful.
 
-.. c_codespaces_end
-
 .. _devcontainer-directly:
 
 Using the dev container directly

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -1222,6 +1222,10 @@ in a clone of the CPython repository.
 
    podman run -it --rm --volume $PWD:/workspace:Z --workdir /workspace ghcr.io/python/devcontainer:latest
 
+Note that the container has read/write access to the working directory.
+You may want to use a separate clone of CPython, or run ``make clean``
+to remove caches and build output generated for your host OS.
+
 .. _devcontainer-build:
 
 Building yourself

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -1209,7 +1209,7 @@ Using the pre-built container image
 
 `Dev container images <https://github.com/python/cpython-devcontainers/pkgs/container/devcontainer>`__
 are available from the
-`GitHub Container Registry (GHCR) account for the Python org <https://github.com/orgs/python/packages>`__ .
+`GitHub Container Registry (GHCR) account for the Python org <https://github.com/orgs/python/packages>`__.
 
 To run the container and launch a Bash shell, run one of the following commands
 in a clone of the CPython repository.

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -1188,19 +1188,57 @@ select the option ``Open in VS Code``. You will still be working on the remote
 codespace instance, thus using the remote instance's compute power. The compute
 power may be a much higher spec than your local machine which can be helpful.
 
+.. c_codespaces_end
 
-Building the container locally
-------------------------------
+.. _devcontainer-directly:
+
+Using the dev container directly
+================================
 
 If you want more control over the environment, or to work offline,
-you can build the container locally.
+you can use the same container used in
+:ref:`GitHub Codespaces <using-codespaces>` directly.
 This is meant for users who have (or want to get) some experience
 with containers.
-The following instructions are a starting point for
-your own customizations.
-They assume a Unix-like environment, and Docker or Podman installed.
+These instructions assume a Unix-like environment with
+`Docker <https://www.docker.com/>`__ or `Podman <https://podman.io/>`__
+installed.
 
-In a clone of the `cpython-devcontainers repo <https://github.com/python/cpython-devcontainers>`_,
+.. _devcontainer-image:
+
+Using the pre-built container image
+-----------------------------------
+
+`Dev container images <https://github.com/python/cpython-devcontainers/pkgs/container/devcontainer>`__
+are available from the
+`GitHub Container Registry (GHCR) account for the Python org <https://github.com/orgs/python/packages>`__ .
+
+You can download the latest version of the container image via:
+
+.. code-block:: bash
+
+   docker pull ghcr.io/python/devcontainer:latest
+
+(Substitute ``podman`` for ``docker`` if you use Podman.)
+
+To run the container and launch a Bash shell, run one of the following commands
+in a clone of the CPython repository.
+
+.. code-block:: bash
+
+   docker run -it --rm --volume $PWD:/workspace --workdir /workspace ghcr.io/python/devcontainer:latest
+
+.. code-block:: bash
+
+   podman run -it --rm --volume $PWD:/workspace:Z --workdir /workspace ghcr.io/python/devcontainer:latest
+
+.. _devcontainer-build:
+
+Building yourself
+-----------------
+
+If you prefer, you can build the container image yourself. In a clone of the
+`cpython-devcontainers repo <https://github.com/python/cpython-devcontainers>`_,
 build the container and name it ``cpython-dev``:
 
 .. code-block:: bash
@@ -1213,8 +1251,8 @@ The same command will update any existing ``cpython-dev`` container.
 Run it again from time to time -- especially if the container stops
 working for you.
 
-To run the container, run one of the following commands in a clone of the
-CPython repository.
+To run the container and launch a Bash shell, run one of the following commands
+in a clone of the CPython repository.
 
 .. code-block:: bash
 
@@ -1224,11 +1262,8 @@ CPython repository.
 
    podman run -it --rm --volume $PWD:/workspace:Z --workdir /workspace cpython-dev
 
-Note that the container has read/write access to the working directory.
-You may want to use a separate clone of CPython, or run ``make clean``
-to remove caches and build output generated for your host OS.
-
-.. c_codespaces_end
+The same caveats outlined above when running from a container image from GHCR
+also apply here.
 
 
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -1259,6 +1259,7 @@ in a clone of the CPython repository.
 
 The same caveats outlined above when running from a container image from GHCR
 also apply here.
+
 .. c_codespaces_end
 
 


### PR DESCRIPTION
Along the way make using the container outside of GitHub Codespaces its own section.


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1581.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->