### PR TITLE
Extend style guide "Use simple language" section

### DIFF
--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -41,8 +41,9 @@ For more details about translations and their progress, see `the dashboard
      - Sanyam Khurana (:github-user:`CuriousLearner`)
      - :github:`GitHub <CuriousLearner/python-docs-hi-in>`
    * - Hungarian (hu)
-     -
+     - Tamás Bajusz (:github-user:`gbtami`)
      - :github:`GitHub <python/python-docs-hu>`,
+       `mailing list <https://mail.python.org/pipermail/python-hu>`__
    * - `Indonesian (id) <https://docs.python.org/id/>`__
      - | Irvan Putra (:github-user:`irvan-putra`),
        | Jeff Jacobson (:github-user:`jwjacobson`)


### PR DESCRIPTION
The diff is quite short, and I think it will explain better than a comment here. A section on gender neutrality may also be a good addition, there is in fact already one in the translation style guide.
