### PR TITLE
Initial draft of Python 'Security Policy'

### DIFF
--- a/security/index.rst
+++ b/security/index.rst
@@ -7,5 +7,6 @@ Security
 .. toctree::
    :maxdepth: 5
 
+   policy
    psrt
    sbom

--- a/security/policy.rst
+++ b/security/policy.rst
@@ -37,7 +37,8 @@ modifications to files on the target system. We assume that, at the time Python
 is executed, the environment is as intended by the legitimate user, and any
 malicious variation from this cannot be mitigated by Python itself.
 
-Vulnerabilities that affect availability (such as DoS or ReDoS) must be
+Vulnerabilities that affect availability (such as DoS, ReDoS, crashes,
+dead-locks, and resource exhaustion) must be
 triggerable with data inputs that are reasonably sized for the use-case.
 Availability vulnerabilities must also demonstrate an "upward" change in posture
 for the attacker, rather than a "lateral" one.
@@ -87,9 +88,8 @@ be formatted correctly:
   ``1`` if vulnerable and ``0`` if not vulnerable).
 * When reporting large numbers or "batches" of vulnerabilities or
   searching for potential vulnerabilities using an LLM, you as a reporter must
-  verify the validity of all reports prior to submission to the PSRT.
-  PSRT members WILL NOT spend time confirming the validity of reports, only
-  whether a valid bug report is a vulnerability or not.
+  verify the factual validity (such as whether APIs have been hallucinated)
+  of the content in all reports prior to submission to the PSRT.
 * Do not include severity or CVSS information in your initial report,
   this information will be determined by the PSRT.
 * Ideally, include a minimal patch with the mitigation for the report.
@@ -99,6 +99,8 @@ be formatted correctly:
   No PDFs, binaries, notebooks, or other files that cannot be safely reviewed.
   If your proof-of-concept depends on a specially constructed binary file,
   please include a script to construct it rather than the file itself.
+* Proof-of-concept scripts longer than a few lines should be wrapped
+  with ``<detail></detail>`` for better readability.
 * Reports that do not contain a potential security vulnerability (such as spam
   or requesting compliance or due-diligence work)
   will be discarded without a reply.
@@ -119,7 +121,7 @@ Here's what to expect for how a vulnerability report will be handled:
 * If the PSRT determines the report isn't a vulnerability, the issue
   can be opened in the public issue tracker.
 * If the PSRT determines the report is a vulnerability, the PSRT will
-  accept your report and a CVE ID will be assigned by the PSF CNA.
+  accept the report and a CVE ID will be assigned by the PSF CNA.
 * Once a public pull request containing a fix is merged to CPython,
   the advisory and CVE record will be published with attribution.
 

--- a/security/policy.rst
+++ b/security/policy.rst
@@ -5,8 +5,8 @@ Security policy
 :ref:`Python Security Response Team <psrt>` (PSRT) members balance this work against
 many other responsibilities. Please be thoughtful about the time and attention
 your report requires. Repeated failure to respect the security policy will
-result in future reports being rejected or banned from the ``python``
-GitHub organization, regardless of technical merit.
+result in future reports being rejected, or the reporter being banned from the
+``python`` GitHub organization, regardless of technical merit.
 
 What types of bugs are vulnerabilities?
 ---------------------------------------
@@ -39,7 +39,7 @@ malicious variation from this cannot be mitigated by Python itself.
 
 Vulnerabilities that affect availability (such as DoS, ReDoS, crashes,
 dead-locks, and resource exhaustion) must be
-triggerable with data inputs that are reasonably sized for the use-case.
+triggerable with data inputs that are reasonably sized for the use case.
 Availability vulnerabilities must also demonstrate an "upward" change in posture
 for the attacker, rather than a "lateral" one.
 This is to avoid handling performance improvements as security vulnerabilities.
@@ -66,7 +66,7 @@ resolved on the ``main`` branch and only requires backporting.
 Sometimes features may be marked as
 "experimental" in Python, even in a stable Python version.
 These features are not eligible for security vulnerabilities.
-Instead open a public GitHub issue.
+Instead, open a public GitHub issue.
 
 If a vulnerability is platform-dependent, check if the platform is
 supported per :pep:`11`.
@@ -84,7 +84,7 @@ be formatted correctly:
   overly long, verbose, or excessive structure (such as headers or tables).
   Ideally reports should be a few sentences describing the vulnerability and
   a proof-of-concept script that reproduces the issue and provides a clear
