### PR TITLE
Fill PSRT emeritus list

### DIFF
--- a/developer-workflow/psrt-emeritus.csv
+++ b/developer-workflow/psrt-emeritus.csv
@@ -1,0 +1,10 @@
+Anthony Baxter,,Release Manager
+Christian Heimes,tiran,
+Georg Brandl,birkenfeld,
+Huzaifa Sidhpurwala,,
+Jesse Noller,,
+Kushal Das,kushaldas,
+Mark Hammond,mhammond,
+Nam Nguyen,,
+Neal Norwitz,,
+Trent Mick,,


### PR DESCRIPTION
Follow-up from https://github.com/python/devguide/pull/1767 by @StanFromIreland. Many accounts didn't make the GitHub migration, so don't have a GitHub username that I was able to verify.