### PR TITLE
Fix SVG paths in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,9 @@ include/branches.csv:
 # Other files are generated together with branches.csv
 include/end-of-life.csv: include/branches.csv
 	@:
-include/release-cycle-all.svg: include/branches.csv
+_static/release-cycle-all.svg: include/branches.csv
 	@:
-include/release-cycle.svg: include/branches.csv
+_static/release-cycle.svg: include/branches.csv
 	@:
 
 # Catch-all target: route all unknown targets to Sphinx using the new


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Merging https://github.com/python/devguide/pull/1708 broke `make html`: 

```
Run make html
make: *** No rule to make target 'html'.  Stop.
```

https://github.com/python/devguide/actions/runs/20598038153/job/59156872074

I'm not sure why that PR passed: https://github.com/python/devguide/actions/runs/19898283190/job/57034529183?pr=1708

Anyway, here's a fix: update the other paths to point to the new SVGs location.