### PR TITLE
RST markup: recommend anonymous hyperlinks

### DIFF
--- a/contrib/intro/index.rst
+++ b/contrib/intro/index.rst
@@ -24,12 +24,12 @@ Python is an open source project, with culture and techniques from the broader
 open source world.  You might find it helpful to read about open source in
 general.  A number of individuals from the Python community have contributed to
 a series of excellent guides at `Open Source Guides
-<https://opensource.guide/>`_.
+<https://opensource.guide/>`__.
 
 Anyone will find the following guides useful:
 
-* `How to Contribute to Open Source <https://opensource.guide/how-to-contribute/>`_
-* `Building Welcoming Communities <https://opensource.guide/building-community/>`_
+* `How to Contribute to Open Source <https://opensource.guide/how-to-contribute/>`__
+* `Building Welcoming Communities <https://opensource.guide/building-community/>`__
 
 
 Healthy collaboration

--- a/core-team/committing.rst
+++ b/core-team/committing.rst
@@ -59,11 +59,11 @@ to enter the public source tree. Ask yourself the following questions:
 
 * **Does the pull request pass a check indicating that the submitter has signed the CLA?**
    Make sure that the contributor has signed a `Contributor
-   Licensing Agreement <https://www.python.org/psf/contrib/contrib-form/>`_
+   Licensing Agreement <https://www.python.org/psf/contrib/contrib-form/>`__
    (CLA), unless their change has no possible intellectual property
    associated with it (for example, fixing a spelling mistake in documentation).
    The `Python Software Foundation Contributor License Agreement Management Bot
-   <https://github.com/psf/clabot>`_
+   <https://github.com/psf/clabot>`__
    checks whether the author has signed the CLA, and replies in the PR
    if they haven't. For further questions about the CLA
    process, write to contributors@python.org.
@@ -125,7 +125,7 @@ How to add a NEWS entry
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 ``NEWS`` entries go into the ``Misc/NEWS.d`` directory as individual files. The
-``NEWS`` entry can be created by using `blurb-it <https://blurb-it.herokuapp.com/>`_,
+``NEWS`` entry can be created by using `blurb-it <https://blurb-it.herokuapp.com/>`__,
 or the :pypi:`blurb` tool and its ``blurb add`` command.
 
 If you are unable to use the tool, then you can create the ``NEWS`` entry file

--- a/core-team/experts.rst
+++ b/core-team/experts.rst
@@ -365,6 +365,6 @@ Documentation translations
 ==========================
 
 Translations are within the charter of
-`Editorial Board <https://python.github.io/editorial-board/>`_.
+`Editorial Board <https://python.github.io/editorial-board/>`__.
 For a list of translations and their coordinators, see
 :ref:`this table of translations <translation-coordinators>`.

--- a/core-team/join-team.rst
+++ b/core-team/join-team.rst
@@ -40,14 +40,14 @@ are granted through these steps:
    (as per :pep:`13`), the submitter `emails the steering council
    <mailto:steering-council@python.org>`_ with the candidate's email address
    requesting that the council either accept or reject the proposed membership.  Technically, the
-   council may only `veto a positive vote <https://peps.python.org/pep-0013/#membership>`_.
+   council may only `veto a positive vote <https://peps.python.org/pep-0013/#membership>`__.
 
 #. Assuming the steering council does not veto the positive vote, a member of the council or its
    delegate (approver, usually in practice a :ref:`Developer-in-Residence <current owners>`) will
    email the candidate:
 
    - A request for account details as required by
-     `🔒 python/voters <https://github.com/python/voters>`_.
+     `🔒 python/voters <https://github.com/python/voters>`__.
    - A reminder about the `Code of Conduct`_ and guidance on reporting issues
      to the PSF Conduct WG.
 
@@ -55,12 +55,12 @@ are granted through these steps:
 
    - Enable the various new privileges.
    - Remove the new committer from the triage team, if applicable.
-   - Add their details to `🔒 python/voters <https://github.com/python/voters>`_.
+   - Add their details to `🔒 python/voters <https://github.com/python/voters>`__.
    - Once the python/voters update is merged, regenerate the public team membership
      list at :ref:`developers`.
      See "Public list of members" in the ``voters`` README.
    - Post an announcement in the `Committers Discourse category
-     <https://discuss.python.org/c/committers/5>`_.  The past few announcements
+     <https://discuss.python.org/c/committers/5>`__.  The past few announcements
      were in the form of a separate post on the already open topic with
      the poll.
 
@@ -69,7 +69,7 @@ Getting a python.org email address
 
 Members of the core team can get an email address on the python.org domain.
 For more details refer to the `python.org email policy
-<https://www.python.org/psf/records/board/policies/email/>`_.
+<https://www.python.org/psf/records/board/policies/email/>`__.
 
 
 Poll template

--- a/core-team/memorialization.rst
+++ b/core-team/memorialization.rst
@@ -31,11 +31,11 @@ certain content when the legacy contact or family members request it.
 GitHub
 ------
 
-* The user is removed from the `python/ <https://github.com/orgs/python/>`_
+* The user is removed from the `python/ <https://github.com/orgs/python/>`__
   organization on GitHub;
-* The user is removed from the `psf/ <https://github.com/orgs/psf/>`_
+* The user is removed from the `psf/ <https://github.com/orgs/psf/>`__
   organization on GitHub;
-* The user is removed from the `pypa/ <https://github.com/orgs/pypa/>`_
+* The user is removed from the `pypa/ <https://github.com/orgs/pypa/>`__
   organization on GitHub.
 
 The PSF staff does not follow up with GitHub with regards to GitHub account
@@ -43,7 +43,7 @@ cancellation as this action is reserved for next-of-kin or designated by
 the deceased GitHub user to act as an account successor.
 
 The general policy regarding deceased users on GitHub is described on their
-`Deceased User Policy <https://docs.github.com/en/site-policy/other-site-policies/github-deceased-user-policy>`_
+`Deceased User Policy <https://docs.github.com/en/site-policy/other-site-policies/github-deceased-user-policy>`__
 page.
 
 Repositories in the organization
@@ -51,9 +51,9 @@ Repositories in the organization
 
 * The user's GitHub handle is removed from ``/.github/CODEOWNERS``.
   To see all that need action, perform
-  `this query <https://github.com/search?q=org%3Apython+path%3A**%2F.github%2FCODEOWNERS+USERNAME&type=code>`_.
+  `this query <https://github.com/search?q=org%3Apython+path%3A**%2F.github%2FCODEOWNERS+USERNAME&type=code>`__.
 * The user is marked as deceased in the private
-  `voters/python-core.toml <https://github.com/python/voters/blob/main/python-core.toml>`_
+  `voters/python-core.toml <https://github.com/python/voters/blob/main/python-core.toml>`__
   file with the ``left=`` field set to the day of passing, if known.
 
 discuss.python.org
@@ -80,7 +80,7 @@ a community member close to the deceased.
 
 The general best practice for deceased community members on
 Discourse-powered forums is described on their
-`Best practices for deceased community members <https://meta.discourse.org/t/best-practices-for-deceased-community-members/146210>`_
+`Best practices for deceased community members <https://meta.discourse.org/t/best-practices-for-deceased-community-members/146210>`__
 page.
 
 python.org email account
@@ -116,8 +116,8 @@ python.org admin
 devguide.python.org
 -------------------
 
-* The user is marked as deceased in `core-team.csv <https://github.com/python/devguide/blob/main/core-team/core-team.csv>`_;
-* The user is removed from the `experts index <https://github.com/python/devguide/blob/main/core-team/experts.rst>`_.
+* The user is marked as deceased in `core-team.csv <https://github.com/python/devguide/blob/main/core-team/core-team.csv>`__;
+* The user is removed from the `experts index <https://github.com/python/devguide/blob/main/core-team/experts.rst>`__.
 
 bugs.python.org
 ---------------
@@ -139,16 +139,16 @@ Other PSF-related infrastructure
   Discord server to remove the user from the server. The PSF staff
   does not follow up with Discord with regards to Discord account
   cancellation. The general policy regarding deceased users on Discord
-  is available on their `Deceased or Incapacitated Users <https://support.discord.com/hc/en-us/articles/19872987802263--Deceased-or-Incapacitated-Users>`_
+  is available on their `Deceased or Incapacitated Users <https://support.discord.com/hc/en-us/articles/19872987802263--Deceased-or-Incapacitated-Users>`__
   page.
 
 * The user is removed from Salt configuration for the PSF infrastructure
-  in `/pillar/base/users <https://github.com/python/psf-salt/tree/main/pillar/base/users>`_
+  in `/pillar/base/users <https://github.com/python/psf-salt/tree/main/pillar/base/users>`__
   that allows SSH access to PSF-controlled servers.
 
 * The user might have ran a buildbot worker. The PSF staff member will
   look for that in the
-  `buildmaster-config <https://github.com/search?q=repo%3Apython%2Fbuildmaster-config%20USERNAME&type=code>`_
+  `buildmaster-config <https://github.com/search?q=repo%3Apython%2Fbuildmaster-config%20USERNAME&type=code>`__
   repository.
 
 PyPI

--- a/core-team/motivations.rst
+++ b/core-team/motivations.rst
@@ -97,13 +97,13 @@ participating in the CPython core development process:
 
 .. topic:: Brett Cannon (Canada)
 
-   * Personal site: `snarky.ca <https://snarky.ca/>`_
+   * Personal site: `snarky.ca <https://snarky.ca/>`__
    * Microsoft (Software Developer)
    * Python Software Foundation (Fellow)
 
 .. topic:: Alyssa Coghlan (Australia)
 
-   * Personal site: `Curious Efficiency <https://www.curiousefficiency.org/>`_
+   * Personal site: `Curious Efficiency <https://www.curiousefficiency.org/>`__
    * `Extended bio <https://www.curiousefficiency.org/pages/about>`__
    * Python Software Foundation (Fellow, Packaging Working Group)
    * Westpac (Principal Python Engineer)
