### PR TITLE
Mark 3.9 as EOL

### DIFF
--- a/include/release-cycle.json
+++ b/include/release-cycle.json
@@ -50,9 +50,9 @@
   "3.9": {
     "branch": "3.9",
     "pep": 596,
-    "status": "security",
+    "status": "end-of-life",
     "first_release": "2020-10-05",
-    "end_of_life": "2025-10",
+    "end_of_life": "2025-10-31",
     "release_manager": "Łukasz Langa"
   },
   "3.8": {


### PR DESCRIPTION


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1676.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->