### PR TITLE
gh-1638: update EBNF abbreviation to PEG

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -1094,7 +1094,7 @@ every rule.
      See also :ref:`building-doc`.
 
 ``Grammar``
-     Contains the :abbr:`EBNF (Extended Backus-Naur Form)` grammar file for
+     Contains the :abbr:`PEG (Parser Expression Grammar)` grammar file for
      Python.
 
 ``Include``


### PR DESCRIPTION
https://github.com/python/devguide/issues/1638 : Update the `EBNF` abbreviation to `PEG` abbreviation (Parser Expression Grammar).
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1639.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->