### PR TITLE
Add workflow to check for `DO-NOT-MERGE` label

### DIFF
--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -1,0 +1,23 @@
+name: Check labels
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+jobs:
+  label-dnm:
+    name: DO-NOT-MERGE
+    if: github.repository_owner == 'python'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    timeout-minutes: 10
+
+    steps:
+      - name: Check there's no DO-NOT-MERGE
+        uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 0
+          labels: |
+            DO-NOT-MERGE


### PR DESCRIPTION
I noticed this recently when going through the labels. I copied the workflow from [CPython](https://github.com/python/cpython/blob/main/.github/workflows/require-pr-label.yml).
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
