### PR TITLE
add command for PowerShell (Windows) while checking out others pull requests in git bootcamp

### DIFF
--- a/getting-started/git-boot-camp.rst
+++ b/getting-started/git-boot-camp.rst
@@ -461,11 +461,18 @@ If you don't have GitHub CLI or hub installed, you can set up a git alias:
 
       $ git config --global alias.pr '!sh -c "git fetch upstream pull/${1}/head:pr_${1} && git checkout pr_${1}" -'
 
-.. tab:: Windows
+.. tab:: Windows cmd
 
    .. code-block:: dosbatch
 
       git config --global alias.pr "!sh -c 'git fetch upstream pull/${1}/head:pr_${1} && git checkout pr_${1}' -"
+
+.. tab:: Windows Powershell
+
+   .. code-block:: shell
+
+      git config --global alias.pr '!f() { git fetch upstream pull/$1/head:pr_$1 && git checkout pr_$1; }; f'
+
 
 The alias only needs to be done once.  After the alias is set up, you can get a
 local copy of a pull request as follows::


### PR DESCRIPTION
I have tried something like this

`git config --global alias.pr '!git fetch upstream pull/$1/head:pr_$1 && git checkout pr_$1;'
`

it works fine but raises an error :(

<img width="927" height="168" alt="image" src="https://github.com/user-attachments/assets/aa3c01c9-8a29-42cb-bcb1-f45fd4e8f72b" />

closes [issue](https://github.com/python/devguide/issues/1645)


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1666.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->