### PR TITLE
Remove outdated whitespace checks from patchcheck list

### DIFF
--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -277,10 +277,6 @@ On *Windows* (after any successful build):
 
 The automated checklist runs through:
 
-* Are there any whitespace problems in Python files?
-  (using :cpy-file:`Tools/patchcheck/reindent.py`)
-* Are there any whitespace problems in C files?
-* Are there any whitespace problems in the documentation?
 * Has the documentation been updated?
 * Has the test suite been updated?
 * Has an entry under ``Misc/NEWS.d/next`` been added?


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

The whitespace checks are now part of pre-commit and not patchcheck:

```console
❯ make patchcheck
...
Checked 114 modules (35 built-in, 79 shared, 0 n/a on macosx-15.5-arm64, 0 disabled, 0 missing, 0 failed on import)
./python.exe -E ./Tools/build/generate-build-details.py `cat pybuilddir.txt`/build-details.json
./python.exe ./Tools/patchcheck/patchcheck.py
Getting base branch for PR ... upstream/main
Getting the list of files that have been added/changed ... 13 files
Docs modified ... yes
Misc/ACKS updated ... NO
Misc/NEWS.d updated with `blurb` ... yes
configure regenerated ... not needed
pyconfig.h.in regenerated ... not needed

Did you run the test suite and check for refleaks?
```
