### PR TITLE
Replace deprecated workflow with RtD app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ sphinx-notfound-page>=1.0.0
 sphinx_copybutton>=0.3.3
 sphinxext-opengraph>=0.13.0
 sphinxext-rediraffe
-Sphinx>=8.2.3
+Sphinx~=8.2.3


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

For https://github.com/python/core-workflow/issues/587.

This workflow is deprecated, and uses the `pull_request_target` target which can be insecure. 

Let's test replacing it with the Read the Docs app. If it goes well, we can replace it in the other repos.

@python/organization-owners I've sent a request to install the RtD app for just this repo, please could you enable it?


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1713.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->