### PR TITLE
Removed `edelsohn` as AIX expert

### DIFF
--- a/core-team/experts.rst
+++ b/core-team/experts.rst
@@ -282,7 +282,7 @@ for “their” platform as a third-party project.
 ===================   ===========
 Platform              Maintainers
 ===================   ===========
-AIX                   edelsohn, ayappanec
+AIX                   ayappanec
 Android               mhsmith
 Cygwin                jlt63^, stutzbach^
 Emscripten            hoodmane, pmp-p, rdb, rth, ryanking13


### PR DESCRIPTION
As requested in https://github.com/python/buildmaster-config/pull/663#issuecomment-3917109664.