-  indication whether the vulnerability is still present (such as exiting with
+  indication of whether the vulnerability is still present (such as exiting with
   ``1`` if vulnerable and ``0`` if not vulnerable).
 * When reporting large numbers or "batches" of vulnerabilities or
   searching for potential vulnerabilities using an LLM, you as a reporter must
@@ -120,8 +120,8 @@ not sure where to send your report, send an email to
 Here's what to expect for how a vulnerability report will be handled:
 
 * Reporter reports the vulnerability privately to the PSRT.
-* If the PSRT determines the report isn't a vulnerability, the issue
-  can be opened in the public issue tracker.
+* If the PSRT determines the report isn't a vulnerability, the reporter
+   may open a public issue.
 * If the PSRT determines the report is a vulnerability, the PSRT will
   accept the report and a CVE ID will be assigned by the PSF CNA.
 * Once a public pull request containing a fix is merged to CPython,

--- a/security/policy.rst
+++ b/security/policy.rst
@@ -20,8 +20,8 @@ the latter has been considered while determining whether
 to report a bug as a vulnerability.
 
 Vulnerabilities must be exploitable from code, configurations,
-pre-conditions, or deployments that might feasibly exist in
-the real world. For example, a vulnerability only affecting code
+pre-conditions, or deployments that may in the real world.
+For example, a vulnerability only affecting code
 that does not make sense in a production program
 will not be accepted as a vulnerability.
 
@@ -99,11 +99,13 @@ be formatted correctly:
   No PDFs, binaries, notebooks, or other files that cannot be safely reviewed.
   If your proof-of-concept depends on a specially constructed binary file,
   please include a script to construct it rather than the file itself.
-* Proof-of-concept scripts longer than a few lines should be wrapped
-  with ``<detail></detail>`` for better readability.
+* Proof-of-concept scripts longer than a few lines should be wrapped with a
+  `collapsed section`_ using ``<details></details>`` for better readability.
 * Reports that do not contain a potential security vulnerability (such as spam
   or requesting compliance or due-diligence work)
   will be discarded without a reply.
+
+.. _collapsed section: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections
 
 How to submit a vulnerability report?
 -------------------------------------

--- a/security/policy.rst
+++ b/security/policy.rst
@@ -20,7 +20,7 @@ the latter has been considered while determining whether
 to report a bug as a vulnerability.
 
 Vulnerabilities must be exploitable from code, configurations,
-pre-conditions, or deployments that may in the real world.
+pre-conditions, or deployments that may exist in the real world.
 For example, a vulnerability only affecting code
 that does not make sense in a production program
 will not be accepted as a vulnerability.

--- a/security/policy.rst
+++ b/security/policy.rst
@@ -27,9 +27,9 @@ will not be accepted as a vulnerability.
 
 Documented functionality will not be considered a vulnerability.
 For example, :mod:`pickle`, :mod:`marshal`, :mod:`shelve`, :func:`eval`,
-and :func:`exec` are documented to execute arbitrary Python code that is supplied
-as data. The :mod:`ctypes` module is documented to enable modifying arbitrary
-locations in memory.
+and :func:`exec` are documented to execute arbitrary Python code that is
+supplied as data. The :mod:`ctypes` module is documented to enable modifying
+arbitrary locations in memory.
 
 Vulnerabilities must not depend on malicious control of Python's launch
 conditions, including command line arguments, environment variables, or
@@ -53,12 +53,12 @@ What versions of Python accept reports?
 ---------------------------------------
 
 Python accepts vulnerability reports and will
-assign CVE IDs for :ref:`supported Python versions <branchstatus>` that have a status of
-:ref:`"bugfix" or "security" <version-status-key>`. Versions that are not yet
-stable (status of :ref:`"feature" or "prerelease" <version-status-key>`) are not
-eligible for CVE IDs. If the vulnerability only exists in prerelease versions
-(alphas, betas, release candidates), then the issue should be reported as a
-regular bug.
+assign CVE IDs for :ref:`supported Python versions <branchstatus>` that have a
+status of :ref:`"bugfix" or "security" <version-status-key>`. Versions that are
+not yet stable (status of :ref:`"feature" or "prerelease" <version-status-key>`)
+are not eligible for CVE IDs. If the vulnerability only exists in prerelease
+versions (alphas, betas, release candidates), then the issue should be reported
+as a regular bug.
 Prior to submitting a report, check whether the issue has already been
 resolved on the ``main`` branch and only requires backporting.
 
@@ -103,7 +103,6 @@ How to submit a vulnerability report?
 -------------------------------------
 
 Submit all potential security vulnerability reports for CPython
-to GitHub Security Advisories
 by `opening a new ticket <GHSA>`__.
 Do not open a public GitHub issue to report a security vulnerability.
 For all other projects (such as pip, python.org and tools) or if you're
@@ -129,8 +128,8 @@ Code of conduct
 Well-being and safety of the Python Security Response Team members is
 prioritized over the technical merit of vulnerability reports.
 Despite communications being private, vulnerability reporting is subject
-to the `PSF Code of Conduct`_. Violations will be reported to the Code of Conduct
-team with undisclosed vulnerability information removed, if applicable.
+to the `PSF Code of Conduct`_. Violations will be reported to the Code of
+Conduct team with undisclosed vulnerability information removed, if applicable.
 
 .. _GHSA: https://github.com/python/cpython/security/advisories/new
 .. _PSF Code of Conduct: https://policies.python.org/python.org/code-of-conduct/

--- a/security/policy.rst
+++ b/security/policy.rst
@@ -1,5 +1,5 @@
 ===============
-Security Policy
+Security policy
 ===============
 
 Python Security Response Team (PSRT) members balance this work against
@@ -26,8 +26,8 @@ that does not make sense in a production program
 will not be accepted as a vulnerability.
 
 Documented functionality will not be considered a vulnerability.
-For example, :mod:`pickle`, :mod:`marshal`, :mod:`shelve`, :mod:`eval`,
-and :mod:`exec` are documented to execute arbitrary Python code that is supplied
+For example, :mod:`pickle`, :mod:`marshal`, :mod:`shelve`, :func:`eval`,
+and :func:`exec` are documented to execute arbitrary Python code that is supplied
 as data. The :mod:`ctypes` module is documented to enable modifying arbitrary
 locations in memory.
 
@@ -49,13 +49,13 @@ interferes with secure use of the dependency.
 For example, a vulnerability in the bundled copy of zlib in Python is a
 vulnerability in zlib, not Python.
 
-What versions of Python are accepting reports?
-----------------------------------------------
+What versions of Python accept reports?
+---------------------------------------
 
-Python accepts security vulnerabilities and will
-assign CVE IDs for `supported Python versions <branchstatus>`_ that have a status of
-`"bugfix" or "security" <version-status-key>`_. Versions that are not yet
-stable (status of `"feature" or "prerelease" <version-status-key>`_) are not
+Python accepts vulnerability reports and will
+assign CVE IDs for :ref:`supported Python versions <branchstatus>` that have a status of
+:ref:`"bugfix" or "security" <version-status-key>`. Versions that are not yet
+stable (status of :ref:`"feature" or "prerelease" <version-status-key>`) are not
 eligible for CVE IDs. If the vulnerability only exists in prerelease versions
 (alphas, betas, release candidates), then the issue should be reported as a
 regular bug.
@@ -121,10 +121,10 @@ Here's what to expect for how a vulnerability report will be handled:
   the advisory and CVE record will be published with attribution.
 
 For more information about how the PSRT handles vulnerabilities,
-`consult the Python Developer Guide <psrt-vulnerability-process>`__.
+see :ref:`psrt-vulnerability-process`.
 
-PSF Code of Conduct
--------------------
+Code of conduct
+---------------
 
 Well-being and safety of the Python Security Response Team members is
 prioritized over the technical merit of vulnerability reports.

--- a/security/policy.rst
+++ b/security/policy.rst
@@ -2,7 +2,7 @@
 Security policy
 ===============
 
-Python Security Response Team (PSRT) members balance this work against
+:ref:`Python Security Response Team <psrt>` (PSRT) members balance this work against
 many other responsibilities. Please be thoughtful about the time and attention
 your report requires.  Repeated failure to respect the security policy will
 result in future reports being rejected or being banned from the ``python``
@@ -93,8 +93,12 @@ be formatted correctly:
 * Do not include severity or CVSS information in your initial report,
   this information will be determined by the PSRT.
 * Ideally, include a minimal patch with the mitigation for the report.
-* If the vulnerability only affects certain Python versions, optionally
-  include the versions of Python that are affected.
+* Always include the versions of Python that were tested,
+  and indicate which were found to be vulnerable.
+* Submit reports as plain-text only, including attachments.
+  No PDFs, binaries, notebooks, or other files that cannot be safely reviewed.
+  If your proof-of-concept depends on a specially constructed binary file,
+  please include a script to construct it rather than the file itself.
 * Reports that do not contain a potential security vulnerability (such as spam
   or requesting compliance or due-diligence work)
   will be discarded without a reply.
@@ -140,8 +144,8 @@ CVE Numbering Authority (CNA)
 The Python and pip projects are scoped under the
 `Python Software Foundation CVE Numbering Authority <CNA>`__
 (CNA). This means you must submit all security
-vulnerability reports to the PSRT to receive
-a CVE ID for Python or pip. To reach the PSF
+vulnerability reports to the PSRT for a CVE ID
+to be issued for Python or pip. To reach the PSF
 CNA contact directly, send an email to
 `cna@python.org <mailto:cna@python.org>`__.
 

--- a/security/policy.rst
+++ b/security/policy.rst
@@ -147,4 +147,3 @@ CNA contact directly, send an email to
 `cna@python.org <mailto:cna@python.org>`__.
 
 .. _CNA: https://www.python.org/cve-numbering-authority/
-

--- a/security/policy.rst
+++ b/security/policy.rst
@@ -2,17 +2,20 @@
 Security policy
 ===============
 
-:ref:`Python Security Response Team <psrt>` (PSRT) members balance this work against
-many other responsibilities. Please be thoughtful about the time and attention
-your report requires. Repeated failure to respect the security policy will
-result in future reports being rejected, or the reporter being banned from the
-``python`` GitHub organization, regardless of technical merit.
+.. important::
+
+   :ref:`Python Security Response Team <psrt>` (PSRT) members balance this work
+   against many other responsibilities. Please be thoughtful about the time and
+   attention your report requires. Repeated failure to respect the security policy
+   will result in future reports being rejected, or the reporter being banned
+   from the ``python`` GitHub organization, regardless of technical merit.
 
 What types of bugs are vulnerabilities?
 ---------------------------------------
 
-Not all bugs are vulnerabilities. To avoid causing
-duplicate work for PSRT members, all potential reports
+**Not all bugs are vulnerabilities.**
+
+To avoid causing duplicate work for PSRT members, **all potential** reports
 must be evaluated against the relevant threat models
 prior to being submitted to the PSRT.
 Where possible, cite the relevant threat model to show that
@@ -21,9 +24,9 @@ to report a bug as a vulnerability.
 
 Vulnerabilities must be exploitable from code, configurations,
 pre-conditions, or deployments that may exist in the real world.
-For example, a vulnerability only affecting code
-that does not make sense in a production program
-will not be accepted as a vulnerability.
+A vulnerability that only affecting code
+unlikely to be used in a production program
+will not be accepted.
 
 Documented functionality is not considered a vulnerability.
 For example, :mod:`pickle`, :mod:`marshal`, :mod:`shelve`, :func:`eval`,
@@ -71,7 +74,16 @@ Instead, open a public GitHub issue.
 If a vulnerability is platform-dependent, check if the platform is
 supported per :pep:`11`.
 Vulnerabilities that exclusively affect unsupported platforms
-may not be accepted.
+are not treated as vulnerabilities in Python.
+
+As per the :pep:`Unsupported Platforms section of PEP 11 <11#unsupported-platforms>`,
+porting Python to an unsupported platform is treated as a third-party project.
+If you choose to report such a vulnerability to Python, please follow the
+requirements of this guide. Note that these reports may be shared with
+parties who expressed interested in the relevant platforms and will
+generally be handled according to the relevant maintainers' security
+policies. These reports may closed if the maintainers are unknown or
+unresponsive.
 
 What to include and how to structure a vulnerability report?
 ------------------------------------------------------------
@@ -82,7 +94,7 @@ be formatted correctly:
 
 * For the initial report and follow-up communications, avoid
   overly long, verbose, or excessive structure (such as headers or tables).
-  Ideally reports should be a few sentences describing the vulnerability and
+  Reports should be a few sentences describing the vulnerability. Ideally include
   a proof-of-concept script that reproduces the issue and provides a clear
   indication of whether the vulnerability is still present (such as exiting with
   ``1`` if vulnerable and ``0`` if not vulnerable).

--- a/security/policy.rst
+++ b/security/policy.rst
@@ -2,11 +2,11 @@
 Security Policy
 ===============
 
-The majority of Python Security Response Team (PSRT)
-members are volunteers. Therefore, you must respect this volunteered time
-by following this security policy. Repeated failure to
-respect the security policy will result in future reports
-being rejected or being banned from the `python` GitHub organization, regardless of technical merit.
+Python Security Response Team (PSRT) members balance this work against
+many other responsibilities. Please be thoughtful about the time and attention
+your report requires.  Repeated failure to respect the security policy will
+result in future reports being rejected or being banned from the ``python``
+GitHub organization, regardless of technical merit.
 
 What types of bugs are vulnerabilities?
 ---------------------------------------
@@ -15,6 +15,9 @@ Not all bugs are vulnerabilities. To avoid causing
 duplicate work for PSRT members all potential reports
 must be evaluated against the relevant threat models
 prior to being submitted to the PSRT.
+Where possible, cite the relevant threat model to show that
+the threat model has been considered while determining whether
+to report a bug as a vulnerability.
 
 Vulnerabilities must be exploitable from code, configurations,
 pre-conditions, and deployments that might feasibly exist in
@@ -23,21 +26,16 @@ that does not make sense in a production program
 will not be accepted as a vulnerability.
 
 Documented functionality will not be considered a vulnerability.
-For example, :mod:`pickle`, :mod:`marshal``, :mod:`shelve``, :mod:`eval``,
+For example, :mod:`pickle`, :mod:`marshal`, :mod:`shelve`, :mod:`eval`,
 and :mod:`exec` are documented to execute arbitrary Python code that is supplied
-as data. The :mod:`ctypes` module is documented to enable modifying arbitrary locations in memory.
+as data. The :mod:`ctypes` module is documented to enable modifying arbitrary
+locations in memory.
 
-Vulnerabilities must not depend on malicious control of:
-
-* what Python code is executed by the interpreter
-* locations where code is loaded prior to execution (such as current working
-  directory, ``PYTHONPATH``)
-* configuration files
-* environment variables
-* command line options
-* installed packages or modules
-* `.pth files <https://docs.python.org/3/library/site.html>`__
-* caches or ``.pyc`` files
+Vulnerabilities must not depend on malicious control of Python's launch
+conditions, including command line arguments, environment variables, or
+modifications to files on the target system. We assume that, at the time Python
+is executed, the environment is as intended by the legitimate user, and any
+malicious variation from this cannot be mitigated by Python itself.
 
 Vulnerabilities that affect availability (such as DoS, ReDoS) must be
 triggerable with data inputs that are reasonably sized for the use-case.
@@ -48,21 +46,21 @@ This is to avoid handling performance improvements as security vulnerabilities.
 Vulnerabilities in dependencies of Python (such as zlib, Tcl/Tk, or OpenSSL)
 are not vulnerabilities in Python unless Python's use of the dependency
 interferes with secure use of the dependency.
-For example, Python is not vulnerable because it bundles a vulnerable
-version of zlib, users are expected to upgrade their own dependencies.
-
-The complete threat model for Python and standard library modules
-is available in the Threat Model section of the Python Developer Guide.
+For example, a vulnerability in the bundled copy of zlib in Python is a
+vulnerability in zlib, not Python.
 
 What versions of Python are accepting reports?
 ----------------------------------------------
 
 Python accepts security vulnerabilities and will
-assign CVE IDs for `supported Python versions`_ that have a status of
-`"bugfix" or "security" <python-status>`_. Versions that are not yet
-stable (status of `"feature" or "prerelease" <python-status>`_) are not
-eligible for CVE IDs. If the vulnerability exclusively exists in
-non-stable versions, then the issue should be handled as a public bug issue.
+assign CVE IDs for `supported Python versions <branchstatus>`_ that have a status of
+`"bugfix" or "security" <version-status-key>`_. Versions that are not yet
+stable (status of `"feature" or "prerelease" <version-status-key>`_) are not
+eligible for CVE IDs. If the vulnerability only exists in prerelease versions
+(alphas, betas, release candidates), then the issue should be reported as a
+regular bug.
+Prior to submitting a report, check whether the issue has already been
+resolved on the ``main`` branch and only requires backporting.
 
 Sometimes features may be marked as
 "experimental" in Python, even in a stable Python version.
@@ -70,12 +68,9 @@ These features are not eligible for security vulnerabilities.
 Instead open a public GitHub issue.
 
 If a vulnerability is platform-dependent, check if the platform is
-`supported per :pep:`11`.
+supported per :pep:`11`.
 Vulnerabilities that exclusively affect unsupported platforms
 may not be accepted.
-
-.. _supported Python versions: https://devguide.python.org/versions/
-.. _python-status: https://devguide.python.org/versions/#status-key
 
 What to include and how to structure a vulnerability report?
 ------------------------------------------------------------
@@ -87,7 +82,9 @@ be formatted correctly:
 * For the initial report and follow-up communications, avoid
   overly long, verbose, or excessive structure (such as headers or tables).
   Ideally reports should be a few sentences describing the vulnerability and
-  a proof-of-concept script that reproduces the issue.
+  a proof-of-concept script that reproduces the issue and provides a clear
+  indication whether the vulnerability is still present (such as exiting with
+  ``1`` if vulnerable and ``0`` if not vulnerable).
 * When reporting large numbers or "batches" of vulnerabilities or
   searching for potential vulnerabilities using an LLM, you as a reporter must
   verify the validity of all reports prior to submission to the PSRT.
@@ -124,7 +121,7 @@ Here's what to expect for how a vulnerability report will be handled:
   the advisory and CVE record will be published with attribution.
 
 For more information about how the PSRT handles vulnerabilities,
-`consult the Python Developer Guide <https://devguide.python.org/developer-workflow/psrt/#triaging-a-vulnerability-report>`__.
+`consult the Python Developer Guide <psrt-vulnerability-process>`__.
 
 PSF Code of Conduct
 -------------------

--- a/security/policy.rst
+++ b/security/policy.rst
@@ -1,0 +1,154 @@
+===============
+Security Policy
+===============
+
+The majority of Python Security Response Team
+members are volunteers and therefore you must respect this volunteered time
+by following this security policy. Repeated failure to
+respect the security policy will result in future reports
+being rejected, regardless of technical merit.
+
+What types of bugs are vulnerabilities?
+---------------------------------------
+
+Not all bugs are vulnerabilities. To avoid causing
+duplicate work for PSRT members all potential reports
+must be evaluated against the relevant threat model(s)
+prior to being submitted to the PSRT.
+
+Vulnerabilities must be exploitable from code, configurations,
+pre-conditions, and deployments that might feasibly exist in
+the real-world. For example, a vulnerability only affecting code
+that does not make sense to write in a production program
+will not be accepted as a vulnerability.
+
+Documented functionality will not be considered a vulnerability.
+For example, ``pickle``, ``marshal``, ``shelve``, ``eval``, and ``exec``
+are documented to execute arbitrary Python code that is supplied as data.
+The ``ctypes`` module is documented to enable modifying arbitrary locations
+in memory.
+
+Vulnerabilities must not depend on malicious control of:
+
+* what Python code is executed by the interpreter
+* locations where code is loaded prior to execution (such as current working
+  directory, ``PYTHONPATH``)
+* configuration files
+* environment variables
+* command line options
+* installed packages or modules
+* `.pth files <https://docs.python.org/3/library/site.html>`__
+* caches or ``.pyc`` files
+
+Vulnerabilities that affect availability (such as DoS, ReDoS) must be
+triggerable with data inputs that are reasonably sized for the use-case.
+Availability vulnerabilities must also demonstrate an "upward" change in posture
+for the attacker, rather than a "lateral" change in posture.
+This is to avoid handling performance improvements as security vulnerabilities.
+
+Vulnerabilities in dependencies of Python (such as zlib, Tcl/Tk, or OpenSSL)
+are not vulnerabilities in Python unless Python's usage of the dependency
+interferes with secure usage of the dependency.
+For example, Python is not vulnerable because it bundles a vulnerable
+version of zlib, users are expected to upgrade their own dependencies.
+
+The complete threat model for Python and standard library modules,
+is available in the Threat Model section of the Python Developer Guide.
+
+What versions of Python are accepting reports?
+----------------------------------------------
+
+Python accepts security vulnerabilities and will
+assign CVE IDs for `supported Python versions`_ that have a status of
+`"bugfix" or "security" <python-status>`_. Versions that are not yet
+stable (status of `"feature" or "prerelease" <python-status>`_) are not
+eligible for CVE IDs. If the vulnerability exclusively exists in
+non-stable versions, then the issue should be handled as a public bug issue.
+
+Sometimes features may be marked as
+"experimental" in Python, even in a stable Python version.
+These features are not eligible for security vulnerabilities,
+instead open a public GitHub issue.
+
+If a vulnerability is platform-dependent, check if the platform is a
+`supported platform per PEP 11 <https://peps.python.org/pep-0011/>`__.
+Vulnerabilities that exclusively affect unsupported platforms
+may not be accepted.
+
+.. _supported Python versions: https://devguide.python.org/versions/
+.. _python-status: https://devguide.python.org/versions/#status-key
+
+What to include and how to structure a vulnerability report?
+------------------------------------------------------------
+
+For your vulnerability report to be handled efficiently by
+the PSRT, the report must include certain information and
+be formatted correctly:
+
+* For the initial report and follow-up communications, avoid
+  overly long, verbose, or excessive structure (such as headers or tables).
+  Ideally reports should be a few sentences describing the vulnerability and
+  a proof-of-concept script that reproduces the issue.
+* When reporting large numbers or "batches" of vulnerabilities or
+  searching for potential vulnerabilities using an LLM, you as a reporter must
+  verify the validity of all reports prior to submission to the PSRT.
+  PSRT members WILL NOT spend time confirming the validity of reports, only
+  whether a valid bug report is a vulnerability or not.
+* Do not include severity or CVSS information in your initial report,
+  this information will be determined by the PSRT.
+* Optionally, include a minimal patch with the mitigation for the report.
+* If the vulnerability only affects certain Python versions, optionally
+  include the versions of Python that are affected.
+* Reports that do not contain a potential security vulnerability (such as spam
+  or requesting compliance or due-diligence work)
+  will be discarded without a reply.
+
+How to submit a vulnerability report?
+-------------------------------------
+
+Submit all potential security vulnerability reports for CPython
+to `GitHub Security Advisories <GHSA>`__
+by `opening a new ticket <GHSA>`__.
+Do not open a public GitHub issue to report a security vulnerability.
+For all other projects (pip, python.org, tools, etc) or if you're
+not sure where to send your report, send an email to
+`security at python dot org <mailto:security@python.org>`__.
+
+Here's what to expect for how a vulnerability report will be handled:
+
+* Reporter reports the vulnerability privately to the PSRT.
+* If the PSRT determines the report isn't a vulnerability, the issue
+  can be opened in the public issue tracker.
+* If the PSRT determines the report is a vulnerability, the PSRT will
+  accept your report and a CVE ID will be assigned by the PSF CNA.
+* Once a public pull request containing a fix is merged to CPython,
+  the advisory and CVE record will be published with attribution.
+
+For more information about how the PSRT handles vulnerabilities,
+`consult the Python Developer Guide <https://devguide.python.org/developer-workflow/psrt/#triaging-a-vulnerability-report>`__.
+
+PSF Code of Conduct
+-------------------
+
+Well-being and safety of the Python Security Response Team members is
+prioritized over the technical merit of vulnerability reports.
+Despite communications being private, vulnerability reporting is subject
+to the `PSF Code of Conduct`_. Violations will be reported to the Code of Conduct
+team with undisclosed vulnerability information removed, if applicable.
+
+.. _GHSA: https://github.com/python/cpython/security/advisories/new
+.. _PSF Code of Conduct: https://policies.python.org/python.org/code-of-conduct/
+
+CVE Numbering Authority (CNA)
+-----------------------------
+
+The Python and pip projects are scoped under the
+`Python Software Foundation CVE Numbering Authority <CNA>`__
+(CNA). This means you must submit all security
+vulnerability reports to the PSRT to receive
+a CVE ID for Python or pip. To reach the PSF
+CNA contact directly, send an email to
+`cna at python dot org <mailto:cna@python.org>`__.
+
+.. _CNA: https://www.python.org/cve-numbering-authority/
+

--- a/security/policy.rst
+++ b/security/policy.rst
@@ -4,43 +4,43 @@ Security policy
 
 :ref:`Python Security Response Team <psrt>` (PSRT) members balance this work against
 many other responsibilities. Please be thoughtful about the time and attention
-your report requires.  Repeated failure to respect the security policy will
-result in future reports being rejected or being banned from the ``python``
+your report requires. Repeated failure to respect the security policy will
+result in future reports being rejected or banned from the ``python``
 GitHub organization, regardless of technical merit.
 
 What types of bugs are vulnerabilities?
 ---------------------------------------
 
 Not all bugs are vulnerabilities. To avoid causing
-duplicate work for PSRT members all potential reports
+duplicate work for PSRT members, all potential reports
 must be evaluated against the relevant threat models
 prior to being submitted to the PSRT.
 Where possible, cite the relevant threat model to show that
-the threat model has been considered while determining whether
+the latter has been considered while determining whether
 to report a bug as a vulnerability.
 
 Vulnerabilities must be exploitable from code, configurations,
-pre-conditions, and deployments that might feasibly exist in
+pre-conditions, or deployments that might feasibly exist in
 the real world. For example, a vulnerability only affecting code
 that does not make sense in a production program
 will not be accepted as a vulnerability.
 
-Documented functionality will not be considered a vulnerability.
+Documented functionality is not considered a vulnerability.
 For example, :mod:`pickle`, :mod:`marshal`, :mod:`shelve`, :func:`eval`,
 and :func:`exec` are documented to execute arbitrary Python code that is
 supplied as data. The :mod:`ctypes` module is documented to enable modifying
 arbitrary locations in memory.
 
 Vulnerabilities must not depend on malicious control of Python's launch
-conditions, including command line arguments, environment variables, or
+conditions, including (but not limited to) command line arguments, environment variables, or
 modifications to files on the target system. We assume that, at the time Python
 is executed, the environment is as intended by the legitimate user, and any
 malicious variation from this cannot be mitigated by Python itself.
 
-Vulnerabilities that affect availability (such as DoS, ReDoS) must be
+Vulnerabilities that affect availability (such as DoS or ReDoS) must be
 triggerable with data inputs that are reasonably sized for the use-case.
 Availability vulnerabilities must also demonstrate an "upward" change in posture
-for the attacker, rather than a "lateral" change in posture.
+for the attacker, rather than a "lateral" one.
 This is to avoid handling performance improvements as security vulnerabilities.
 
 Vulnerabilities in dependencies of Python (such as zlib, Tcl/Tk, or OpenSSL)

--- a/security/policy.rst
+++ b/security/policy.rst
@@ -2,31 +2,30 @@
 Security Policy
 ===============
 
-The majority of Python Security Response Team
-members are volunteers and therefore you must respect this volunteered time
+The majority of Python Security Response Team (PSRT)
+members are volunteers. Therefore, you must respect this volunteered time
 by following this security policy. Repeated failure to
 respect the security policy will result in future reports
-being rejected, regardless of technical merit.
+being rejected or being banned from the `python` GitHub organization, regardless of technical merit.
 
 What types of bugs are vulnerabilities?
 ---------------------------------------
 
 Not all bugs are vulnerabilities. To avoid causing
 duplicate work for PSRT members all potential reports
-must be evaluated against the relevant threat model(s)
+must be evaluated against the relevant threat models
 prior to being submitted to the PSRT.
 
 Vulnerabilities must be exploitable from code, configurations,
 pre-conditions, and deployments that might feasibly exist in
-the real-world. For example, a vulnerability only affecting code
-that does not make sense to write in a production program
+the real world. For example, a vulnerability only affecting code
+that does not make sense in a production program
 will not be accepted as a vulnerability.
 
 Documented functionality will not be considered a vulnerability.
-For example, ``pickle``, ``marshal``, ``shelve``, ``eval``, and ``exec``
-are documented to execute arbitrary Python code that is supplied as data.
-The ``ctypes`` module is documented to enable modifying arbitrary locations
-in memory.
+For example, :mod:`pickle`, :mod:`marshal``, :mod:`shelve``, :mod:`eval``,
+and :mod:`exec` are documented to execute arbitrary Python code that is supplied
+as data. The :mod:`ctypes` module is documented to enable modifying arbitrary locations in memory.
 
 Vulnerabilities must not depend on malicious control of:
 
@@ -47,12 +46,12 @@ for the attacker, rather than a "lateral" change in posture.
 This is to avoid handling performance improvements as security vulnerabilities.
 
 Vulnerabilities in dependencies of Python (such as zlib, Tcl/Tk, or OpenSSL)
-are not vulnerabilities in Python unless Python's usage of the dependency
-interferes with secure usage of the dependency.
+are not vulnerabilities in Python unless Python's use of the dependency
+interferes with secure use of the dependency.
 For example, Python is not vulnerable because it bundles a vulnerable
 version of zlib, users are expected to upgrade their own dependencies.
 
-The complete threat model for Python and standard library modules,
+The complete threat model for Python and standard library modules
 is available in the Threat Model section of the Python Developer Guide.
 
 What versions of Python are accepting reports?
@@ -67,11 +66,11 @@ non-stable versions, then the issue should be handled as a public bug issue.
 
 Sometimes features may be marked as
 "experimental" in Python, even in a stable Python version.
-These features are not eligible for security vulnerabilities,
-instead open a public GitHub issue.
+These features are not eligible for security vulnerabilities.
+Instead open a public GitHub issue.
 
-If a vulnerability is platform-dependent, check if the platform is a
-`supported platform per PEP 11 <https://peps.python.org/pep-0011/>`__.
+If a vulnerability is platform-dependent, check if the platform is
+`supported per :pep:`11`.
 Vulnerabilities that exclusively affect unsupported platforms
 may not be accepted.
 
@@ -96,7 +95,7 @@ be formatted correctly:
   whether a valid bug report is a vulnerability or not.
 * Do not include severity or CVSS information in your initial report,
   this information will be determined by the PSRT.
-* Optionally, include a minimal patch with the mitigation for the report.
+* Ideally, include a minimal patch with the mitigation for the report.
 * If the vulnerability only affects certain Python versions, optionally
   include the versions of Python that are affected.
 * Reports that do not contain a potential security vulnerability (such as spam
@@ -107,12 +106,12 @@ How to submit a vulnerability report?
 -------------------------------------
 
 Submit all potential security vulnerability reports for CPython
-to `GitHub Security Advisories <GHSA>`__
+to GitHub Security Advisories
 by `opening a new ticket <GHSA>`__.
 Do not open a public GitHub issue to report a security vulnerability.
-For all other projects (pip, python.org, tools, etc) or if you're
+For all other projects (such as pip, python.org and tools) or if you're
 not sure where to send your report, send an email to
-`security at python dot org <mailto:security@python.org>`__.
+`security@python.org <mailto:security@python.org>`__.
 
 Here's what to expect for how a vulnerability report will be handled:
 
@@ -148,7 +147,7 @@ The Python and pip projects are scoped under the
 vulnerability reports to the PSRT to receive
 a CVE ID for Python or pip. To reach the PSF
 CNA contact directly, send an email to
-`cna at python dot org <mailto:cna@python.org>`__.
+`cna@python.org <mailto:cna@python.org>`__.
 
 .. _CNA: https://www.python.org/cve-numbering-authority/
 

--- a/security/psrt.rst
+++ b/security/psrt.rst
@@ -84,6 +84,8 @@ following additional responsibilities:
 * Running nomination elections, including counting final votes and giving
   the Steering Council an opportunity to veto nominations via email.
 
+.. _psrt-vulnerability-process:
+
 Triaging a vulnerability report
 -------------------------------
 

--- a/security/psrt.rst
+++ b/security/psrt.rst
@@ -1,3 +1,5 @@
+.. _psrt:
+
 Python Security Response Team (PSRT)
 ====================================
 

--- a/versions.rst
+++ b/versions.rst
@@ -45,6 +45,7 @@ Full chart
 .. raw:: html
    :file: _static/release-cycle-all.svg
 
+.. _version-status-key:
 
 Status key
 ==========


### PR DESCRIPTION
Part of https://github.com/python/devguide/issues/1803, this is an initial draft of the Python security policy and "limited" threat model that will be expanded and include more details for specific standard library modules and features. The security policy:

* Prioritizes PSRT members well-being over technical merit of reports.
* Documents how the Code of Conduct applies to vulnerability reporting communications.
* Creates a small threat model for the Python interpreter for common reports which are not vulnerabilities. Future threat models will be added to a separate document and linked to.

cc @python/psrt 