### PR TITLE
Default EOL to end of month in SVG

### DIFF
--- a/_tools/generate_release_cycle.py
+++ b/_tools/generate_release_cycle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import calendar
 import csv
 import datetime as dt
 import json
@@ -18,10 +19,17 @@ def csv_date(date_str: str, now_str: str) -> str:
     return date_str
 
 
-def parse_date(date_str: str) -> dt.date:
+def parse_date(date_str: str, *, last: bool = False) -> dt.date:
     if len(date_str) == len("yyyy-mm"):
         # We need a full yyyy-mm-dd, so let's approximate
-        return dt.date.fromisoformat(date_str + "-01")
+        if last:
+            # Last day of month
+            year, month = map(int, date_str.split("-"))
+            last_day = calendar.monthrange(year, month)[1]
+            return dt.date(year, month, last_day)
+        else:
+            return dt.date.fromisoformat(date_str + "-01")
+
     return dt.date.fromisoformat(date_str)
 
 
@@ -46,7 +54,7 @@ class Versions:
                 full_years = 1.5
             version["first_release_date"] = r1 = parse_date(version["first_release"])
             version["start_security_date"] = r1 + dt.timedelta(days=full_years * 365)
-            version["end_of_life_date"] = parse_date(version["end_of_life"])
+            version["end_of_life_date"] = parse_date(version["end_of_life"], last=True)
 
         self.cutoff = min(ver["first_release_date"] for ver in self.versions.values())
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

3.9 isn't EOL yet, but the SVG defaults to showing YYYY-MM dates as YYYY-MM-01, making it look like 3.9 is already EOL:

<img width="1128" height="490" alt="image" src="https://github.com/user-attachments/assets/9f875073-3e97-4e25-be98-ea470c373958" />

https://devguide.python.org/versions/

Let's default EOL YYYY-MM dates to the end of the month instead:

<img width="1128" height="509" alt="image" src="https://github.com/user-attachments/assets/d9b51b06-1775-4fad-a8c4-04fe8d45c44f" />

And keep the default as first of the month for initial release and security dates.


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1672.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->