### PR TITLE
Add multicultural communication guidelines

### DIFF
--- a/developer-workflow/communication-channels.rst
+++ b/developer-workflow/communication-channels.rst
@@ -33,7 +33,7 @@ feels neutral in one culture can read as blunt or rude in another.
 **Practice active listening.** Try to focus on understanding the message before reacting.
 
 **Confirm understanding.** Ask open-ended questions and paraphrase to avoid
-misunderstandings. If you're unsure what someone meant, ask: "I want to make 
+misunderstandings. If you're unsure what someone meant, ask: "I want to make
 sure I understand: are you saying X?"
 
 **Use translation tools freely.** If English isn't your first language,

--- a/developer-workflow/communication-channels.rst
+++ b/developer-workflow/communication-channels.rst
@@ -22,6 +22,37 @@ in return.
 .. _Diversity Statement: https://www.python.org/psf/diversity/
 
 
+.. _multicultural-communication:
+
+Communicating across cultures and languages
+===========================================
+
+Not every contributor writes English as a first language, and phrasing that
+feels neutral in one culture can read as blunt or rude in another.
+
+**Assume good faith.** If a message feels abrupt, it's probably a language
+barrier or a different communication style rather than rudeness. If you're
+unsure what someone meant, ask: "I want to make sure I understand: are you
+saying X?"
+
+**Use translation tools freely.** If English isn't your first language,
+translation software or AI tools can help you check that your message has the
+tone you intend. Getting the phrasing wrong can make a reasonable point sound
+more aggressive than it is.
+
+**Watch out for rhetorical questions.** They read as hostile in text even when
+that's not the intent at all:
+
+* Instead of "Why do you think it is wrong?!", try "That doesn't sound right
+  to me. Here's why: …"
+* Instead of "Did you even read the docs?", try "The relevant documentation
+  is at …"
+
+**Be patient with newcomers.** If someone doesn't know how things work here,
+point them to the right docs or give them the context they need. Criticism
+without guidance isn't helpful.
+
+
 .. _mailinglists:
 
 Mailing lists

--- a/developer-workflow/communication-channels.rst
+++ b/developer-workflow/communication-channels.rst
@@ -30,13 +30,14 @@ Communicating across cultures and languages
 Not every contributor writes English as a first language, and phrasing that
 feels neutral in one culture can read as blunt or rude in another.
 
-**Assume good faith.** If a message feels abrupt, it's probably a language
-barrier or a different communication style rather than rudeness. If you're
+**Practice active listening.** Try to focus on understanding the message before reacting.
+
+**Confirm Understanding.** Ask open-ended questions and paraphrase to avoid misunderstandings. If you're
 unsure what someone meant, ask: "I want to make sure I understand: are you
 saying X?"
 
 **Use translation tools freely.** If English isn't your first language,
-translation software or AI tools can help you check that your message has the
+translation software or AI tools may help you check that your message has the
 tone you intend. Getting the phrasing wrong can make a reasonable point sound
 more aggressive than it is.
 

--- a/developer-workflow/communication-channels.rst
+++ b/developer-workflow/communication-channels.rst
@@ -32,9 +32,9 @@ feels neutral in one culture can read as blunt or rude in another.
 
 **Practice active listening.** Try to focus on understanding the message before reacting.
 
-**Confirm Understanding.** Ask open-ended questions and paraphrase to avoid misunderstandings. If you're
-unsure what someone meant, ask: "I want to make sure I understand: are you
-saying X?"
+**Confirm understanding.** Ask open-ended questions and paraphrase to avoid
+misunderstandings. If you're unsure what someone meant, ask: "I want to make 
+sure I understand: are you saying X?"
 
 **Use translation tools freely.** If English isn't your first language,
 translation software or AI tools may help you check that your message has the

--- a/triage/issue-tracker.rst
+++ b/triage/issue-tracker.rst
@@ -124,7 +124,8 @@ Disagreement with a resolution on the issue tracker
 
 As humans, we will have differences of opinions from time to time. First and
 foremost, please be respectful that care, thought, and volunteer time went into
-the resolution.
+the resolution. Keep in mind that contributors come from many different cultural
+and linguistic backgrounds; see :ref:`multicultural-communication`.
 
 With this in mind, take some time to consider any comments made in association
 with the resolution of the issue. On reflection, the resolution steps may seem


### PR DESCRIPTION
Add a new section covering good-faith assumptions, use of translation and language tools, collaborative phrasing, and patience/mentoring for contributors communicating across cultural and linguistic backgrounds.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Closes #1447.