### PR TITLE
Add Portuguese to the translation table

### DIFF
--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -85,7 +85,7 @@ For more details about translations and their progress, see
        `article <https://rgth.co/blog/python-ptbr-cenario-atual/>`__
    * - Portuguese (pt)
      - André Moreira (:github-user:`NyaPuma`)
-     - :github:`GitHub <NyaPuma/python-docs-pt>`
+     - :github:`GitHub <NyaPuma/python-docs-pt>`,
        `Transifex <tx_>`_
    * - `Romanian (ro)  <https://docs.python.org/ro/>`__
      - Octavian Mustafa (:github-user:`octaG-M`, `email <mailto:octawian@yahoo.com>`__)


### PR DESCRIPTION
Adds Portuguese (Portugal) to the documentation translation teams table.

Language: Portuguese (Portugal)
Tag: pt
Repository: https://github.com/NyaPuma/python-docs-pt