### PR TITLE
Remove translation coördinator for Hungarian

### DIFF
--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -41,9 +41,8 @@ For more details about translations and their progress, see `the dashboard
      - Sanyam Khurana (:github-user:`CuriousLearner`)
      - :github:`GitHub <CuriousLearner/python-docs-hi-in>`
    * - Hungarian (hu)
-     - Tamás Bajusz (:github-user:`gbtami`)
+     -
      - :github:`GitHub <python/python-docs-hu>`,
-       `mailing list <https://mail.python.org/pipermail/python-hu>`__
    * - `Indonesian (id) <https://docs.python.org/id/>`__
      - | Irvan Putra (:github-user:`irvan-putra`),
        | Jeff Jacobson (:github-user:`jwjacobson`)

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -42,7 +42,7 @@ For more details about translations and their progress, see `the dashboard
      - :github:`GitHub <CuriousLearner/python-docs-hi-in>`
    * - Hungarian (hu)
      -
-     - :github:`GitHub <python/python-docs-hu>`,
+     - :github:`GitHub <python/python-docs-hu>`
    * - `Indonesian (id) <https://docs.python.org/id/>`__
      - | Irvan Putra (:github-user:`irvan-putra`),
        | Jeff Jacobson (:github-user:`jwjacobson`)


### PR DESCRIPTION
The coordinator listed may make it seem like one is not necessary, and I don't watch the mailing list which means I won't be able to help anyone who messages it.


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1640.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->