### PR TITLE
Change translation co-ordinator for Hindi (`hi-IN`)

### DIFF
--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -39,9 +39,9 @@ For more details about translations and their progress, see `the dashboard
        | Fanis Petkos (:github-user:`thepetk`),
        | Panagiotis Skias (:github-user:`skpanagiotis`)
      - :github:`GitHub <python/python-docs-el>`
-   * - Hindi (hi)
-     - Sanyam Khurana (:github-user:`himanshugarg`)
-     - :github:`GitHub <himanshugarg/python-docs-hi>`
+   * - Hindi (hi-IN)
+     - Himanshu Garg (:github-user:`himanshugarg`)
+     - :github:`GitHub <himanshugarg/python-docs-hi-IN>`
    * - Hungarian (hu)
      - Tamás Bajusz (:github-user:`gbtami`)
      - :github:`GitHub <python/python-docs-hu>`,

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -41,7 +41,7 @@ For more details about translations and their progress, see `the dashboard
      - :github:`GitHub <python/python-docs-el>`
    * - Hindi (hi-IN)
      - Himanshu Garg (:github-user:`himanshugarg`)
-     - :github:`GitHub <himanshugarg/python-docs-hi-IN>`
+     - :github:`GitHub <himanshugarg/python-docs-hi-in>`
    * - Hungarian (hu)
      - Tamás Bajusz (:github-user:`gbtami`)
      - :github:`GitHub <python/python-docs-hu>`,

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -39,9 +39,9 @@ For more details about translations and their progress, see `the dashboard
        | Fanis Petkos (:github-user:`thepetk`),
        | Panagiotis Skias (:github-user:`skpanagiotis`)
      - :github:`GitHub <python/python-docs-el>`
-   * - Hindi (hi-IN)
-     - Sanyam Khurana (:github-user:`CuriousLearner`)
-     - :github:`GitHub <CuriousLearner/python-docs-hi-in>`
+   * - Hindi (hi)
+     - Sanyam Khurana (:github-user:`himanshugarg`)
+     - :github:`GitHub <himanshugarg/python-docs-hi>`
    * - Hungarian (hu)
      - Tamás Bajusz (:github-user:`gbtami`)
      - :github:`GitHub <python/python-docs-hu>`,


### PR DESCRIPTION
This PR adds @himanshugarg and [the repo](https://github.com/himanshugarg/python-docs-hi) for the hi translations after having tried to contact the last contributor. The previous translation has the about page translated. 

See Also: https://mail.python.org/archives/list/translation@python.org/thread/HDPVLNGLIS55RFKUUAZSFFNBKUENKDFE/

Requesting a quick look at  [the repo](https://github.com/himanshugarg/python-docs-hi) to see if it looks good to go. Created using cookie-cutter.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1637.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->