### PR TITLE
Fix Discord link in Tamil translation section

### DIFF
--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -105,7 +105,7 @@ For more details about translations and their progress, see
      - | Murugan Santhosh (:github-user:`terminaljoint`),
        | Hari (:github-user:`nammahari`)
      - :github:`GitHub <Terminal-Joint/python-docs-ta>`,
-       `Discord <https://discord.gg/9rpdtag3ej>`__
+       `Discord <https://discord.gg/JNWjefK2yG>`__
    * - `Traditional Chinese (zh-tw) <https://docs.python.org/zh-tw/>`__
      - | 王威翔 Matt Wang (:github-user:`mattwang44`),
        | Josix Wang (:github-user:`josix`)


### PR DESCRIPTION
Updated the Discord link for Tamil translation.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
