### PR TITLE
Fix unsupported versions table include

### DIFF
--- a/versions.rst
+++ b/versions.rst
@@ -36,7 +36,7 @@ Unsupported versions
 .. csv-table::
    :header-rows: 1
    :width: 100%
-   :file: _static/end-of-life.csv
+   :file: include/end-of-life.csv
 
 
 .. _full-chart:

--- a/versions.rst
+++ b/versions.rst
@@ -27,8 +27,6 @@ Dates shown in *italic* are scheduled and can be adjusted.
    :width: 100%
    :file: include/branches.csv
 
-.. Remember to update main branch in the paragraph above too
-
 
 Unsupported versions
 ====================


### PR DESCRIPTION
The "unsupported versions" chart is currently MIA.

If I'm understanding this correctly, https://github.com/python/devguide/pull/1708 accidentally changed the location for the CSV file (1) when only the SVG files were actually moved (2).
1. https://github.com/python/devguide/pull/1708/changes#diff-c723da19c21e67235cf32667679c240c838ee6df048b1073508227fc0d83ec6fL39-R39
2. https://github.com/python/devguide/pull/1708/changes#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R24

The build script still says "`include`", so I've updated the page to use that again.
https://github.com/python/devguide/blob/beb6b6160940b39ab8ceb3933980dbfb80e9ffae/_tools/generate_release_cycle.py#L118
https://github.com/python/devguide/blob/beb6b6160940b39ab8ceb3933980dbfb80e9ffae/_tools/generate_release_cycle.py#L122