### PR TITLE
Update libmpdec-related instructions

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -781,9 +781,12 @@ some of CPython's modules (for example, ``zlib``).
             libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev \
             lzma lzma-dev tk-dev uuid-dev zlib1g-dev libmpdec-dev libzstd-dev
 
-   Note that Debian 12 and Ubuntu 24.04 do not have the ``libmpdec-dev`` package.  You can safely
-   remove it from the install list above and the Python build will use a bundled version.
-   Alternatively, you can install this package from https://deb.sury.org.
+   Note that Debian 12 and Ubuntu 24.04 do not have the ``libmpdec-dev``
+   package.  You can safely remove it from the install list above and the
+   Python build will use a bundled version.  But we recommend using the system
+   `libmpdec <https://www.bytereef.org/mpdecimal/doc/libmpdec/>`_ library.
+   Either built it from sources or install this package from
+   https://deb.sury.org.
 
 .. tab:: macOS
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -783,6 +783,7 @@ some of CPython's modules (for example, ``zlib``).
 
    Note that Debian 12 and Ubuntu 24.04 do not have the ``libmpdec-dev`` package.  You can safely
    remove it from the install list above and the Python build will use a bundled version.
+   Alternatively, you can install this package from https://deb.sury.org/.
 
 .. tab:: macOS
 
@@ -823,7 +824,6 @@ some of CPython's modules (for example, ``zlib``).
             $ GDBM_CFLAGS="-I$(brew --prefix gdbm)/include" \
                GDBM_LIBS="-L$(brew --prefix gdbm)/lib -lgdbm" \
                ./configure --with-pydebug \
-                           --with-system-libmpdec \
                            --with-openssl="$(brew --prefix openssl@3)"
 
       .. tab:: Python 3.11-3.12

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -783,7 +783,7 @@ some of CPython's modules (for example, ``zlib``).
 
    Note that Debian 12 and Ubuntu 24.04 do not have the ``libmpdec-dev`` package.  You can safely
    remove it from the install list above and the Python build will use a bundled version.
-   Alternatively, you can install this package from https://deb.sury.org/.
+   Alternatively, you can install this package from https://deb.sury.org.
 
 .. tab:: macOS
 


### PR DESCRIPTION
* drop --with-system-libmpdec on macOS (default to yes since 3.13)
* recommend deb.sury.org for Debian 12 and Ubuntu 24.04

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1598.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->