### PR TITLE
Add pganssle to zoneinfo experts list

### DIFF
--- a/core-team/experts.rst
+++ b/core-team/experts.rst
@@ -251,6 +251,7 @@ xmlrpc
 zipapp                pfmoore
 zipfile               alanmcintyre^, serhiy-storchaka, Yhg1s, gpshead
 zipimport             Yhg1s*
+zoneinfo              pganssle
 ====================  =============================================
 
 


### PR DESCRIPTION
As noticed by @StanFromIreland, there is currently no expert listed for `zoneinfo`, so I have added myself.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1658.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->