### PR TITLE
PSRT: Add link to report security issues

### DIFF
--- a/developer-workflow/psrt.rst
+++ b/developer-workflow/psrt.rst
@@ -4,6 +4,8 @@ Python Security Response Team (PSRT)
 The Python Security Response Team (PSRT) is responsible for handling
 vulnerability reports for CPython and pip.
 
+To report security issues: https://www.python.org/dev/security/
+
 Members
 -------
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

https://devguide.python.org/developer-workflow/psrt/ shows up first (for me) in Google for "PSRT".

This page is mostly process info for us.

Let's put a clear link to the page with info about how to report issues.