@@ -123,9 +123,9 @@ participating in the CPython core development process:
 .. topic:: Steve Dower (United States/Australia)
 
    * Microsoft (Software Developer)
-   * Personal site: `stevedower.id.au <https://stevedower.id.au/>`_
-   * Speaking: `stevedower.id.au/speaking <https://stevedower.id.au/speaking>`_
-   * Work blog: `devblogs.microsoft.com/python/ <https://devblogs.microsoft.com/python/>`_
+   * Personal site: `stevedower.id.au <https://stevedower.id.au/>`__
+   * Speaking: `stevedower.id.au/speaking <https://stevedower.id.au/speaking>`__
+   * Work blog: `devblogs.microsoft.com/python/ <https://devblogs.microsoft.com/python/>`__
    * Email address: steve.dower@python.org
 
    Steve started with Python while automating a test harness for medical
@@ -143,25 +143,25 @@ participating in the CPython core development process:
 
 .. topic:: Mariatta (Canada)
 
-   * Personal site: `mariatta.ca <https://mariatta.ca>`_
-   * Works as a `Software Engineer <https://www.linkedin.com/in/mariatta/>`_
+   * Personal site: `mariatta.ca <https://mariatta.ca>`__
+   * Works as a `Software Engineer <https://www.linkedin.com/in/mariatta/>`__
      in Vancouver, helps organize `Vancouver PyLadies
-     <https://www.meetup.com/PyLadies-Vancouver/>`_ meetup on the side, and
-     sometimes `speaks <https://mariatta.ca/posts/talks/>`_
+     <https://www.meetup.com/PyLadies-Vancouver/>`__ meetup on the side, and
+     sometimes `speaks <https://mariatta.ca/posts/talks/>`__
      at conferences.
    * Email address: mariatta@python.org
-   * `Sponsor Mariatta on GitHub <https://github.com/sponsors/Mariatta>`_
-   * `Patreon <https://www.patreon.com/Mariatta>`_
+   * `Sponsor Mariatta on GitHub <https://github.com/sponsors/Mariatta>`__
+   * `Patreon <https://www.patreon.com/Mariatta>`__
 
-   Support Mariatta by `becoming a sponsor <https://github.com/sponsors/Mariatta>`_,
-   sending her a `happiness packet <https://www.happinesspackets.io/send/>`_,
-   or `paypal <https://www.paypal.com/paypalme/mariatta>`_.
+   Support Mariatta by `becoming a sponsor <https://github.com/sponsors/Mariatta>`__,
+   sending her a `happiness packet <https://www.happinesspackets.io/send/>`__,
+   or `paypal <https://www.paypal.com/paypalme/mariatta>`__.
 
 .. topic:: R. David Murray (United States)
 
-   * Personal site: `bitdance.com <https://www.bitdance.com>`_
+   * Personal site: `bitdance.com <https://www.bitdance.com>`__
    * Available for `Python and Internet Services Consulting
-     and Python contract programming <https://www.murrayandwalker.com/>`_
+     and Python contract programming <https://www.murrayandwalker.com/>`__
 
    David has been involved in the Internet since the days when the old IBM
    BITNET and the ARPANet got cross connected, and in Python programming since
