### PR TITLE
docs: add label to translating so it can be referenced

### DIFF
--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -1,3 +1,5 @@
+.. _translating:
+
 ===========
 Translating
 ===========


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Added a label to fix the link to the translation guide in https://devguide.python.org/

<img width="600" alt="image" src="https://github.com/user-attachments/assets/b609228a-54bc-4b88-9d84-6523902512f6" />

- [x] Tested it locally with `makehtml`

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1619.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->