### PR TITLE
Make no-force-push advice linkable

### DIFF
--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -54,10 +54,13 @@ Here is a quick overview of how you can contribute to CPython:
 .. [*] If an issue is trivial (for example, typo fixes), or if an issue already exists,
        you can skip this step.
 
-.. note::
-   In order to keep the commit history intact, please avoid squashing or amending
-   history and then force-pushing to the PR. Reviewers often want to look at
-   individual commits.
+Don't force-push
+----------------
+
+In order to keep the commit history intact, please avoid squashing or amending
+history and then force-pushing to the PR. Reviewers often want to look at
+individual commits.
+When the PR is merged, everything will be squashed into a single commit.
 
 .. _Clear communication: https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
 .. _Open Source: https://opensource.guide/


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Promote the note to something that can be linked to, so we can easily share it with contributors who force push their PRs.

Add an extra sentence: 

"When the PR is merged, everything will be squashed into a single commit."


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1687.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->