@@ -177,7 +177,7 @@ participating in the CPython core development process:
 
    David currently does both proprietary and open source development work,
    primarily in Python, through the company in which he is a partner, `Murray &
-   Walker, Inc <https://www.murrayandwalker.com>`_.  He has done contract work
+   Walker, Inc <https://www.murrayandwalker.com>`__.  He has done contract work
    focused specifically on CPython development both through the PSF (the
    kickstart of the email Unicode API development) and directly funded by
    interested corporations (additional development work on email funded by
@@ -187,7 +187,7 @@ participating in the CPython core development process:
 
 .. topic:: Antoine Pitrou (France)
 
-   * LinkedIn: `<https://www.linkedin.com/in/pitrou/>`_ (Senior Software Engineer)
+   * LinkedIn: `<https://www.linkedin.com/in/pitrou/>`__ (Senior Software Engineer)
    * QuantStack
    * Python Software Foundation (Fellow)
    * Email address: antoine@python.org
@@ -213,7 +213,7 @@ participating in the CPython core development process:
 
    Victor is paid by Red Hat to maintain Python upstream and downstream (RHEL,
    CentOS, Fedora & Software collections). See `Victor's contributions to
-   Python <https://vstinner.readthedocs.io/python_contrib.html>`_.
+   Python <https://vstinner.readthedocs.io/python_contrib.html>`__.
 
 .. topic:: Kushal Das (India)
 
@@ -224,21 +224,21 @@ participating in the CPython core development process:
 .. topic:: Barry Warsaw (United States)
 
    * NVIDIA, Principal System Software Engineer, Open Source Python Ecosystem
-   * Personal site: `barry.warsaw.us <https://barry.warsaw.us/>`_
-   * Blog: `We Fear Change <https://www.wefearchange.org/>`_
-   * `LinkedIn <https://www.linkedin.com/in/barry-warsaw/>`_
-   * `Bluesky <https://bsky.app/profile/pumpichank.bsky.social>`_
+   * Personal site: `barry.warsaw.us <https://barry.warsaw.us/>`__
+   * Blog: `We Fear Change <https://www.wefearchange.org/>`__
+   * `LinkedIn <https://www.linkedin.com/in/barry-warsaw/>`__
+   * `Bluesky <https://bsky.app/profile/pumpichank.bsky.social>`__
    * Email address: barry@python.org
    * Python Software Foundation (Fellow)
 
    Barry has been working in, with, and on Python since 1994.  He attended the
-   first Python workshop at `NIST <https://www.nist.gov/>`_ in Gaithersburg,
+   first Python workshop at `NIST <https://www.nist.gov/>`__ in Gaithersburg,
    MD in 1994, where he met Guido and several other early Python adopters.
    Barry subsequently worked with Guido for 8 years while at `CNRI
-   <http://cnri.reston.va.us/>`_.  Barry has served as Python's postmaster,
+   <http://cnri.reston.va.us/>`__.  Barry has served as Python's postmaster,
    webmaster, release manager, Language Summit co-chair, `Jython
-   <https://www.jython.org/>`_ project leader, `GNU Mailman
-   <https://www.list.org/>`_ project leader, and Python Steering Council
+   <https://www.jython.org/>`__ project leader, `GNU Mailman
+   <https://www.list.org/>`__ project leader, and Python Steering Council
    member in 2019, 2020, 2021, 2024, and 2025.
 
 .. topic:: Eric Snow (United States)
@@ -256,13 +256,13 @@ participating in the CPython core development process:
    developers on the project for 6 years.  After that he started the Python
    Tools for Visual Studio project focusing on providing advanced code completion
    and debugging features for Python.  Today he works on
-   `Cinder <https://github.com/facebookincubator/cinder/>`_ improving Python
+   `Cinder <https://github.com/facebookincubator/cinder/>`__ improving Python
    performance for Instagram.
 
 .. topic:: Carol Willing (United States)
 
    * Noteable (VP Engineering)
-   * Personal site: `Willing Consulting <https://www.willingconsulting.com/>`_
+   * Personal site: `Willing Consulting <https://www.willingconsulting.com/>`__
    * `Extended bio <https://www.willingconsulting.com/about/>`__
    * Project Jupyter (Software Council, Core Team for JupyterHub/Binder)
    * Python Software Foundation (Fellow)

--- a/core-team/responsibilities.rst
+++ b/core-team/responsibilities.rst
@@ -48,12 +48,12 @@ Communication channels and bug notifications
 ============================================
 
 Mailing lists have generally been replaced by the
-`Discourse forum <https://discuss.python.org/>`_ (``discuss.python.org``).
+`Discourse forum <https://discuss.python.org/>`__ (``discuss.python.org``).
 Refer to the :ref:`mailinglists` and :ref:`communication-discourse` sections
 for more information.
 
 If you want notification of new issues, you can use the appropriate GitHub notification
-settings for the `python/cpython <https://github.com/python/cpython>`_ repository —
+settings for the `python/cpython <https://github.com/python/cpython>`__ repository —
 follow the link and click on the :guilabel:`Watch` button to set your notification options.
 
 

--- a/developer-workflow/c-api.rst
+++ b/developer-workflow/c-api.rst
@@ -38,7 +38,7 @@ While internal API can be changed at any time, it's still good to keep it
 stable: other API or other CPython developers may depend on it.
 For users, internal API is sometimes the best workaround for a thorny problem
 --- though those use cases should be discussed on the
-`C API Discourse category <https://discuss.python.org/c/30>`_
+`C API Discourse category <https://discuss.python.org/c/30>`__
 or an issue so we can try to find a supported way to serve them.
 
 
@@ -218,7 +218,7 @@ use this API reliably:
   (:samp:`3.{x}.0`, including Alphas and Betas for :samp:`3.{x}.0`).
 * Adding a new unstable API *for an existing feature* is allowed even after
   Beta feature freeze, up until the first Release Candidate.
-  Consensus on the `Core Development Discourse <https://discuss.python.org/c/core-dev/23>`_
+  Consensus on the `Core Development Discourse <https://discuss.python.org/c/core-dev/23>`__
   is needed in the Beta period.
 * Backwards-incompatible changes should make existing C callers fail to compile.
   For example, arguments should be added/removed, or a function should be

--- a/developer-workflow/communication-channels.rst
+++ b/developer-workflow/communication-channels.rst
@@ -64,7 +64,7 @@ core development workflow.
 A complete list of Python mailing lists can be found at
 https://mail.python.org/mailman/listinfo (older lists, using Mailman2) or
 https://mail.python.org/mailman3/ (newer lists, using Mailman3). Some lists may also
-be mirrored at `GMANE <https://gmane.io/>`_ and can be read and posted to in various
+be mirrored at `GMANE <https://gmane.io/>`__ and can be read and posted to in various
 ways, including via web browsers, NNTP newsreaders, and RSS feed readers.
 
 .. _python-list: https://mail.python.org/mailman/listinfo/python-list
@@ -84,7 +84,7 @@ take place in the open forum categories for `PEPs`_ and `Core Development`_
 (these are the Discourse equivalents to the python-dev mailing list).
 All categories are open for users to read and post with the exception of
 the `Committers`_ category, where posting is restricted to the `CPython
-<https://github.com/python/cpython>`_ core team.
+<https://github.com/python/cpython>`__ core team.
 
 The Committers category is often used for announcements and notifications.
 It is also the designated venue for the core team promotion votes.
@@ -97,8 +97,8 @@ create an account using an email address or GitHub account. You can do so by
 clicking the :guilabel:`Sign Up` button on the top right hand corner of the
 `Discourse`_ main page.
 
-The Python Discourse `Quick Start <https://discuss.python.org/t/python-discourse-quick-start/116>`_
-compiled by `Carol Willing <https://discuss.python.org/u/willingc/>`_ gives you
+The Python Discourse `Quick Start <https://discuss.python.org/t/python-discourse-quick-start/116>`__
+compiled by `Carol Willing <https://discuss.python.org/u/willingc/>`__ gives you
 a quick overview on how to kick off Python Discourse.
 
 We recommend new users getting familiarised with the forum by going through Discobot tutorials.
@@ -114,13 +114,13 @@ Greetings!" received under Notifications and Messages in your user account.
 * Select either Notifications or Messages.
 * Open the "Greetings!" message sent by Discobot to start the tutorial.
 
-Ensure that you read through the `Python Code of Conduct <https://discuss.python.org/faq>`_.
+Ensure that you read through the `Python Code of Conduct <https://discuss.python.org/faq>`__.
 We are to be open, considerate and respectful to all users in the community.
 You can report messages that don't respect the CoC by clicking on the three
 dots under the message and then on the :guilabel:`⚐` icon.  You can also mention the
-`@staff <https://discuss.python.org/groups/staff>`_,
-`@moderators <https://discuss.python.org/groups/moderators>`_, or
-`@admins <https://discuss.python.org/groups/admins>`_ groups in a message.
+`@staff <https://discuss.python.org/groups/staff>`__,
+`@moderators <https://discuss.python.org/groups/moderators>`__, or
+`@admins <https://discuss.python.org/groups/admins>`__ groups in a message.
 
 
 
@@ -164,7 +164,7 @@ Customising notifications on user preference
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To get a bird's eye view of all your customised notifications, you can
-go to `Preferences of your account <https://discuss.python.org/my/preferences/categories>`_.
+go to `Preferences of your account <https://discuss.python.org/my/preferences/categories>`__.
 This allows you to make adjustments according to categories, users, and tags.
 
 Enabling mailing list mode
@@ -174,7 +174,7 @@ In mailing list mode, you will receive one email per post, as happens with
 traditional mailing lists. This is desirable if you prefer to interact via email,
 without visiting the forum website.
 To activate the mailing list mode, go to the `email preferences
-<https://discuss.python.org/my/preferences/emails>`_, check "Enable
+<https://discuss.python.org/my/preferences/emails>`__, check "Enable
 mailing list mode" and save changes.
 
 .. _Discourse: https://discuss.python.org/
@@ -243,7 +243,7 @@ Setting expectations for open source participation
 ==================================================
 
 Burn-out is common in open source due to a misunderstanding of what users, contributors,
-and maintainers should expect from each other. Brett Cannon gave a `talk <https://www.youtube.com/watch?v=-Nk-8fSJM6I>`_
+and maintainers should expect from each other. Brett Cannon gave a `talk <https://www.youtube.com/watch?v=-Nk-8fSJM6I>`__
 about this topic that sets out to help everyone set reasonable expectations of each other in
 order to make open source pleasant for everyone involved.
 

--- a/developer-workflow/development-cycle.rst
+++ b/developer-workflow/development-cycle.rst
@@ -134,7 +134,7 @@ former branch, for example, ``3.8`` or ``2.7``.
 The :ref:`versions` page contains list of active and end-of-life branches.
 
 The latest release for each Python version can be found on the `download page
-<https://www.python.org/downloads/>`_.
+<https://www.python.org/downloads/>`__.
 
 .. _stages:
 
@@ -212,27 +212,27 @@ Repository administration
 -------------------------
 
 The source code is currently hosted on `GitHub
-<https://github.com/python/cpython>`_ in the `Python organization <https://github.com/python/>`_.
+<https://github.com/python/cpython>`__ in the `Python organization <https://github.com/python/>`__.
 
 Organization repository policy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Within the `GitHub Python organization <https://github.com/python/>`_,
+Within the `GitHub Python organization <https://github.com/python/>`__,
 repositories are expected to relate to the Python language, the CPython
 reference implementation, their documentation and their development workflow.
 This includes, for example:
 
-* The reference implementation of Python and related repositories: `CPython <https://github.com/python/cpython>`_.
-* Tooling and support around CPython development: `pyperformance <https://github.com/python/pyperformance>`_, `Bedevere <https://github.com/python/bedevere>`_.
-* Helpers and backports for Python/CPython features: `typing_extensions <https://github.com/python/typing_extensions>`_, `typeshed <https://github.com/python/typeshed>`_, `tzdata <https://github.com/python/tzdata>`_, `pythoncapi-compat <https://github.com/python/pythoncapi-compat>`_.
-* Organization-related repositories: the `Code of Conduct <https://github.com/python/pycon-code-of-conduct>`_, `.github <https://github.com/python/.github>`_.
-* Documentation and websites for all the above: `python.org repository <https://github.com/python/pythondotorg>`_, `PEPs <https://github.com/python/peps>`_, `Devguide <https://github.com/python/devguide>`_, docs translations.
-* Infrastructure for all the above: `docsbuild-scripts <https://github.com/python/docsbuild-scripts>`_, `buildmaster-config <https://github.com/python/buildmaster-config>`_.
-* Discussions and notes around official development-related processes and events: `steering-council <https://github.com/python/steering-council>`_, `core-sprint <https://github.com/python/core-sprint>`_.
+* The reference implementation of Python and related repositories: `CPython <https://github.com/python/cpython>`__.
+* Tooling and support around CPython development: `pyperformance <https://github.com/python/pyperformance>`__, `Bedevere <https://github.com/python/bedevere>`__.
+* Helpers and backports for Python/CPython features: `typing_extensions <https://github.com/python/typing_extensions>`__, `typeshed <https://github.com/python/typeshed>`__, `tzdata <https://github.com/python/tzdata>`__, `pythoncapi-compat <https://github.com/python/pythoncapi-compat>`__.
+* Organization-related repositories: the `Code of Conduct <https://github.com/python/pycon-code-of-conduct>`__, `.github <https://github.com/python/.github>`__.
+* Documentation and websites for all the above: `python.org repository <https://github.com/python/pythondotorg>`__, `PEPs <https://github.com/python/peps>`__, `Devguide <https://github.com/python/devguide>`__, docs translations.
+* Infrastructure for all the above: `docsbuild-scripts <https://github.com/python/docsbuild-scripts>`__, `buildmaster-config <https://github.com/python/buildmaster-config>`__.
+* Discussions and notes around official development-related processes and events: `steering-council <https://github.com/python/steering-council>`__, `core-sprint <https://github.com/python/core-sprint>`__.
 
 Before adding a new repository to the organization, open a discussion to seek consensus
-in the `Committers Discourse category <https://discuss.python.org/c/committers/5>`_.
-Once people are satisfied with that, ask the `Python steering council <https://github.com/python/steering-council>`_
+in the `Committers Discourse category <https://discuss.python.org/c/committers/5>`__.
+Once people are satisfied with that, ask the `Python steering council <https://github.com/python/steering-council>`__
 to grant permission.
 
 Note that several repositories remain in the organization for historic reasons,
@@ -241,18 +241,18 @@ and would probably not be appropriate to add today.
 Generally, new repositories should start their life under personal GitHub
 accounts or other GitHub orgs. It is relatively easy to move a repository to
 the organization once it is mature. For example, this would now apply to
-experimental features like `asyncio <https://github.com/python/asyncio>`_,
-`exceptiongroups <https://github.com/python/exceptiongroups>`_,
+experimental features like `asyncio <https://github.com/python/asyncio>`__,
+`exceptiongroups <https://github.com/python/exceptiongroups>`__,
 and drafts of new guides and other documentation (for example, `redistributor-guide
-<https://github.com/python/redistributor-guide>`_).
+<https://github.com/python/redistributor-guide>`__).
 
-General-use tools and libraries (for example, `mypy <https://github.com/python/mypy>`_
-or `Black <https://github.com/psf/black>`_) should also be developed outside
+General-use tools and libraries (for example, `mypy <https://github.com/python/mypy>`__
+or `Black <https://github.com/psf/black>`__) should also be developed outside
 the ``python`` organization, unless core devs (as represented by the SC)
 specifically want to “bless” one implementation (as with
-`typeshed <https://github.com/python/typeshed>`_,
-`tzdata <https://github.com/python/tzdata>`_, or
-`pythoncapi-compat <https://github.com/python/pythoncapi-compat>`_).
+`typeshed <https://github.com/python/typeshed>`__,
+`tzdata <https://github.com/python/tzdata>`__, or
+`pythoncapi-compat <https://github.com/python/pythoncapi-compat>`__).
 
 
 Organization owner policy
@@ -264,7 +264,7 @@ at all levels including organization membership, team membership, access
 control, and merge privileges on all repositories. For full details of the
 permission levels see `GitHub's documentation on Organization permission
 levels
-<https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#permissions-for-organization-roles>`_.
+<https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#permissions-for-organization-roles>`__.
 This role is paramount to the security of the Python Language, Community, and
 Infrastructure.
 
@@ -315,7 +315,7 @@ The Administrator role on the repository allows for managing all aspects
 including collaborators, access control, integrations, webhooks, and branch
 protection. For full details of the permission levels see `GitHub's
 documentation on repository permission levels
-<https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#permissions-for-organization-roles>`_.
+<https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#permissions-for-organization-roles>`__.
 Common reasons for this role are: maintenance of core
 workflow tooling, Release Managers for all :ref:`in-development <indevbranch>`,
 :ref:`maintenance <maintbranch>`, and :ref:`security mode <secbranch>`

