### PR TITLE
Remove deleted modules from experts index

### DIFF
--- a/core-developers/experts.rst
+++ b/core-developers/experts.rst
@@ -126,7 +126,6 @@ http
 idlelib               kbkaiser (inactive), terryjreedy*, serwy (inactive),
                       taleinat
 imaplib
-imghdr
 importlib             brettcannon
 inspect               1st1
 io                    benjaminp, stutzbach^
@@ -145,24 +144,19 @@ math                  rhettinger, stutzbach^
 mimetypes
 mmap                  Yhg1s
 modulefinder          theller (inactive), jvr^
-msilib
 msvcrt
 multiprocessing       applio*, pitrou, jnoller^ (inactive), sbt^ (inactive), gpshead*
 netrc
-nis
-nntplib
 numbers
 operator
 optparse              mitsuhiko, serhiy-storchaka*
 os
 os.path               serhiy-storchaka*
-ossaudiodev
 parser                pablogsal
 pathlib               barneygale*
 pdb                   gaogaotiantian
 pickle                avassalotti, serhiy-storchaka*
 pickletools           avassalotti, serhiy-storchaka*
-pipes
 pkgutil
 platform              malemburg
 plistlib
@@ -195,10 +189,8 @@ shutil                tarekziade, giampaolo
 signal                gpshead
 site
 smtplib
-sndhdr
 socket                gpshead
 socketserver
-spwd
 sqlite3               ghaering^, erlend-aasland*
 ssl                   jackjansen, tiran, dstufft, alex
 stat                  tiran
@@ -236,7 +228,6 @@ unicodedata           malemburg, ezio-melotti
 unittest              ezio-melotti, rbtcollins, gpshead, serhiy-storchaka*
 unittest.mock
 urllib                orsenthil
-uu
 uuid
 venv                  vsajip, FFY00
 warnings
@@ -246,7 +237,6 @@ webbrowser
 winreg                stutzbach^
 winsound
 wsgiref               pjenvey
-xdrlib
 xml.dom
 xml.dom.minidom
 xml.dom.pulldom


### PR DESCRIPTION
Remove those modules deleted in 3.13 ([PEP 594](https://peps.python.org/pep-0594/)) from the expert index
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
