### PR TITLE
Improve label versions triaging

### DIFF
--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -98,7 +98,8 @@ These labels are used to indicate which versions of Python are affected.
 The available version labels (with the form :samp:`3.{N}`) are updated
 whenever new feature releases are created or retired.
 
-Triagers may adhere to the following recommendations:
+Recommendations
+---------------
 
 - For security issues, add the :gh-label:`type-security` label and
   the affected version labels. This makes the issue stand out.
@@ -107,14 +108,10 @@ Triagers may adhere to the following recommendations:
   the :gh-label:`type-bug` label as knowing which versions are affected
   does not give more information.
 
-  Once the bug is resolved, one can optionally add the version labels for
-  the affected versions. This helps readers in knowing whether their issue
-  has been solved for their Python version.
+- Labels for end-of-life versions should be removed when possible but there is
+  no need to explicitly go through old issues to remove such labels.
 
-- EOL version labels should be removed when possible but there is no need
-  to explicitly go through old issues to remove such labels.
-
-- Otherwise, add the corresponding version label(s) and remember to
+- Otherwise, add the corresponding version labels and remember to
   update them when the latest major version is updated.
 
 See also :ref:`the branch status page <branchstatus>`
@@ -135,7 +132,7 @@ cases subject to the release manager approval:
   version under development would now be :samp:`3.{N+1}.0a1`.
 
   To indicate that the labelling is correct and the extension is
-  approved, the :gh-label:`triaged` label could also be applied.
+  approved, the :gh-label:`triaged` label can also be applied.
 
 
 .. _Keywords:

--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -27,7 +27,8 @@ These labels are used to specify the type of issue:
   core dump.
 * :gh-label:`type-feature`: for feature requests or enhancements.
   Feature requests do not need :ref:`version labels <Version labels>`;
-  it is implicit that features are added to the ``main`` branch only.
+  it is implicit that features are added to the ``main`` branch only,
+  except for some :ref:`exceptional cases <exceptional-version-labels>`.
   The `Ideas Discourse category`_ can be used to discuss enhancements
   before filing an issue.
 * :gh-label:`type-security`: for security issues.
@@ -97,8 +98,44 @@ These labels are used to indicate which versions of Python are affected.
 The available version labels (with the form :samp:`3.{N}`) are updated
 whenever new feature releases are created or retired.
 
+Triagers may adhere to the following recommendations:
+
+- For security issues, add the :gh-label:`type-security` label and
+  the affected version labels. This makes the issue stands out more.
+
+- For non-security issues affecting *all* bugfix branches, only add
+  the :gh-label:`type-bug` label as knowing which versions are affected
+  does not give more information.
+
+  Once the bug is resolved, one can optionally add the version labels for
+  the affected versions. This helps readers in knowing whether their issue
+  has been solved for their Python version.
+
+- EOL version labels should be removed when possible but there is no need
+  to explicitly go through old issues to remove such labels.
+
+- Otherwise, add the corresponding version label(s) and remember to
+  update them when the latest major version is updated.
+
 See also :ref:`the branch status page <branchstatus>`
 for a list of active branches.
+
+.. _exceptional-version-labels:
+
+Exceptional version labels for features
+---------------------------------------
+
+While features should not have a version label, there are a few exceptional
+cases subject to the release manager approval:
+
+- If we are currently in the *beta* period of :samp:`3.{N}.0` and
+  if a feature was implemented in its *alpha* period but requires a
+  non-trivial extension (hence a new *feature* issue), this new
+  feature issue is given the :samp:`3.{N}` label as the latest
+  version under development would now be :samp:`3.{N+1}.0a1`.
+
+  To indicate that the labelling is correct and the extension is
+  approved, the :gh-label:`triaged` label could also be applied.
 
 
 .. _Keywords:

--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -112,7 +112,7 @@ Recommendations
   no need to explicitly go through old issues to remove such labels.
 
 - Otherwise, add the corresponding version labels and remember to
-  update them when the latest major version is updated.
+  update them when the latest feature version is released.
 
 See also :ref:`the branch status page <branchstatus>`
 for a list of active branches.

--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -101,7 +101,7 @@ whenever new feature releases are created or retired.
 Triagers may adhere to the following recommendations:
 
 - For security issues, add the :gh-label:`type-security` label and
-  the affected version labels. This makes the issue stands out more.
+  the affected version labels. This makes the issue stand out.
 
 - For non-security issues affecting *all* bugfix branches, only add
   the :gh-label:`type-bug` label as knowing which versions are affected


### PR DESCRIPTION
Some people asked me about how I actually apply my labels while triaging and I think I could actually share my workflow in the devguide instead for future triaging. I especially think that it's not necessary for bugs that span across all active versions to be labelled with the all labels... Ideally, I would have wanted a 3.X+ tag which implies that the bug started appearing in 3.X, and a bot would be able to automate the labels every time a new one is added but this would be a separate issue.

cc @hugovk 

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1613.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->