--- a/developer-workflow/extension-modules.rst
+++ b/developer-workflow/extension-modules.rst
@@ -562,7 +562,7 @@ Now that the configuration is in place, it remains to compile the project:
 
   .. tip::
 
-     We recommend installing `Podman <https://podman.io/docs/installation>`_
+     We recommend installing `Podman <https://podman.io/docs/installation>`__
      instead of Docker since the former does not require a background service
      and avoids creating files owned by the ``root`` user in some cases.
 
@@ -609,8 +609,8 @@ by executing :cpy-file:`Tools/build/regen-configure.sh`:
 
 If Docker complains about missing permissions, this Stack Overflow post
 could be useful in solving the issue: `How to fix docker: permission denied
-<https://stackoverflow.com/q/48957195/9579194>`_. Alternatively, you may try
-using `Podman <https://podman.io/docs/installation>`_.
+<https://stackoverflow.com/q/48957195/9579194>`__. Alternatively, you may try
+using `Podman <https://podman.io/docs/installation>`__.
 
 Missing ``Py_BUILD_CORE`` define when using internal headers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/developer-workflow/grammar.rst
+++ b/developer-workflow/grammar.rst
@@ -5,4 +5,4 @@ Changing CPython's grammar
 ==========================
 
 This document is now part of the
-`CPython Internals Docs <https://github.com/python/cpython/blob/main/InternalDocs/changing_grammar.md>`_.
+`CPython Internals Docs <https://github.com/python/cpython/blob/main/InternalDocs/changing_grammar.md>`__.

--- a/developer-workflow/sbom.rst
+++ b/developer-workflow/sbom.rst
@@ -5,15 +5,15 @@ Software Bill-of-Materials (abbreviated as "SBOM") is a document for sharing
 information about software and how it's been composed. This format is used
 most often in the security space for checking software and its dependencies
 for vulnerabilities using vulnerability databases like
-`CVE <https://www.cve.org/>`_ and `OSV <https://osv.dev/>`_. The SBOM format
-that the CPython project uses is `SPDX <https://spdx.github.io/spdx-spec/v2.3/>`_
+`CVE <https://www.cve.org/>`__ and `OSV <https://osv.dev/>`__. The SBOM format
+that the CPython project uses is `SPDX <https://spdx.github.io/spdx-spec/v2.3/>`__
 which can be transformed into other formats if necessary by consumers.
 
 There are multiple sources of third-party dependencies for CPython.
 Some are vendored into the source code of CPython itself (like ``mpdecimal``
 vendored at :cpy-file:`Modules/_decimal/libmpdec`) or they could be optionally pulled
 in during builds like Windows using dependencies from the
-`python/cpython-source-deps <https://github.com/python/cpython-source-deps>`_
+`python/cpython-source-deps <https://github.com/python/cpython-source-deps>`__
 repository.
 
 Whenever adding or updating a third-party dependency, an update will likely
@@ -51,10 +51,10 @@ Adding a new dependency
 When adding a dependency it's important to have the following information:
 
 * Name, version, and download URL of the project
-* License of the project as an `SPDX License Expression <https://spdx.org/licenses/>`_
+* License of the project as an `SPDX License Expression <https://spdx.org/licenses/>`__
 * Software identifiers that match values in vulnerability databases
