### PR TITLE
Add free-threaded to style guide (#1353)

### DIFF
--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -77,12 +77,12 @@ C API
   to write extension modules. All caps and unhyphenated.
 
 CPU
-    Central processing unit. No need to spell out.
+   Central processing unit. No need to spell out.
 
 free-threaded
-    The preferred term for the build mode that makes the global interpreter
-    lock (GIL) optional (per :pep:`703`). Avoid using "No-GIL" to prevent
-    double negatives (for example, "non-no-GIL").
+   The preferred term for the build mode that makes the global interpreter
+   lock (GIL) optional (per :pep:`703`). Avoid using "No-GIL" to avoid
+   double negatives (for example, "non-no-GIL").
 
 POSIX
    The name assigned to a particular group of standards. This is always

--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -82,7 +82,10 @@ CPU
 POSIX
    The name assigned to a particular group of standards. This is always
    uppercase.
-
+free-threaded
+    The preferred term for the build mode that makes the Global Interpreter
+    Lock (GIL) optional (per PEP 703). Avoid using "No-GIL" to prevent
+    double-negatives (e.g., "non-no-GIL").
 Python
    The name of our favorite programming language is always capitalized.
 

--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -83,9 +83,9 @@ POSIX
    The name assigned to a particular group of standards. This is always
    uppercase.
 free-threaded
-    The preferred term for the build mode that makes the Global Interpreter
-    Lock (GIL) optional (per PEP 703). Avoid using "No-GIL" to prevent
-    double-negatives (e.g., "non-no-GIL").
+    The preferred term for the build mode that makes the global interpreter
+    lock (GIL) optional (per :pep:`703`). Avoid using "no-GIL" to prevent
+    double negatives (for example, "non-no-GIL").
 Python
    The name of our favorite programming language is always capitalized.
 

--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -1,4 +1,4 @@
-.. _style-guide:
+﻿.. _style-guide:
 
 ===========
 Style guide
@@ -81,22 +81,13 @@ CPU
 
 free-threaded
     The preferred term for the build mode that makes the global interpreter
-    lock (GIL) optional (per :pep:`703`). Avoid using "no-gil" to prevent
+    lock (GIL) optional (per :pep:`703`). Avoid using "No-GIL" to prevent
     double negatives (for example, "non-no-GIL").
 
 POSIX
-<<<<<<< HEAD
    The name assigned to a particular group of standards. This is always
    uppercase.
-free-threaded
-    The preferred term for the build mode that makes the global interpreter
-    lock (GIL) optional (per :pep:`703`). Avoid using "no-GIL" to prevent
-    double negatives (for example, "non-no-GIL").
-=======
-    The name assigned to a particular group of standards. This is always
-    uppercase.
 
->>>>>>> a22760b (Final cleanup: alphabetical order and whitespace)
 Python
    The name of our favorite programming language is always capitalized.
 

--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -77,15 +77,26 @@ C API
   to write extension modules. All caps and unhyphenated.
 
 CPU
-   Central processing unit. No need to spell out.
+    Central processing unit. No need to spell out.
+
+free-threaded
+    The preferred term for the build mode that makes the global interpreter
+    lock (GIL) optional (per :pep:`703`). Avoid using "no-gil" to prevent
+    double negatives (for example, "non-no-GIL").
 
 POSIX
+<<<<<<< HEAD
    The name assigned to a particular group of standards. This is always
    uppercase.
 free-threaded
     The preferred term for the build mode that makes the global interpreter
     lock (GIL) optional (per :pep:`703`). Avoid using "no-GIL" to prevent
     double negatives (for example, "non-no-GIL").
+=======
+    The name assigned to a particular group of standards. This is always
+    uppercase.
+
+>>>>>>> a22760b (Final cleanup: alphabetical order and whitespace)
 Python
    The name of our favorite programming language is always capitalized.
 

--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -1,4 +1,3 @@
-﻿.. _style-guide:
 
 ===========
 Style guide

--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -1,3 +1,4 @@
+.. _style-guide:
 
 ===========
 Style guide


### PR DESCRIPTION
Closes #1353
Added 'free-threaded' to the style guide as the preferred term for PEP 703 to avoid double-negatives.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
