### PR TITLE
Update bootcamp FAQ about "Checking out others' PRs"

### DIFF
--- a/getting-started/git-boot-camp.rst
+++ b/getting-started/git-boot-camp.rst
@@ -453,19 +453,26 @@ Both of these tools will configure a remote URL for the branch, so you can
 ``git push`` if the pull request author checked "Allow edits from maintainers"
 when creating the pull request.
 
-If you don't have GitHub CLI or hub installed, you can set up a git alias:
+If you don't have GitHub CLI or hub installed, you can run the following commands:
+
+.. code-block:: shell
+
+   $ git fetch upstream pull/NNNNN/head:pr_NNNNN
+   $ git switch pr_NNNNN
+   
+or set up a Git alias:
 
 .. tab:: Unix/macOS
 
    .. code-block:: shell
 
-      $ git config --global alias.pr '!sh -c "git fetch upstream pull/${1}/head:pr_${1} && git checkout pr_${1}" -'
+      $ git config --global alias.pr '!sh -c "git fetch upstream pull/${1}/head:pr_${1} && git switch pr_${1}" -'
 
 .. tab:: Windows
 
    .. code-block:: dosbatch
 
-      git config --global alias.pr "!sh -c 'git fetch upstream pull/${1}/head:pr_${1} && git checkout pr_${1}' -"
+      git config --global alias.pr "!sh -c 'git fetch upstream pull/${1}/head:pr_${1} && git switch pr_${1}' -"
 
 The alias only needs to be done once.  After the alias is set up, you can get a
 local copy of a pull request as follows::

--- a/getting-started/git-boot-camp.rst
+++ b/getting-started/git-boot-camp.rst
@@ -459,7 +459,7 @@ If you don't have GitHub CLI or hub installed, you can run the following command
 
    $ git fetch upstream pull/NNNNN/head:pr_NNNNN
    $ git switch pr_NNNNN
-   
+
 or set up a Git alias:
 
 .. tab:: Unix/macOS

--- a/getting-started/git-boot-camp.rst
+++ b/getting-started/git-boot-camp.rst
@@ -460,7 +460,7 @@ If you don't have GitHub CLI or hub installed, you can run the following command
    $ git fetch upstream pull/NNNNN/head:pr_NNNNN
    $ git switch pr_NNNNN
 
-or set up a Git alias:
+Or set up a Git alias:
 
 .. tab:: Unix/macOS
 

--- a/getting-started/git-boot-camp.rst
+++ b/getting-started/git-boot-camp.rst
@@ -453,7 +453,7 @@ Both of these tools will configure a remote URL for the branch, so you can
 ``git push`` if the pull request author checked "Allow edits from maintainers"
 when creating the pull request.
 
-If you don't have GitHub CLI or hub installed, you can run the following commands:
+Otherwise, you can run the following commands:
 
 .. code-block:: shell
 

--- a/getting-started/git-boot-camp.rst
+++ b/getting-started/git-boot-camp.rst
@@ -466,7 +466,7 @@ Or set up a Git alias:
 
    .. code-block:: shell
 
-      $ git config --global alias.pr '!sh -c "git fetch upstream pull/${1}/head:pr_${1} && git switch pr_${1}" -'
+      git config --global alias.pr '!sh -c "git fetch upstream pull/${1}/head:pr_${1} && git switch pr_${1}" -'
 
 .. tab:: Windows
 


### PR DESCRIPTION
I wanted to pull a PR branch and I was looking up ["Checking out others' PRs"](https://devguide.python.org/getting-started/git-boot-camp/#git-pr), and the options were either to install `gh`, `hub`, or creating a Git alias.  

Since I wanted a less permanent solution, I created this PR to show the commands individually before suggesting adding them as an alias.  In addition I replaced `checkout` with the more modern `switch`, and capitalized "Git".

Another possible solution is to add the contributor's repo as a remote and fetch their branch from there, but I didn't want to add yet another solution.  If people want to add it, we can create another PR.

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1694.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->