### PR TITLE
Prevent `make venv` from reporting success when it actually failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ venv:
 
 .PHONY: ensure-venv
 ensure-venv:
+	set -e;
 	@if [ ! -d $(VENVDIR) ] ; then \
 		echo "Creating venv in $(VENVDIR)"; \
 		if $(UV) --version >/dev/null 2>&1; then \

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ venv:
 
 .PHONY: ensure-venv
 ensure-venv:
-	set -e;
 	@if [ ! -d $(VENVDIR) ] ; then \
+		set -e; \
 		echo "Creating venv in $(VENVDIR)"; \
 		if $(UV) --version >/dev/null 2>&1; then \
 			$(UV) venv --python=$(PYTHON) $(VENVDIR); \

--- a/documentation/start-documenting.rst
+++ b/documentation/start-documenting.rst
@@ -76,24 +76,22 @@ To build the documentation, follow the steps in one of the sections below.
 You can view the documentation after building the HTML
 by opening the file :file:`Doc/build/html/index.html` in a web browser.
 
-.. _doc-initial-requirements:
-
 Initial requirements
 --------------------
 
-
-Ensure your current working dir is the ``Doc`` subdirectory in your
-:ref:`CPython repository clone <checkout>`.
-
-.. code-block:: shell
-
-  cd Doc
-
-Ensure your Python version is at least 3.11 (Sphinx requirement).
+Ensure your current working directory is the top level ``Doc/`` directory
+inside your :ref:`CPython repository clone <checkout>`.
 
 .. code-block:: shell
 
-  python --version
+   cd Doc
+
+Ensure your Python version is at least 3.11.
+
+.. code-block:: shell
+
+   $ python --version
+   Python 3.13.5
 
 .. _doc-create-venv:
 

--- a/documentation/start-documenting.rst
+++ b/documentation/start-documenting.rst
@@ -76,12 +76,24 @@ To build the documentation, follow the steps in one of the sections below.
 You can view the documentation after building the HTML
 by opening the file :file:`Doc/build/html/index.html` in a web browser.
 
-.. note::
+.. _doc-initial-requirements:
 
-   The following instructions all assume your current working dir is
-   the ``Doc`` subdirectory in your :ref:`CPython repository clone <checkout>`.
-   Make sure to switch to it with ``cd Doc`` if necessary.
+Initial requirements
+--------------------
 
+
+Ensure your current working dir is the ``Doc`` subdirectory in your
+:ref:`CPython repository clone <checkout>`.
+
+.. code-block:: shell
+
+  cd Doc
+
+Ensure your Python version is at least 3.11 (Sphinx requirement).
+
+.. code-block:: shell
+
+  python --version
 
 .. _doc-create-venv:
 

--- a/documentation/start-documenting.rst
+++ b/documentation/start-documenting.rst
@@ -80,7 +80,8 @@ Initial requirements
 --------------------
 
 Ensure your current working directory is the top level ``Doc/`` directory
-inside your :ref:`CPython repository clone <checkout>`.
+inside your :ref:`CPython repository clone <checkout>`. You can switch to
+it with:
 
 .. code-block:: shell
 

--- a/documentation/start-documenting.rst
+++ b/documentation/start-documenting.rst
@@ -87,12 +87,11 @@ it with:
 
    cd Doc
 
-Ensure your Python version is at least 3.11.
+Ensure your Python version is at least 3.11. You can verify it with:
 
 .. code-block:: shell
 
-   $ python --version
-   Python 3.13.5
+   python --version
 
 .. _doc-create-venv:
 


### PR DESCRIPTION
Fixes #1607

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1611.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->