### PR TITLE
Remove Portuguese translation

### DIFF
--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -76,9 +76,6 @@ For more details about translations and their progress, see `the dashboard
      - :github:`GitHub <python/python-docs-pl>`,
        `Transifex <tx_>`_,
        `original announcement <https://mail.python.org/pipermail/doc-sig/2019-April/004106.html>`__
-   * - Portuguese (pt)
-     - Gustavo Toffo
-     -
    * - `Brazilian Portuguese (pt-br) <https://docs.python.org/pt-br/>`__
      - | Rafael Fontenelle (:github-user:`rffontenelle`),
        | Marco Rougeth (:github-user:`rougeth`)


### PR DESCRIPTION
I did some git commit history sleuthing, but to no avail. The only person who can reveal more about this mystery is @JulienPalard.

A Portuguese translation expert was added in https://github.com/python/devguide/commit/88f3dff11e082307376656a21ca71011c9965c5d, however that has since become the Brazilian Portuguese translation. As for the one in the table, it was added in https://github.com/python/devguide/commit/66e8b9ef88aa95a5da61e12914f2c003aaf9e30b by Julien, but listed no announcement, coordinator, contact or repository link.

Seeing as the state of this entry has not changed for five years, and no repository has been created, I propose removing this entry, so as to not block a new translation.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1670.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->