### PR TITLE
Fix markups for emphasis

### DIFF
--- a/development-tools/clinic.rst
+++ b/development-tools/clinic.rst
@@ -107,8 +107,8 @@ Terminology
 
    end line
       The line ``[clinic start generated code]*/``.
-      The *end line* marks the _end_ of Argument Clinic :term:`input`,
-      but at the same time marks the _start_ of Argument Clinic :term:`output`,
+      The *end line* marks the *end* of Argument Clinic :term:`input`,
+      but at the same time marks the *start* of Argument Clinic :term:`output`,
       thus the text *"clinic start start generated code"*
       Note that the *end line* closes the C block comment opened
       by the *start line*.


### PR DESCRIPTION
The word emphasis character `_` is not supported as reST markup.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1608.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->