### PR TITLE
Use consistent tab titles

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -409,13 +409,13 @@ The easiest way to get a debug build of CPython for WASI is to use the
 ``Tools/wasm/wasi.py build`` command (which should be run w/ a recent version of
 Python you have installed on your machine):
 
-.. tab:: CPython 3.14 and newer
+.. tab:: Python 3.14+
 
    .. code-block:: shell
 
       python3 Tools/wasm/wasi build --quiet -- --config-cache --with-pydebug
 
-.. tab:: CPython 3.13
+.. tab:: Python 3.13
 
    .. code-block:: shell
 
@@ -429,7 +429,7 @@ You can also do each configuration and build step separately; the command above
 is a convenience wrapper around the following commands:
 
 
-.. tab:: CPython 3.14 and newer
+.. tab:: Python 3.14+
 
    .. code-block:: shell
 
@@ -438,7 +438,7 @@ is a convenience wrapper around the following commands:
       $ python Tools/wasm/wasi configure-host --quiet -- --config-cache
       $ python Tools/wasm/wasi make-host --quiet
 
-.. tab:: CPython 3.13
+.. tab:: Python 3.13
 
    .. code-block:: shell
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Follow on from https://github.com/python/devguide/pull/1632.

We already have tabs on https://devguide.python.org/getting-started/setup-building/ with this pattern:

<img width="758" height="202" alt="image" src="https://github.com/user-attachments/assets/1f98ae65-be8b-4f54-bf44-b12eee85d39b" />

I suggest we follow the same pattern and change this:

<img width="753" height="440" alt="image" src="https://github.com/user-attachments/assets/51f2b7e0-cda3-45ef-8386-a01df3aee63c" />

To this:

<img width="756" height="443" alt="image" src="https://github.com/user-attachments/assets/2c311f12-fb09-44d0-b3fa-508c91531784" />


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1634.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->