### PR TITLE
Docs: Add troubleshooting for OpenSSL build errors

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -198,6 +198,16 @@ More flags are available to ``configure``, but this is the minimum you should
 do to get a pydebug build of CPython.
 
 .. note::
+   **Could not build the ssl module!**
+
+   If the build fails with an error stating ``Python requires a OpenSSL 1.1.1 or newer``
+   despite having it installed, try using the following configuration flag:
+
+   .. code-block:: bash
+
+      ./configure --with-openssl-rpath=auto
+
+.. note::
    You might need to run ``make clean`` before or after re-running ``configure``
    in a particular build directory.
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -198,10 +198,10 @@ More flags are available to ``configure``, but this is the minimum you should
 do to get a pydebug build of CPython.
 
 .. note::
-   **Could not build the ssl module!**
+   **Could not build the ssl module**
 
-   If the build fails with an error stating ``Python requires a OpenSSL 1.1.1 or newer``
-   despite having it installed, try using the following configuration flag:
+   If the build fails with an error stating ``Python requires OpenSSL 1.1.1 or newer``
+   when OpenSSL is installed, try using the following configuration flag:
 
    .. code-block:: bash
 


### PR DESCRIPTION
This PR adds documentation for the --with-openssl-rpath=auto flag to the Unix build instructions in setup-building.rst.

Technical Context
On several modern Linux distributions and WSL environments, the CPython ./configure script can fail to link the SSL module correctly, even when a compatible OpenSSL version is present. This typically results in the error: Could not build the ssl module! Python requires a OpenSSL 1.1.1 or newer.

Using the --with-openssl-rpath=auto flag ensures the build system correctly identifies the runtime search path for OpenSSL, allowing the _ssl extension to build successfully.

Related Issue
Fixes #1727
