### PR TITLE
Add Vietnamese translation details to documentation

### DIFF
--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -121,7 +121,7 @@ For more details about translations and their progress, see
    * - `Vietnamese (vi) <https://docs.python.org/vi/>`__
      - Duc-Tam Nguyen (:github-user:`tamnd`)
      - :github:`GitHub <tamnd/python-docs-vi>`,
-       `Transifex <https://www.transifex.com/>`__
+       `Transifex <tx_>`_
 
 How to get help
 ===============

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -123,6 +123,7 @@ For more details about translations and their progress, see
      - :github:`GitHub <tamnd/python-docs-vi>`,
        `Transifex <tx_>`_
 
+
 How to get help
 ===============
 

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -118,7 +118,7 @@ For more details about translations and their progress, see
      - Dmytro Kazanzhy (:github-user:`kazanzhy`, `email <mailto:dkazanzhy@gmail.com>`__)
      - :github:`GitHub <python/python-docs-uk>`,
        `Transifex <tx_>`_
-   * - `Vietnamese (vi) <https://docs.python.org/vi/>`__
+   * - Vietnamese (vi)
      - Duc-Tam Nguyen (:github-user:`tamnd`)
      - :github:`GitHub <tamnd/python-docs-vi>`,
        `Transifex <tx_>`_

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -118,7 +118,10 @@ For more details about translations and their progress, see
      - Dmytro Kazanzhy (:github-user:`kazanzhy`, `email <mailto:dkazanzhy@gmail.com>`__)
      - :github:`GitHub <python/python-docs-uk>`,
        `Transifex <tx_>`_
-
+   * - `Vietnamese (vi) <https://docs.python.org/vi/>`__
+     - Duc-Tam Nguyen (:github-user:`tamnd`)
+     - :github:`GitHub <tamnd/python-docs-vi>`,
+       `Transifex <https://www.transifex.com/>`__
 
 How to get help
 ===============


### PR DESCRIPTION
I am currently hosting the Vietnamese translation at https://github.com/tamnd/python-docs-vi. Once the project reaches the maturity criteria defined in PEP 545, I am prepared to transfer it to the official `python/python-docs-vi` organization.

The milestones I am working toward are:

- 100% translation of `bugs.html`, including correct links to the language-specific issue tracker (completed)
- 100% translation of the tutorial (currently 3 out of 16 sections)
- 100% translation of `library/functions` (builtins) (currently ~20%)

Progress is ongoing, and I will proceed with the transfer once these requirements are satisfied.
