### PR TITLE
Merge macOS "Python 3.13+" and "Python 3.11-3.12" tabs in "Setup and building" guide

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -858,18 +858,9 @@ some of CPython's modules (for example, ``zlib``).
 
          $ brew install pkg-config openssl@3 xz gdbm tcl-tk mpdecimal zstd
 
-      .. tab:: Python 3.13+
+      .. tab:: Python 3.11+
 
-         For Python 3.13 and newer::
-
-            $ GDBM_CFLAGS="-I$(brew --prefix gdbm)/include" \
-               GDBM_LIBS="-L$(brew --prefix gdbm)/lib -lgdbm" \
-               ./configure --with-pydebug \
-                           --with-openssl="$(brew --prefix openssl@3)"
-
-      .. tab:: Python 3.11-3.12
-
-         For Python 3.11 and 3.12::
+         For Python 3.11 and newer::
 
             $ GDBM_CFLAGS="-I$(brew --prefix gdbm)/include" \
                GDBM_LIBS="-L$(brew --prefix gdbm)/lib -lgdbm" \


### PR DESCRIPTION
This change merges the tabs "Python 3.13+" and "Python 3.11-3.12" in the "Setup and building" guide (Installing dependencies) for macOS to "Python 3.11+". This is done because both tabs have the same content.

Fixes: #1725

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
