### PR TITLE
Add the `:deco:` role

### DIFF
--- a/documentation/markup.rst
+++ b/documentation/markup.rst
@@ -544,8 +544,8 @@ The directives are:
 
          Set name of the decorated function to *name*.
 
-   There is no ``deco`` role to link to a decorator that is marked up with
-   this directive; rather, use the ``:func:`` role.
+   To link to a decorator that is marked up with this directive,
+   use the ``:deco:`` role.
 
 .. describe:: class
 
@@ -805,6 +805,10 @@ a matching identifier is found:
 .. describe:: exc
 
    The name of an exception. A dotted name may be used.
+
+.. describe:: deco
+
+   The name of a decorator. A dotted name may be used.
 
 The name enclosed in this markup can include a module name and/or a class name.
 For example, ``:func:`filter``` could refer to a function named ``filter`` in


### PR DESCRIPTION
The `:deco:` role has been added in Sphinx 8.2 (https://github.com/sphinx-doc/sphinx/issues/13105)

I am assuming here that the devguide always targets the latest release of Sphinx, is that correct?

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1686.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->