### PR TITLE
Update ASan information regarding --without-pymalloc flag

### DIFF
--- a/development-tools/clang.rst
+++ b/development-tools/clang.rst
@@ -107,7 +107,7 @@ The ``--without-pymalloc`` option is not necessary (tests should pass without it
 but disabling pymalloc helps ASan uncover more bugs (ASan does not track
 individual allocations done by pymalloc).
 
-It is OK to specify both sanitizers. 
+It is OK to specify both sanitizers.
 
 After that, run ``make`` and ``make test`` as usual.
 Note that ``make`` itself may fail with a sanitizer failure,


### PR DESCRIPTION
I have tested the CPython latest main build with both ASan and pymalloc enabled and it seems to work just fine. I did run the `python -m test` suite which didn't uncover any ASan crashes (though, it detected some memory leaks, which I believe are irrelevant here).

I have discussed ASan and this flag with @encukou on the CPython Core sprint on EuroPython 2025. We initially thought that the `--without-pymalloc` flag is needed for ASan builds due to the fact pymalloc must hit the begining of page when determining if the memory to be freed comes from pymalloc or was allocated by the system malloc. In other words, we thought, that ASan would crash CPython during free of big objects (allocated by system malloc). It may be that this was the case in the past, but it is not the case anymore as the `address_in_range` function used by pymalloc is annotated to be skipped from the ASan instrumentation.

This code can be seen here:
https://github.com/python/cpython/blob/acefb978dcb5dd554e3c49a3015ee5c2ad6bfda1/Objects/obmalloc.c#L2096-L2110

While the annotation macro is defined here:
https://github.com/python/cpython/blob/acefb978dcb5dd554e3c49a3015ee5c2ad6bfda1/Include/pyport.h#L582-L598

And the corresponding attribute is documented in:
* for gcc: https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-no_005fsanitize_005faddress-function-attribute
* for clang: https://clang.llvm.org/docs/AttributeReference.html#no-sanitize-address-no-address-safety-analysis
