### PR TITLE
issue:1610 Fix broken link to 🔨 test-with-buildbots label in triaging.rst

### DIFF
--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -158,7 +158,7 @@ to trigger specific bot behaviors.
 * :gh-label:`skip news <skip%20news>`: for PRs that don't need a NEWS entry.
   The :ref:`news-entry` section covers in details in which cases the NEWS entry
   can be skipped.
-* :gh-label:`test-with-buildbots`: used to test the latest commit with
+* :gh-label:`🔨 test-with-buildbots <%3Ahammer%3A%20test-with-buildbots>`: used to test the latest commit with
   the :ref:`buildbot fleet <buildbots>` whenever more testing is required
   before merging.  This may take multiple hours to complete.
 * :samp:`awaiting {action}`: these labels are applied and used by `bedevere`_


### PR DESCRIPTION
[Issue:1610](https://github.com/python/devguide/issues/1610)

The previous link to the `test-with-buildbots` label in the triaging guide pointed to a non-existent label URL (missing the `:hammer:` prefix).

This PR updates the link to use the correct URL-encoded label:
https://github.com/python/cpython/labels/%3Ahammer%3A%20test-with-buildbots


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1612.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->