### PR TITLE
Document `type-refactor`

### DIFF
--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -31,7 +31,7 @@ These labels are used to specify the type of issue:
   The `Ideas Discourse category`_ can be used to discuss enhancements
   before filing an issue.
 * :gh-label:`type-refactor`: for internal code refactoring.
-  Refactoring does not change user-facing behaviour. 
+  Refactoring does not change user-facing behaviour.
 * :gh-label:`type-security`: for security issues.
   See also `Reporting security issues in Python`_.
 

--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -30,8 +30,8 @@ These labels are used to specify the type of issue:
   it is implicit that features are added to the ``main`` branch only.
   The `Ideas Discourse category`_ can be used to discuss enhancements
   before filing an issue.
-* :gh-label:`type-refactor`: for general code refactoring.
-  Refactoring does not change user-facing behaviour.
+* :gh-label:`type-refactor`: for general code refactoring that
+  does not change user-facing behaviour.
 * :gh-label:`type-security`: for security issues.
   See also `Reporting security issues in Python`_.
 

--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -30,7 +30,7 @@ These labels are used to specify the type of issue:
   it is implicit that features are added to the ``main`` branch only.
   The `Ideas Discourse category`_ can be used to discuss enhancements
   before filing an issue.
-* :gh-label:`type-refactor`: for internal code refactoring.
+* :gh-label:`type-refactor`: for general code refactoring.
   Refactoring does not change user-facing behaviour.
 * :gh-label:`type-security`: for security issues.
   See also `Reporting security issues in Python`_.

--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -30,6 +30,7 @@ These labels are used to specify the type of issue:
   it is implicit that features are added to the ``main`` branch only.
   The `Ideas Discourse category`_ can be used to discuss enhancements
   before filing an issue.
+* :gh-label:`type-refactor`: for internal code refactoring.
 * :gh-label:`type-security`: for security issues.
   See also `Reporting security issues in Python`_.
 

--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -31,6 +31,7 @@ These labels are used to specify the type of issue:
   The `Ideas Discourse category`_ can be used to discuss enhancements
   before filing an issue.
 * :gh-label:`type-refactor`: for internal code refactoring.
+  Refactoring does not change user-facing behaviour. 
 * :gh-label:`type-security`: for security issues.
   See also `Reporting security issues in Python`_.
 


### PR DESCRIPTION
Fixes https://github.com/python/devguide/issues/1589.
Fixes https://github.com/python/core-workflow/issues/563.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1588.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->