### PR TITLE
Add PSRT emeritus table

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # https://git-scm.com/docs/gitignore#_pattern_format
 
 # PSRT member list owned by PSRT admins.
-developer-workflow/psrt.csv   @warsaw @ewdurbin @ned-deily @sethmlarson
+developer-workflow/psrt*.csv   @warsaw @ewdurbin @ned-deily @sethmlarson

--- a/developer-workflow/psrt.rst
+++ b/developer-workflow/psrt.rst
@@ -15,6 +15,8 @@ list of members and admins, included in the table below:
    :file: psrt.csv
    :encoding: "utf-8"
 
+See also the :ref:`members emeritus list <psrt-members-emeritus>`.
+
 How can I join the PSRT?
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -268,3 +270,15 @@ please feel free to adapt them as needed for the current context.
 
    * https://www.cve.org/CVERecord?id={CVE-YYYY-XXXX}
    * {pull request URL}
+
+.. _psrt-members-emeritus:
+
+Members emeritus
+----------------
+
+Members who have previously served on the PSRT.
+
+.. csv-table::
+   :header: "Name", "GitHub username", "Notes"
+   :file: psrt-emeritus.csv
+   :encoding: "utf-8"


### PR DESCRIPTION
We recently moved retired experts to a separate table ([f2d8b2e64e40e](https://github.com/python/devguide/commit/f2d8b2e64e40e4b38a0a3ed867c4fc2c387cf443)), this PR proposes we do the same for PSRT members. (Seth will take care of populating the table.)
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
