### PR TITLE
Python 3.15 is now main

### DIFF
--- a/versions.rst
+++ b/versions.rst
@@ -5,7 +5,7 @@
 Status of Python versions
 =========================
 
-The ``main`` branch is currently the future Python 3.14, and is the only
+The ``main`` branch is currently the future Python 3.15, and is the only
 branch that accepts new features.  The latest release for each Python
 version can be found on the `download page <https://www.python.org/downloads/>`_.
 


### PR DESCRIPTION
Followup of https://github.com/python/cpython/pull/134649

Previous 2 years PRs:
- https://github.com/python/devguide/pull/1383
- https://github.com/python/devguide/pull/1099

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1582.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->