### PR TITLE
Add translating to `help-documenting` page

### DIFF
--- a/documentation/help-documenting.rst
+++ b/documentation/help-documenting.rst
@@ -65,7 +65,17 @@ By following the steps in the :ref:`Quick Guide to Pull Requests <pullrequest-qu
 you will learn the workflow for documentation pull requests.
 
 .. _documentation issues: https://github.com/python/cpython/issues?q=is%3Aissue+is%3Aopen+label%3Adocs
-.. _octocat: https://github.com/logos
+
+
+Translating
+===========
+
+The Python documentation is actively translated into several languages.
+You can switch languages using the language switcher in the online documentation
+navbar.
+
+If you are interested in translation, see our pages on
+:ref:`translating <translating>` to get started.
 
 
 Proofreading

--- a/documentation/help-documenting.rst
+++ b/documentation/help-documenting.rst
@@ -70,7 +70,7 @@ you will learn the workflow for documentation pull requests.
 Translating
 ===========
 
-The Python documentation is actively translated into several languages.
+The Python documentation is actively being translated into several languages.
 You can switch languages using the language switcher in the online documentation
 navbar.
 

--- a/documentation/help-documenting.rst
+++ b/documentation/help-documenting.rst
@@ -70,11 +70,8 @@ you will learn the workflow for documentation pull requests.
 Translating
 ===========
 
-The Python documentation is actively being translated into several languages.
-You can switch languages using the language switcher in the online documentation
-navbar.
-
-If you are interested in translation, see our pages on
+The Python documentation is being actively translated into several languages.
+If you are interested in helping with translation, see our pages on
 :ref:`translating <translating>` to get started.
 
 


### PR DESCRIPTION
Closes https://github.com/python/devguide/issues/1647

Also removes unused link.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1648.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->