### PR TITLE
Fix some broken links to `translation` pages

### DIFF
--- a/contrib/index.rst
+++ b/contrib/index.rst
@@ -75,7 +75,7 @@ major section at the top of each column.]*
        * :ref:`documenting`
        * :ref:`style-guide`
        * :ref:`rst-primer`
-       * :doc:`documentation/translations`
+       * :doc:`/documentation/translations/translating`
        * :ref:`devguide`
      -
        * :ref:`setup`

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -1,3 +1,5 @@
+.. _translating:
+
 ===========
 Translating
 ===========


### PR DESCRIPTION
Fixed the links in the following pages:
https://devguide.python.org/contrib/doc/translating/
https://devguide.python.org/contrib/#using-this-guide
https://devguide.python.org/#contributing

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1603.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->