### PR TITLE
Adds Portuguese (Portugal) to the documentation translation teams table.

### DIFF
--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -83,6 +83,10 @@ For more details about translations and their progress, see
        `guide <https://python.org.br/traducao/>`__,
        `Telegram <https://t.me/pybr_i18n>`__,
        `article <https://rgth.co/blog/python-ptbr-cenario-atual/>`__
+   * - Portuguese (pt)
+     - André Moreira (:github-user:`NyaPuma`)
+     - :github:`GitHub <NyaPuma/python-docs-pt>`,
+       `Transifex <tx_>`_
    * - `Romanian (ro)  <https://docs.python.org/ro/>`__
      - Octavian Mustafa (:github-user:`octaG-M`, `email <mailto:octawian@yahoo.com>`__)
      - :github:`GitHub <python/python-docs-ro>`


### PR DESCRIPTION
Language: Portuguese (Portugal)
Tag: pt
Repository: https://github.com/NyaPuma/python-docs-pt

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1705.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->