### PR TITLE
Fix subpixel gap between release cycle mask rects

### DIFF
--- a/_tools/release_cycle_template.svg.jinja
+++ b/_tools/release_cycle_template.svg.jinja
@@ -169,18 +169,18 @@
             fill="black"
         />
         <rect
+            x="{{ legend_width - 1 }}"
+            y="0"
+            width="{{ diagram_width + 1 }}"
+            height="{{ diagram_height }}"
+            fill="white"
+        />
+        <rect
             x="{{ legend_width - right_margin }}"
             y="0"
             width="{{ right_margin }}"
             height="{{ diagram_height }}"
             fill="url(#release-cycle-mask-gradient-{{ id_key }})"
-        />
-        <rect
-            x="{{ legend_width }}"
-            y="0"
-            width="{{ diagram_width }}"
-            height="{{ diagram_height }}"
-            fill="white"
         />
     </mask>
 


### PR DESCRIPTION
Fix subpixel gap by stretching white part by 1 pixel into black area, and moving gradient mask to top in z order

Before:
<img width="256" height="256" alt="www python org_downloads_ (2)" src="https://github.com/user-attachments/assets/7143e3aa-e24c-4cf9-8ff7-e4e47d7df9d3" />

After:
<img width="256" height="256" alt="www python org_downloads_ (1) (1)" src="https://github.com/user-attachments/assets/208e60fc-e49a-4e83-a87e-d137f91cbff7" />


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