-  (`CPE <https://nvd.nist.gov/products/cpe>`_ and
-  `Package URLs <https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst>`_
+  (`CPE <https://nvd.nist.gov/products/cpe>`__ and
+  `Package URLs <https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst>`__
   or "PURLs")
 * Paths to include and exclude in the CPython source tree corresponding to this dependency
 

--- a/development-tools/clang.rst
+++ b/development-tools/clang.rst
@@ -11,7 +11,7 @@ libraries.
 
 This document does not cover interpreting the findings. For a discussion of
 interpreting results, see Marshall Clow's `Testing libc++ with
--fsanitize=undefined <https://cplusplusmusings.wordpress.com/tag/clang/>`_.  The
+-fsanitize=undefined <https://cplusplusmusings.wordpress.com/tag/clang/>`__.  The
 blog posting is a detailed examinations of issues uncovered by Clang in
 ``libc++``.
 
@@ -45,7 +45,7 @@ flags are passed through ``CFLAGS`` and ``CXXFLAGS``, and sometimes through
 ``CC`` and ``CXX`` (in addition to the compiler).
 
 A complete list of sanitizers can be found at `Controlling Code Generation
-<https://clang.llvm.org/docs/UsersManual.html#controlling-code-generation>`_.
+<https://clang.llvm.org/docs/UsersManual.html#controlling-code-generation>`__.
 
 .. note::
 
@@ -70,7 +70,7 @@ Pre-built Clang builds are available for most platforms:
   includes the "C++ clang tools for windows" feature.
 
 You can also build ``clang`` from source; refer to
-`the clang documentation <https://clang.llvm.org/>`_ for details.
+`the clang documentation <https://clang.llvm.org/>`__ for details.
 
 The installer does not install all the components needed on occasion. For
 example, you might want to run a ``scan-build`` or examine the results with
@@ -284,6 +284,6 @@ Or, you could ignore the entire file with::
 Unfortunately, you won't know what to ignorelist until you run the sanitizer.
 
 The documentation is available at `Sanitizer special case list
-<https://clang.llvm.org/docs/SanitizerSpecialCaseList.html>`_.
+<https://clang.llvm.org/docs/SanitizerSpecialCaseList.html>`__.
 
 .. _Valgrind: https://github.com/python/cpython/blob/main/Misc/README.valgrind

--- a/development-tools/gdb.rst
+++ b/development-tools/gdb.rst
@@ -29,7 +29,7 @@ this approach is less helpful when debugging the runtime virtual
 machine, since the main interpreter loop function,
 ``_PyEval_EvalFrameDefault``, is well over 4,000 lines long as of Python 3.12.
 Fortunately, among the `many ways to set breakpoints
-<https://sourceware.org/gdb/current/onlinedocs/gdb.html/Location-Specifications.html>`_,
+<https://sourceware.org/gdb/current/onlinedocs/gdb.html/Location-Specifications.html>`__,
 you can break at C labels, such as those generated for computed gotos.
 If you are debugging an interpreter compiled with computed goto support
 (generally true, certainly when using GCC), each instruction will be

--- a/documentation/devguide.rst
+++ b/documentation/devguide.rst
@@ -23,7 +23,7 @@ Changes to the Developer's Guide are published when pull requests are merged.
 
 Changes to the Python documentation are published regularly,
 ususally within 48 hours of the change being committed.
-The documentation is also `published for each release <https://docs.python.org/release/>`_,
+The documentation is also `published for each release <https://docs.python.org/release/>`__,
 which may also be used by redistributors.
 
 

--- a/documentation/help-documenting.rst
+++ b/documentation/help-documenting.rst
@@ -37,8 +37,8 @@ The in-development and recent maintenance branches are rebuilt once per day.
 
 If you would like to be more involved with documentation, consider subscribing
 to the `Documentation category on the Python Discourse
-<https://discuss.python.org/c/documentation/26>`_ and the
-`docs@python.org <https://mail.python.org/mailman3/lists/docs.python.org/>`_ mailing list
+<https://discuss.python.org/c/documentation/26>`__ and the
+`docs@python.org <https://mail.python.org/mailman3/lists/docs.python.org/>`__ mailing list
 where user issues are raised and documentation toolchain, projects, and standards
 are discussed.
 

--- a/documentation/markup.rst
+++ b/documentation/markup.rst
@@ -51,7 +51,7 @@ language, this will not take too long.
 .. seealso::
 
     The authoritative `reStructuredText User
-    Documentation <https://docutils.sourceforge.io/rst.html>`_.
+    Documentation <https://docutils.sourceforge.io/rst.html>`__.
 
 
 Use of whitespace
@@ -346,7 +346,7 @@ they are used in the Python documentation.
 
    This is just an overview of Sphinx' extended markup capabilities; full
    coverage can be found in `its own documentation
-   <https://www.sphinx-doc.org/>`_.
+   <https://www.sphinx-doc.org/>`__.
 
 
 Meta-information markup

--- a/documentation/markup.rst
+++ b/documentation/markup.rst
@@ -28,7 +28,7 @@ attribute definitions   ``.. attribute: `attr-name```               :ref:`inform
 attribute references    ``:attr:`attr-name```                       :ref:`roles`
 reference labels        ``.. _label-name:``                         :ref:`doc-ref-role`
 internal references     ``:ref:`label-name```                       :ref:`doc-ref-role`
-external links          ```Link text <https://example.com>`_``      :ref:`hyperlinks`
+external links          ```Link text <https://example.com>`__``     :ref:`hyperlinks`
 roles w/ custom text    ``:role:`custom text <target>```            :ref:`roles`
 roles w/ only last part ``:role:`~hidden.hidden.visible```          :ref:`roles`
 roles w/o link          ``:role:`!target```                         :ref:`roles`
@@ -185,9 +185,12 @@ Hyperlinks
 External links
 ^^^^^^^^^^^^^^
 
-Use ```Link text <http://target>`_`` for inline web links.  If the link text
+Use ```Link text <https://example.com>`__`` for inline web links. If the link text
 should be the web address, you don't need special markup at all, the parser
-finds links and mail addresses in ordinary text.
+finds links and mail addresses in ordinary text. Prefer anonymous hyperlinks
+(with a double underscore) over named hyperlinks (with a single underscore)
+to avoid target name clashes.
+
 
 Internal links
 ^^^^^^^^^^^^^^

--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -73,7 +73,7 @@ boolean
   abbreviated name with appropriate markup (for example, ``:type:`bool```).
 
 C API
-  Python's `API <https://docs.python.org/3/c-api/>`_ used by C programmers
+  Python's `API <https://docs.python.org/3/c-api/>`__ used by C programmers
   to write extension modules. All caps and unhyphenated.
 
 CPU
@@ -122,7 +122,7 @@ such as "for example" or "that is."
 Diátaxis
 ========
 
-Python's documentation strives to follow the `Diátaxis <https://diataxis.fr/>`_
+Python's documentation strives to follow the `Diátaxis <https://diataxis.fr/>`__
 framework. This means adapting the writing style according to the nature of
 the documentation that is being written. The framework splits
 documentation into four distinct types: tutorials, how-to guides, reference, and
@@ -135,7 +135,7 @@ explanation.
   and abstract concepts should be avoided. Please consult the Diátaxis guide on
   :ref:`diataxis:tutorials` for more detail.
 
-* `Python how-to guides <https://docs.python.org/3/howto/index.html>`_ are
+* `Python how-to guides <https://docs.python.org/3/howto/index.html>`__ are
   designed to guide a user through a problem-field.
   Both tutorials and how-to guides are instructional rather than explanatory
   and should provide logical steps on how to complete a task. However,
@@ -158,7 +158,7 @@ explanation.
   found throughout Python's documentation, for example the
   :ref:`python:unicode-howto`.
 
-Please consult the `Diátaxis <https://diataxis.fr/>`_ guide for more
+Please consult the `Diátaxis <https://diataxis.fr/>`__ guide for more
 detail.
 
 

--- a/documentation/translations/coordinating.rst
+++ b/documentation/translations/coordinating.rst
@@ -12,7 +12,7 @@ Communication/help channels
 ===========================
 
 Discussions about translations occur on the Python Docs Discord
-`#translations channel <https://discord.gg/h3qDwgyzga>`_ and the
+`#translations channel <https://discord.gg/h3qDwgyzga>`__ and the
 `translations category <trans_disc_>`_ of the Python Discourse.
 
 For administrative issues, ping ``@python/editorial-board``.
@@ -72,16 +72,16 @@ account, with the correct Git hierarchy and folder structure. This can be done
 in several ways, and depends on what translation process you plan to use.
 
 Each translation is assigned an appropriate lowercase
-`IETF language tag <https://datatracker.ietf.org/doc/html/rfc5646.html>`_.
+`IETF language tag <https://datatracker.ietf.org/doc/html/rfc5646.html>`__.
 The tag may have an optional subtag, joined with a dash.
 For example, ``pt`` (Portuguese) or ``pt-br`` (Brazilian Portuguese).
 The repository name is then: ``python-docs-TAG``
 
 The name of each branch should be the Python version it holds translations
 for, for example, ``3.14``. The files should be structured like the source files
-in `CPython/Doc <https://github.com/python/cpython/tree/main/Doc>`_.
+in `CPython/Doc <https://github.com/python/cpython/tree/main/Doc>`__.
 A correctly set up repository looks like this:
-`python-docs-pl <https://github.com/python/python-docs-pl/>`_
+`python-docs-pl <https://github.com/python/python-docs-pl/>`__
 
 Below, the recommended ways for starting your repository are described. You can
 choose another way if you like; it’s up to you.
@@ -100,7 +100,7 @@ Translation platform
 ~~~~~~~~~~~~~~~~~~~~
 
 You can also start your translation using
-`Transifex <https://explore.transifex.com/python-doc/python-newest/>`_.
+`Transifex <https://explore.transifex.com/python-doc/python-newest/>`__.
 This will allow you to translate via the web interface, and to use shared
 automatically updated source files.
 
@@ -155,7 +155,7 @@ PEP 545 summary
 Here are the essential points of :PEP:`545`:
 
 - Each translation is assigned an appropriate lowercase
-  `IETF language tag <https://datatracker.ietf.org/doc/html/rfc5646.html>`_.
+  `IETF language tag <https://datatracker.ietf.org/doc/html/rfc5646.html>`__.
   The tag may have an optional region subtag, joined with a dash.
   For example, ``pt`` (Portuguese) or ``pt-br`` (Brazilian Portuguese).
 
@@ -210,10 +210,10 @@ Testing should ideally be set up in your repository, and will help catch errors
 early and ensure translation quality. Testing generally consists of building, and
 linting with :pypi:`sphinx-lint`.
 
-See `this documentation <https://python-docs-transifex-automation.readthedocs.io/workflows.html#test-build-workflow>`_
+See `this documentation <https://python-docs-transifex-automation.readthedocs.io/workflows.html#test-build-workflow>`__
 for sample workflows with usage guides.
 
-The `dashboard <https://translations.python.org/build-details.html>`_
+The `dashboard <https://translations.python.org/build-details.html>`__
 also tests translations and uploads error logs.
 
 
@@ -289,7 +289,7 @@ Is there a Weblate instance we can translate on?
 ------------------------------------------------
 
 There is currently no Weblate instance for Python translations.
-See this `Discourse thread <https://discuss.python.org/t/docs-translation-platform/29940>`_
+See this `Discourse thread <https://discuss.python.org/t/docs-translation-platform/29940>`__
 for updates.
 
 

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -32,7 +32,7 @@ For more details about translations and their progress, see
      - :github:`GitHub <python/python-docs-bn-in>`
    * - `French (fr) <https://docs.python.org/fr/>`__
      - Julien Palard (:github-user:`JulienPalard`)
-     - `AFPy/python-docs-fr <https://git.afpy.org/AFPy/python-docs-fr/>`_,
+     - `AFPy/python-docs-fr <https://git.afpy.org/AFPy/python-docs-fr/>`__,
        :github:`mirror <python/python-docs-fr>`
    * - `Greek (el) <https://docs.python.org/el/>`__
      - | Lysandros Nikolaou (:github-user:`lysnikolaou`),
@@ -122,7 +122,7 @@ If there is already a repository for your language team (there may be links to
 Telegrams/Discords in the ``README``), join and introduce
 yourself. Your fellow translators will be more than happy to help!
 General discussions about translations occur on the Python Docs Discord
-`#translations channel <https://discord.gg/h3qDwgyzga>`_ and the
+`#translations channel <https://discord.gg/h3qDwgyzga>`__ and the
 `translations category <discourse_>`_ of the Python Discourse.
 
 .. _translation-style-guide:
@@ -215,7 +215,7 @@ Code examples
 
 Translate values in code examples, that is string literals, and comments.
 Don't translate keywords or names, including variable, function, class, argument,
-and attribute names. An example of a translated codeblock from the `tutorial <https://docs.python.org/3/tutorial/controlflow.html#keyword-arguments>`_
+and attribute names. An example of a translated codeblock from the `tutorial <https://docs.python.org/3/tutorial/controlflow.html#keyword-arguments>`__
 is provided below:
 
 .. code-block:: python
@@ -259,7 +259,7 @@ through the following resources from the Transifex documentation:
 Within the organization, a project for translating the
 :github:`Python Docs Sphinx Theme <python/python-docs-theme>` can also be
 found.
-For further information about Transifex see our `documentation <https://python-docs-transifex-automation.readthedocs.io/>`_.
+For further information about Transifex see our `documentation <https://python-docs-transifex-automation.readthedocs.io/>`__.
 
 
 Resources
@@ -270,10 +270,10 @@ Some useful resources:
 - :ref:`git-boot-camp`:
    Several translations accept contributions by pull requests. Most have their
    own guide for how to do this, but this can provide useful tips.
-- `Translation issues & improvements <https://github.com/orgs/python/projects/58>`_ GitHub project:
+- `Translation issues & improvements <https://github.com/orgs/python/projects/58>`__ GitHub project:
    This project contains issues and pull requests that aim to improve
    the Python documentation for translations.
-- `Python Pootle archive <https://github.com/python/pootle-python-org-backup>`_:
+- `Python Pootle archive <https://github.com/python/pootle-python-org-backup>`__:
    Pootle is no longer used for translation. Contains translations for old Python versions.
 
 
@@ -322,7 +322,7 @@ How do I translate the Python Docs Sphinx Theme?
 The Sphinx theme for the Python documentation supports localization.
 
 You can translate either on
-`Transifex <https://explore.transifex.com/python-doc/python-docs-theme/>`_
+`Transifex <https://explore.transifex.com/python-doc/python-docs-theme/>`__
 (see :ref:`translating on Transifex <transifex-use>` for more information)
 or locally by following the steps outlined below.
 
@@ -357,7 +357,7 @@ The coordination team for my language is inactive, what do I do?
 ----------------------------------------------------------------
 
 If you would like to coordinate, open a pull request in the
-`devguide <https://github.com/python/devguide>`_ adding yourself to the table
+`devguide <https://github.com/python/devguide>`__ adding yourself to the table
 at the top of this page, and ping ``@python/editorial-board``.
 
 

--- a/getting-started/git-boot-camp.rst
+++ b/getting-started/git-boot-camp.rst
@@ -33,7 +33,7 @@ relevant to CPython's workflow.
 .. note::
    Setting up Git aliases for common tasks can be useful to you. You can
    get more information about that in
-   `Git documentation <https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases>`_
+   `Git documentation <https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases>`__
 
 .. _fork-cpython:
 
@@ -280,7 +280,7 @@ Compare to the ``main`` branch::
    $ git diff main
 
 Exclude generated files from diff using an ``attr``
-`pathspec <https://git-scm.com/docs/gitglossary#def_pathspec>`_ (note the
+`pathspec <https://git-scm.com/docs/gitglossary#def_pathspec>`__ (note the
 single quotes)::
 
    $ git diff main ':(attr:!generated)'
@@ -289,7 +289,7 @@ Exclude generated files from diff by default::
 
    $ git config diff.generated.binary true
 
-The ``generated`` `attribute <https://git-scm.com/docs/gitattributes>`_ is
+The ``generated`` `attribute <https://git-scm.com/docs/gitattributes>`__ is
 defined in :cpy-file:`.gitattributes`, found in the repository root.
 
 .. _push-changes:
@@ -389,8 +389,8 @@ you run ``git merge upstream/main``.
 
 When it happens, you need to resolve conflict.  See these articles about resolving conflicts:
 
-- `About merge conflicts <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/about-merge-conflicts>`_
-- `Resolving a merge conflict using the command line <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line>`_
+- `About merge conflicts <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/about-merge-conflicts>`__
+- `Resolving a merge conflict using the command line <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line>`__
 
 .. _git_from_patch:
 
@@ -443,8 +443,8 @@ Scenario:
 - A contributor made a pull request to CPython.
 - Before merging it, you want to be able to test their changes locally.
 
-If you've got `GitHub CLI <https://cli.github.com>`_ or
-`hub <https://hub.github.com>`_ installed, you can do::
+If you've got `GitHub CLI <https://cli.github.com>`__ or
+`hub <https://hub.github.com>`__ installed, you can do::
 
    $ gh co <pr_number>  # GitHub CLI
    $ hub pr checkout <pr_number>  # hub
@@ -523,7 +523,7 @@ The bad example contains bullet points that are a direct effect of the
 PR life cycle, while being irrelevant to the final change.
 
 .. note::
-   `How to Write a Git Commit Message <https://cbea.ms/git-commit/>`_
+   `How to Write a Git Commit Message <https://cbea.ms/git-commit/>`__
    is a nice article describing how to write a good commit message.
 
 Finally, press the :guilabel:`Confirm squash and merge` button.
@@ -557,7 +557,7 @@ after it has been accepted and merged into ``main``.  It is usually indicated
 by the label ``needs backport to X.Y`` on the pull request itself.
 
 Use the utility script
-`cherry_picker.py <https://github.com/python/cherry-picker>`_
+`cherry_picker.py <https://github.com/python/cherry-picker>`__
 to backport the commit.
 
 The commit hash for backporting is the squashed commit that was merged to
@@ -649,12 +649,12 @@ To edit an open pull request that targets ``main``:
 GitHub CLI
 ----------
 
-`GitHub CLI <https://cli.github.com>`_ is a command-line
+`GitHub CLI <https://cli.github.com>`__ is a command-line
 interface that allows you to create, update, and check GitHub
 issues and pull requests.
 
 You can install GitHub CLI `by following these instructions
-<https://github.com/cli/cli#installation>`_. After installing,
+<https://github.com/cli/cli#installation>`__. After installing,
 you need to authenticate::
 
     $ gh auth login
@@ -740,6 +740,6 @@ Change into a directory to work from that branch. For example::
 
 .. seealso::
 
-   * `Git Reference Manual <https://git-scm.com/docs/git-worktree>`_
+   * `Git Reference Manual <https://git-scm.com/docs/git-worktree>`__
    * `"Experiment on your code freely with Git worktree"
-     <https://opensource.com/article/21/4/git-worktree>`_
+     <https://opensource.com/article/21/4/git-worktree>`__

--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -183,7 +183,7 @@ resolved as follows:
 When running the final command, Git may open an editor for writing a commit
 message. It is usually okay to leave that as-is and close the editor.
 
-See `the merge command's documentation <https://git-scm.com/docs/git-merge>`_
+See `the merge command's documentation <https://git-scm.com/docs/git-merge>`__
 for a detailed technical explanation.
 
 
@@ -283,7 +283,7 @@ The automated checklist runs through:
 * Has the documentation been updated?
 * Has the test suite been updated?
 * Has an entry under ``Misc/NEWS.d/next`` been added?
-  (using `blurb-it <https://blurb-it.herokuapp.com/>`_,
+  (using `blurb-it <https://blurb-it.herokuapp.com/>`__,
   or the :pypi:`blurb` tool)
 * Has ``Misc/ACKS`` been updated?
 * Has ``configure`` been regenerated, if necessary?
@@ -329,7 +329,7 @@ instructions on how the commit message should look like when merging a pull
 request.
 
 .. note::
-   `How to Write a Git Commit Message <https://cbea.ms/git-commit/>`_
+   `How to Write a Git Commit Message <https://cbea.ms/git-commit/>`__
    is a nice article that describes how to write a good commit message.
 
 
@@ -417,7 +417,7 @@ This will get your changes up to GitHub.
 
 Now you want to
 `create a pull request from your fork
-<https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork>`_.
+<https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork>`__.
 If this is a pull request in response to a pre-existing issue on the
 `issue tracker`_, please make sure to reference the issue number using
 ``gh-NNNNN:`` prefix in the pull request title and ``#NNNNN`` in the description.
@@ -452,7 +452,7 @@ existing patch. In this case, both parties should sign the :ref:`CLA <cla>`.
 When creating a pull request based on another person's patch, provide
 attribution to the original patch author by adding "Co-authored-by:
 Author Name <email_address> ." to the pull request description and commit message.
-See `the GitHub article <https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors>`_
+See `the GitHub article <https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors>`__
 on how to properly add the co-author info.
 
 See also :ref:`Applying a Patch to Git <git_from_patch>`.

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -20,9 +20,9 @@ compiled version of the CPython interpreter (CPython is the version of Python
 available from https://www.python.org/). It also gives an overview of the
 directory structure of the CPython source code.
 
-Alternatively, if you have `Docker <https://www.docker.com/>`_ installed you
+Alternatively, if you have `Docker <https://www.docker.com/>`__ installed you
 might want to use `our official images
-<https://gitlab.com/python-devs/ci-images/blob/main/README.md>`_.  These
+<https://gitlab.com/python-devs/ci-images/blob/main/README.md>`__.  These
 contain the latest releases of several Python versions, along with Git head,
 and are provided for development and testing purposes only.
 
@@ -38,23 +38,23 @@ Install Git
 
 .. c_install_git_start
 
-CPython is developed using `Git <https://git-scm.com>`_ for version control. The Git
+CPython is developed using `Git <https://git-scm.com>`__ for version control. The Git
 command line program is named ``git``; this is also used to refer to Git
 itself. Git is easily available for all common operating systems.
 
 - **Install**
 
   As the CPython repo is hosted on GitHub, please refer to either the
-  `GitHub setup instructions <https://docs.github.com/en/get-started/getting-started-with-git/set-up-git>`_
-  or the `Git project instructions <https://git-scm.com>`_ for step-by-step
+  `GitHub setup instructions <https://docs.github.com/en/get-started/getting-started-with-git/set-up-git>`__
+  or the `Git project instructions <https://git-scm.com>`__ for step-by-step
   installation directions. You may also want to consider a graphical client
-  such as `TortoiseGit <https://tortoisegit.org/>`_ or
-  `GitHub Desktop <https://github.com/apps/desktop>`_.
+  such as `TortoiseGit <https://tortoisegit.org/>`__ or
+  `GitHub Desktop <https://github.com/apps/desktop>`__.
 
 - **Configure**
 
   Configure :ref:`your name and email <set-up-name-email>` and create
-  `an SSH key <https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account>`_
+  `an SSH key <https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account>`__
   as this will allow you to interact with GitHub without typing a username
   and password each time you execute a command, such as ``git pull``,
   ``git push``, or ``git fetch``.  On Windows, you should also
@@ -141,7 +141,7 @@ Install pre-commit as a Git hook
 --------------------------------
 
 To make sure your code is linted correctly, we recommend setting up
-`pre-commit <https://pre-commit.com#installation>`_ as a Git hook::
+`pre-commit <https://pre-commit.com#installation>`__ as a Git hook::
 
    $ pre-commit install --allow-missing-config
    pre-commit installed at .git/hooks/pre-commit
@@ -170,7 +170,7 @@ working only on pure Python code the pydebug build provides several useful
 checks that one should not skip.
 
 .. seealso:: The effects of various configure and build flags are documented in
-   the `Python configure docs <https://docs.python.org/dev/using/configure.html>`_.
+   the `Python configure docs <https://docs.python.org/dev/using/configure.html>`__.
 
 .. _unix-compiling:
 
@@ -822,7 +822,7 @@ some of CPython's modules (for example, ``zlib``).
    Note that Debian 12 and Ubuntu 24.04 do not have the ``libmpdec-dev``
    package.  You can safely remove it from the install list above and the
    Python build will use a bundled version.  But we recommend using the system
-   `libmpdec <https://www.bytereef.org/mpdecimal/doc/libmpdec/>`_ library.
+   `libmpdec <https://www.bytereef.org/mpdecimal/doc/libmpdec/>`__ library.
    Either build it from sources or install this package from
    https://deb.sury.org.
 
@@ -889,7 +889,7 @@ some of CPython's modules (for example, ``zlib``).
                            --with-dbmliborder=gdbm:ndbm
 
          (``--with-dbmliborder`` is a workaround for a Homebrew-specific change
-         to ``gdbm``; see `#89452 <https://github.com/python/cpython/issues/89452>`_
+         to ``gdbm``; see `#89452 <https://github.com/python/cpython/issues/89452>`__
          for details.)
 
    .. tab:: MacPorts
@@ -928,7 +928,7 @@ some of CPython's modules (for example, ``zlib``).
 
    For more details on various options and considerations for building, refer
    to the `macOS README
-   <https://github.com/python/cpython/blob/main/Mac/README.rst>`_.
+   <https://github.com/python/cpython/blob/main/Mac/README.rst>`__.
 
    .. note:: While you need a C compiler to build CPython, you don't need any
       knowledge of the C language to contribute!  Vast areas of CPython are
@@ -981,7 +981,7 @@ If a change is made to Python which relies on some POSIX system-specific
 functionality (such as using a new system call), it is necessary to update the
 :cpy-file:`configure` script to test for availability of the functionality.
 Python's :file:`configure` script is generated from :cpy-file:`configure.ac`
-using `GNU Autoconf <https://www.gnu.org/software/autoconf/>`_.
+using `GNU Autoconf <https://www.gnu.org/software/autoconf/>`__.
 
 After editing :file:`configure.ac`, run ``make regen-configure`` to generate
 :file:`configure`, :cpy-file:`pyconfig.h.in`, and :cpy-file:`aclocal.m4`.
@@ -1185,13 +1185,13 @@ What is GitHub Codespaces?
 
 If you'd like to start contributing to CPython without needing to set up a local
 developer environment, you can use
-`GitHub Codespaces <https://github.com/features/codespaces>`_.
+`GitHub Codespaces <https://github.com/features/codespaces>`__.
 Codespaces is a cloud-based development environment offered by GitHub that
 allows developers to write, build, test, and debug code directly within their
 web browser or in Visual Studio Code (VS Code).
 
 To help you get started, CPython contains a
-`devcontainer folder <https://github.com/python/cpython/tree/main/.devcontainer>`_
+`devcontainer folder <https://github.com/python/cpython/tree/main/.devcontainer>`__
 with a JSON configuration file that provides consistent and versioned codespace
 configurations for all users of the project. It also contains a Dockerfile that
 allows you to set up the same environment but locally in a Docker container if
@@ -1204,7 +1204,7 @@ Create a CPython codespace
 
 Here are the basic steps needed to contribute a pull request using Codespaces.
 You first need to navigate to the
-`CPython repo <https://github.com/python/cpython>`_ hosted on GitHub.
+`CPython repo <https://github.com/python/cpython>`__ hosted on GitHub.
 
 Then you will need to:
 
@@ -1229,7 +1229,7 @@ Then you will need to:
 2. A screen should appear that lets you know your codespace is being set up.
    (Note: Since the CPython devcontainer is provided, codespaces will use the
    configuration it specifies.)
-3. A `web version of VS Code <https://vscode.dev/>`_ will open inside your web
+3. A `web version of VS Code <https://vscode.dev/>`__ will open inside your web
    browser, already linked up with your code and a terminal to the remote
    codespace where CPython and its documentation have already been built.
 4. Use the terminal with the usual Git commands to create a new branch, commit

--- a/index.rst
+++ b/index.rst
@@ -31,7 +31,7 @@ instructions please see the :ref:`setup guide <setup>`.
 1. Install and set up :ref:`Git <vcsetup>` and other dependencies
    (see the :ref:`Git Setup <setup>` page for detailed information).
 
-2. Fork `the CPython repository <https://github.com/python/cpython>`_
+2. Fork `the CPython repository <https://github.com/python/cpython>`__
    to your GitHub account and :ref:`get the source code <checkout>` using::
 
       git clone https://github.com/<your_username>/cpython
@@ -91,7 +91,7 @@ instructions please see the :ref:`setup guide <setup>`.
       git checkout -b fix-issue-12345 main
 
    If an issue does not already exist, please `create it
-   <https://github.com/python/cpython/issues>`_.  Trivial issues (for example, typo fixes) do
+   <https://github.com/python/cpython/issues>`__.  Trivial issues (for example, typo fixes) do
    not require any issue to be created.
 
 6. Once you fixed the issue, run the tests, and the patchcheck:
@@ -125,10 +125,10 @@ instructions please see the :ref:`setup guide <setup>`.
       gh-12345: Fix some bug in spam module
 
 8. Add a News entry into the ``Misc/NEWS.d`` directory as individual file. The
-   news entry can be created by using `blurb-it <https://blurb-it.herokuapp.com/>`_,
+   news entry can be created by using `blurb-it <https://blurb-it.herokuapp.com/>`__,
    or the :pypi:`blurb` tool and its ``blurb add``
    command. Please read more about ``blurb`` in its
-   `repository <https://github.com/python/blurb>`_.
+   `repository <https://github.com/python/blurb>`__.
 
 .. note::
 
@@ -159,12 +159,12 @@ this guide, then the `Core Python Mentorship`_ group is available to help guide 
 contributors through the process.
 
 A number of individuals from the Python community have contributed to a series
-of excellent guides at `Open Source Guides <https://opensource.guide/>`_.
+of excellent guides at `Open Source Guides <https://opensource.guide/>`__.
 
 Core developers and contributors alike will find the following guides useful:
 
-* `How to Contribute to Open Source <https://opensource.guide/how-to-contribute/>`_
-* `Building Welcoming Communities <https://opensource.guide/building-community/>`_
+* `How to Contribute to Open Source <https://opensource.guide/how-to-contribute/>`__
+* `Building Welcoming Communities <https://opensource.guide/building-community/>`__
 
 Guide for contributing to Python:
 
@@ -251,8 +251,8 @@ Key resources
 * `Buildbot status`_
 * Source code
 
-  * `Browse online <https://github.com/python/cpython/>`_
-  * `Snapshot of the *main* branch <https://github.com/python/cpython/archive/main.zip>`_
+  * `Browse online <https://github.com/python/cpython/>`__
+  * `Snapshot of the *main* branch <https://github.com/python/cpython/archive/main.zip>`__
 
 * PEPs_ (Python Enhancement Proposals)
 * :ref:`help`
@@ -279,7 +279,7 @@ Additional resources
   * :ref:`clang`
   * Various tools with configuration files as found in the `Misc directory`_
   * Information about editors and their configurations can be found in the
-    `wiki <https://wiki.python.org/moin/PythonEditors>`_
+    `wiki <https://wiki.python.org/moin/PythonEditors>`__
 
 * `python.org maintenance`_
 * :ref:`Search this guide <search>`

--- a/internals/compiler.rst
+++ b/internals/compiler.rst
@@ -7,4 +7,4 @@ Compiler design
 .. highlight:: none
 
 This document is now part of the
-`CPython Internals Docs <https://github.com/python/cpython/blob/main/InternalDocs/compiler.md>`_.
+`CPython Internals Docs <https://github.com/python/cpython/blob/main/InternalDocs/compiler.md>`__.

--- a/internals/garbage-collector.rst
+++ b/internals/garbage-collector.rst
@@ -9,4 +9,4 @@ Garbage collector design
 .. highlight:: none
 
 This document is now part of the
-`CPython Internals Docs <https://github.com/python/cpython/blob/main/InternalDocs/garbage_collector.md>`_.
+`CPython Internals Docs <https://github.com/python/cpython/blob/main/InternalDocs/garbage_collector.md>`__.

--- a/internals/interpreter.rst
+++ b/internals/interpreter.rst
@@ -5,4 +5,4 @@ The bytecode interpreter
 ========================
 
 This document is now part of the
-`CPython Internals Docs <https://github.com/python/cpython/blob/main/InternalDocs/interpreter.md>`_.
+`CPython Internals Docs <https://github.com/python/cpython/blob/main/InternalDocs/interpreter.md>`__.

--- a/internals/parser.rst
+++ b/internals/parser.rst
@@ -7,4 +7,4 @@ Guide to the parser
 .. highlight:: none
 
 This document is now part of the
-`CPython Internals Docs <https://github.com/python/cpython/blob/main/InternalDocs/parser.md>`_.
+`CPython Internals Docs <https://github.com/python/cpython/blob/main/InternalDocs/parser.md>`__.

--- a/testing/buildbots.rst
+++ b/testing/buildbots.rst
@@ -11,7 +11,7 @@ branches <devcycle>`, Python has a set of dedicated machines (called *buildbots*
 or *build workers*) used for continuous integration.  They span a number of
 hardware/operating system combinations.  Furthermore, each machine hosts
 several *builders*, one per active branch: when a new change is pushed
-to this branch on the public `GitHub repository <https://github.com/python/cpython>`_, all corresponding builders
+to this branch on the public `GitHub repository <https://github.com/python/cpython>`__, all corresponding builders
 will schedule a new build to be run as soon as possible.
 
 The build steps run by the buildbots are the following:

--- a/testing/coverage.rst
+++ b/testing/coverage.rst
@@ -127,7 +127,7 @@ to install coverage.
 
 You can now use python without the ./ for the rest of these instructions, as
 long as your venv is activated. For more info on venv see `Virtual Environment
-<https://docs.python.org/3/tutorial/venv.html>`_ documentation.
+<https://docs.python.org/3/tutorial/venv.html>`__ documentation.
 
 If this does not work for you for some reason, you should try using the
 in-development version of coverage.py to see if it has been updated as needed.

--- a/testing/new-buildbot-worker.rst
+++ b/testing/new-buildbot-worker.rst
@@ -20,12 +20,12 @@ to go about setting up a buildbot worker, getting it added, and some hints about
 buildbot maintenance.
 
 Anyone running a buildbot that is part of the fleet should subscribe to the
-`python-buildbots <https://mail.python.org/mailman3/lists/python-buildbots.python.org/>`_
+`python-buildbots <https://mail.python.org/mailman3/lists/python-buildbots.python.org/>`__
 mailing list.  This mailing list is also the place to contact if you want to
 contribute a buildbot but have questions.
 
 As for what kind of buildbot to run...take a look at our `current fleet
-<https://buildbot.python.org/all/>`_.  Pretty much anything that isn't
+<https://buildbot.python.org/all/>`__.  Pretty much anything that isn't
 on that list would be interesting: different Linux/Unix distributions,
 different versions of the various OSes, other OSes if you or someone are
 prepared to make the test suite actually pass on that new OS.  Even if you only
@@ -47,7 +47,7 @@ compiled python.
 
 In order to set up the buildbot software, you will need to obtain an identifier
 and password for your worker so it can join the fleet.  Open an issue in the
-`configuration repository <https://github.com/python/buildmaster-config/issues/new/choose>`_
+`configuration repository <https://github.com/python/buildmaster-config/issues/new/choose>`__
 to discuss adding your worker and to obtain the
 needed workername and password.  You can do some of the steps that follow
 before having the credentials, but it is easiest to have them before
@@ -60,7 +60,7 @@ Setting up the buildbot worker
 Conventional always-on machines
 -------------------------------
 
-You need a recent version of the `buildbot <https://buildbot.net/>`_ software,
+You need a recent version of the `buildbot <https://buildbot.net/>`__ software,
 and you will probably want a separate 'buildbot' user to run the buildbot
 software.  You may also want to set the buildbot up using a virtual
 environment, depending on how you manage your system.  We won't cover how to that
@@ -103,7 +103,7 @@ can put the ``buildarea`` wherever you want to)::
 :file:`Scripts` directory of your Python installation.)
 
 On Windows, `the maximum length for a path is limited
-<https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation>`_.
+<https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation>`__.
 This might cause some tests to fail, unless long paths support is enabled.
 
 Use this PowerShell command to check whether long paths are enabled::
@@ -254,7 +254,7 @@ For Windows:
 
 * Alternatively (note: don't do both!), set up the worker
   service as described in the `buildbot documentation
-  <https://docs.buildbot.net/current/manual/installation/misc.html#launching-worker-as-windows-service>`_.
+  <https://docs.buildbot.net/current/manual/installation/misc.html#launching-worker-as-windows-service>`__.
 
 To start the worker running for your initial testing, you can do::
 
@@ -262,7 +262,7 @@ To start the worker running for your initial testing, you can do::
 
 Then you can either wait for someone to make a commit, or you can pick a
 builder associated with your worker from the `list of builders
-<https://buildbot.python.org/all/>`_ and force a build.
+<https://buildbot.python.org/all/>`__ and force a build.
 
 In any case you should initially monitor builds on your builders to make sure
 the tests are passing and to resolve any platform issues that may be revealed
@@ -273,7 +273,7 @@ idea.
 .. note::
    If your buildbot worker is disconnecting regularly, it may be a symptom of the
    default ``keepalive`` value (``600`` for 10 minutes) being `set
-   <https://docs.buildbot.net/latest/manual/installation/worker.html#cmdoption-buildbot-worker-create-worker-keepalive>`_
+   <https://docs.buildbot.net/latest/manual/installation/worker.html#cmdoption-buildbot-worker-create-worker-keepalive>`__
    too high. You can change it to a lower value (for example, ``180`` for 3 minutes)
    in the ``buildbot.tac`` file found in your build area.
 
@@ -282,7 +282,7 @@ Latent workers
 --------------
 
 We also support running `latent workers
-<https://docs.buildbot.net/current/manual/configuration/workers.html#latent-workers>`_
+<https://docs.buildbot.net/current/manual/configuration/workers.html#latent-workers>`__
 on the AWS EC2 service.  To set up such a worker:
 
 * Start an instance of your chosen base AMI and set it up as a
@@ -305,7 +305,7 @@ instance(s), so it is recommended to periodically check and make sure
 there are no "zombie" instances running on your account, created by the
 buildbot master.  Also, if you notice that your worker seems to have been
 down for an unexpectedly long time, please ping the `python-buildbots
-<https://mail.python.org/mailman3/lists/python-buildbots.python.org/>`_ list to
+<https://mail.python.org/mailman3/lists/python-buildbots.python.org/>`__ list to
 request that the master be restarted.
 
 Latent workers should also be updated periodically to include operating system
@@ -390,7 +390,7 @@ Required resources
 ==================
 
 Based on the last time we did a `survey
-<https://mail.python.org/pipermail/python-dev/2012-March/117978.html>`_ on
+<https://mail.python.org/pipermail/python-dev/2012-March/117978.html>`__ on
 buildbot requirements, the recommended resource allocations for a python
 buildbot are at least:
 
@@ -408,7 +408,7 @@ Security considerations
 =======================
 
 We only allow builds to be triggered against commits to the
-`CPython repository on GitHub <https://github.com/python/cpython>`_.
+`CPython repository on GitHub <https://github.com/python/cpython>`__.
 This means that the code your buildbot will run will have been vetted by a committer.
 However, mistakes and bugs happen, as could a compromise, so keep this in mind when
 siting your buildbot on your network and establishing the security around it.
@@ -427,7 +427,7 @@ VM setup.  But if you are confident in your setup, we'd love to have a buildbot
 that runs python as root.
 
 Note that the above is a summary of a `discussion
-<https://mail.python.org/pipermail/python-dev/2011-October/113935.html>`_ on
+<https://mail.python.org/pipermail/python-dev/2011-October/113935.html>`__ on
 python-dev about buildbot security that includes examples of the tests for
 which privilege matters.  There was no final consensus, but the information is
 useful as a point of reference.

--- a/testing/run-write-tests.rst
+++ b/testing/run-write-tests.rst
@@ -286,7 +286,7 @@ Benchmarks
 
 Benchmarking is useful to test that a change does not degrade performance.
 
-`The Python Benchmark Suite <https://github.com/python/pyperformance>`_
+`The Python Benchmark Suite <https://github.com/python/pyperformance>`__
 has a collection of benchmarks for all Python implementations. Documentation
 about running the benchmarks is in the `README.txt
-<https://github.com/python/pyperformance/blob/main/README.rst>`_ of the repo.
+<https://github.com/python/pyperformance/blob/main/README.rst>`__ of the repo.

--- a/triage/github-bpo-faq.rst
+++ b/triage/github-bpo-faq.rst
@@ -16,7 +16,7 @@ How to format my comments nicely?
 =================================
 
 There is a wonderful `beginner guide to writing and formatting on GitHub
-<https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github>`_.
+<https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github>`__.
 Highly recommended.
 
 One pro-tip we can sell you right here is that if you want to paste
@@ -43,7 +43,7 @@ Use Markdown links. If you link to the default GitHub path, the file
 will link to the latest current version on the given branch.
 
 You can get a permanent link to a given revision of a given file by
-`pressing "y" <https://docs.github.com/en/repositories/working-with-files/using-files/getting-permanent-links-to-files>`_.
+`pressing "y" <https://docs.github.com/en/repositories/working-with-files/using-files/getting-permanent-links-to-files>`__.
 
 How to do advanced searches?
 ============================
@@ -80,7 +80,7 @@ Add a checkbox list like this in the issue description::
 then those will become sub-tasks on the given issue. Moreover, GitHub will
 automatically mark a task as complete if the other referenced issue is
 closed. More details in the `official GitHub documentation
-<https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/about-task-lists>`_.
+<https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/about-task-lists>`__.
 
 What on earth is a "mannequin"?
 ===============================
@@ -88,7 +88,7 @@ What on earth is a "mannequin"?
 For issues migrated to GitHub from `bpo`_ where the authors or commenters
 are not core developers, we opted not to link to their GitHub accounts
 directly. Users not in the `python organization on GitHub
-<https://github.com/orgs/python/people>`_ might not like comments to
+<https://github.com/orgs/python/people>`__ might not like comments to
 appear under their name from an automated import.  Others never linked GitHub on
 `bpo`_ in the first place so linking their account, if any, would be impossible.
 

--- a/triage/labels.rst
+++ b/triage/labels.rst
@@ -9,7 +9,7 @@ Triagers, core developers and bots can add labels on GitHub
 to categorize issues and pull requests.
 Many labels are shared for both use cases, while some are dedicated
 only to one. Below is a possibly inexhaustive list, but it should get
-you going. For a full list, see `here <https://github.com/python/cpython/issues/labels>`_.
+you going. For a full list, see `here <https://github.com/python/cpython/issues/labels>`__.
 
 
 .. _general-purpose-labels:
@@ -73,7 +73,7 @@ we don't have a dedicated Unix label.
 
 Use the :gh-label:`OS-unsupported` label for issues on platforms outside the
 support tiers defined in :pep:`11`. Applying this label adds the issue to
-`a GitHub project <https://github.com/orgs/python/projects/27/views/1>`_ where
+`a GitHub project <https://github.com/orgs/python/projects/27/views/1>`__ where
 it can be categorized further.
 See also the :ref:`Platform experts list <platform-experts>`.
 
@@ -92,7 +92,7 @@ they are encouraged to subscribe to them.  Depending on the label,
 this might also automatically add the issue to a GitHub project.
 
 You can see the `full list of topic labels on GitHub
-<https://github.com/python/cpython/labels?q=topic>`_.
+<https://github.com/python/cpython/labels?q=topic>`__.
 
 
 .. _Version labels:

--- a/triage/triage-team.rst
+++ b/triage/triage-team.rst
@@ -86,14 +86,14 @@ Any existing active contributor to the Python repository on GitHub can
 transition into becoming a Python triager. They can request this to any core
 developer, either confidentially via a DM in Discourse, or
 publicly by opening an `issue in the core-workflow repository
-<https://github.com/python/core-workflow/issues/new?template=triage_membership.md>`_.
+<https://github.com/python/core-workflow/issues/new?template=triage_membership.md>`__.
 If the core developer decides you are ready to gain the extra privileges on the
 tracker, they will ask a :ref:`Python organization admin <current owners>`
 to invite you to the Python organisation, and then  act as a mentor to you until
 you are ready to do things entirely on your own.
 
 For every new triager, it would be great to announce them in the
-`Committers category <https://discuss.python.org/c/committers/5>`_
-on the `Python Discourse <https://discuss.python.org/>`_
+`Committers category <https://discuss.python.org/c/committers/5>`__
+on the `Python Discourse <https://discuss.python.org/>`__
 (`example announcement
 <https://discuss.python.org/t/abhilash-raj-has-been-granted-triage-role-on-github/2089>`__).

--- a/versions.rst
+++ b/versions.rst
@@ -7,14 +7,14 @@ Status of Python versions
 
 The ``main`` branch is currently the future Python |main_version|, and is the only
 branch that accepts new features.  The latest release for each Python
-version can be found on the `download page <https://www.python.org/downloads/>`_.
+version can be found on the `download page <https://www.python.org/downloads/>`__.
 
 
 .. raw:: html
    :file: include/release-cycle.svg
 
 (See :ref:`below <full-chart>` for a chart with older versions.
-Another useful visualization is `endoflife.date/python <https://endoflife.date/python>`_.)
+Another useful visualization is `endoflife.date/python <https://endoflife.date/python>`__.)
 
 
 Supported versions


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

To avoid potential clashes in target names, let's recommend "anonymous hyperlinks", which use a double trailing underscore instead of a single underscore.

Re: https://github.com/python/cpython/pull/142057#discussion_r2572910090

---

Not in this PR, updating all the other hyperlinks in the devguide would look like this: https://github.com/hugovk/devguide/commit/072c3da9e4abe7b5d33f58ac098ebf74f90baf1f

Worth including or not?

<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1709.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->