### PR TITLE
Resolve two reference warnings in the Clinic HOWTO

### DIFF
--- a/development-tools/clinic/howto.rst
+++ b/development-tools/clinic/howto.rst
@@ -742,7 +742,7 @@ See also :pep:`573`.
 How to write a custom converter
 -------------------------------
 
-A converter is a Python class that inherits from :py:class:`!CConverter`.
+A converter is a Python class that inherits from :py:class:`~clinic.CConverter`.
 The main purpose of a custom converter, is for parameters parsed with
 the ``O&`` format unit --- parsing such a parameter means calling
 a :c:func:`PyArg_ParseTuple` "converter function".
@@ -758,8 +758,8 @@ write a :py:meth:`!converter_init` method.
 After *self*, all additional parameters **must** be keyword-only.
 Any arguments passed to the converter in Argument Clinic
 will be passed along to your :py:meth:`!converter_init` method.
-See :py:class:`!CConverter` for a list of members you may wish to specify in
-your subclass.
+See :py:class:`~clinic.CConverter` for a list of members you may wish to specify
+in your subclass.
 
 Here's the simplest example of a custom converter, from :cpy-file:`Modules/zlibmodule.c`::
 


### PR DESCRIPTION
```
/home/stan/dev/devguide/development-tools/clinic/howto.rst:745: WARNING: py:class reference target not found: CConverter [ref.class]
/home/stan/dev/devguide/development-tools/clinic/howto.rst:755: WARNING: py:class reference target not found: CConverter [ref.class]
```

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1699.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->