### PR TITLE
Add Chris Eibl to `core-team.csv`

### DIFF
--- a/core-team/core-team.csv
+++ b/core-team/core-team.csv
@@ -1,3 +1,4 @@
+Chris Eibl,chris-eibl,2026-05-10,,
 Stan Ulbrych,StanFromIreland,2026-03-26,,
 Itamar Oren,itamaro,2026-02-16,,
 Emma Smith,emmatyping,2025-07-31,,


### PR DESCRIPTION
Regenerated using `python -m coredev devguide`.
