### PR TITLE
Add runbook for code signing certificate reports to PSRT

### DIFF
--- a/developer-workflow/psrt.rst
+++ b/developer-workflow/psrt.rst
@@ -96,30 +96,35 @@ severity, advisory text, and fixes.
 Handling code signing certificate reports
 -----------------------------------------
 
-Python signs binaries using Azure Trusted Signing and Apple Developer ID certificates.
-If a code signing certificate is reported as "compromised" or "malware signed with certificate",
-the Python Security Response Team must request the following information from the reporter:
+Python signs binaries using Azure Trusted Signing and Apple Developer ID
+certificates. If a code signing certificate is reported as "compromised" or
+"malware signed with certificate", the Python Security Response Team must
+request the following information from the reporter:
 
 * Checksum(s) of binaries signed by certificate.
 * Signature(s) of binaries signed by certificate.
 
-To avoid unnecessary user confusion and churn around revoking code signing certificates,
-any reports **must be verifiable independently by the PSRT before taking destructive
-actions**, such as revoking certificates. With this information the PSRT can
-take investigative steps to verify the report, such as:
+To avoid unnecessary user confusion and churn around revoking code signing
+certificates, any reports **must be verifiable independently by the PSRT before
+taking destructive actions**, such as revoking certificates. With this
+information the PSRT can take investigative steps to verify the report, such as:
 
-* Downloading and checking artifacts from the associated Azure Pipelines executions
-  against the reported list of checksums.
-* Verifying the validity of the signatures. `Past reports <https://discuss.python.org/t/103356/2>`__
-  have contained signatures that purported to be from Python code signing certificates, but were not valid.
-* Checking the Azure Pipelines and Azure Trusted Signing audit logs for signs of compromise.
+* Downloading and checking artifacts from the associated Azure Pipelines
+  executions against the reported list of checksums.
+* Verifying the validity of the signatures. `Past reports
+  <https://discuss.python.org/t/103356/2>`__ have contained signatures that
+  purported to be from Python code signing certificates, but were not valid.
+* Checking the Azure Pipelines and Azure Trusted Signing audit logs for signs of
+  compromise.
 
-If any signs of compromise or incorrectly signed binaries are discovered by the PSRT, only
-then will certificates be revoked and an advisory published.
-If compromise is reported, the following non-destructive actions can be taken by the PSRT without
-verifying the reported information as a precaution, if relevant:
+If any signs of compromise or incorrectly signed binaries are discovered by the
+PSRT, only then will certificates be revoked and an advisory published.
+If compromise is reported, the following non-destructive actions can be taken by
+the PSRT without verifying the reported information as a precaution, if
+relevant:
 
-* Rotating secrets associated with code signing (``TrustedSigningSecret`` for Azure Trusted Publishing).
+* Rotating secrets associated with code signing (``TrustedSigningSecret`` for
+  Azure Trusted Publishing).
 * Resetting passwords for accounts with access to signing certificates.
 
 Template responses


### PR DESCRIPTION
Follow-up from the recent Windows code signing certificate incident, adding a runbook for PSRT members to follow during code signing incident response. If there's particulars about either macOS or Windows code signing that might be helpful, please suggest in this pull request.

cc @zooba @ned-deily @ambv 

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1651.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->