### PR TITLE
Clarify the role PSRT has in handling vulnerability reports for unsupported platforms

### DIFF
--- a/security/policy.rst
+++ b/security/policy.rst
@@ -78,12 +78,14 @@ are not treated as vulnerabilities in Python.
 
 As per the :pep:`Unsupported Platforms section of PEP 11 <11#unsupported-platforms>`,
 porting Python to an unsupported platform is treated as a third-party project.
-If you choose to report such a vulnerability to Python, please follow the
-requirements of this guide. Note that these reports may be shared with
-parties who expressed interested in the relevant platforms and will
-generally be handled according to the relevant maintainers' security
-policies. These reports may closed if the maintainers are unknown or
-unresponsive.
+For these reports, the PSRT treats them as vulnerability reports for a third-party
+port, but not as Python vulnerabilities.
+If you choose to report such an issue to Python, please follow the requirements
+of this guide and include the relevant platform and maintainer context.
+The PSRT forwards these reports to platform maintainers (or other interested
+parties) and they are usually handled under the relevant maintainers’ security
+policies. These reports will be closed without further action if the maintainers
+are unknown or unresponsive.
 
 What to include and how to structure a vulnerability report?
 ------------------------------------------------------------

--- a/security/policy.rst
+++ b/security/policy.rst
@@ -83,9 +83,8 @@ port, but not as Python vulnerabilities.
 If you choose to report such an issue to Python, please follow the requirements
 of this guide and include the relevant platform and maintainer context.
 The PSRT forwards these reports to platform maintainers (or other interested
-parties) and they are usually handled under the relevant maintainers’ security
-policies. These reports will be closed without further action if the maintainers
-are unknown or unresponsive.
+parties) and they are usually handled under the relevant maintainers' security
+policies. These reports will be closed if the maintainers are unknown or unresponsive.
 
 What to include and how to structure a vulnerability report?
 ------------------------------------------------------------

--- a/security/policy.rst
+++ b/security/policy.rst
@@ -79,8 +79,8 @@ are not treated as vulnerabilities in Python.
 As per the :pep:`Unsupported Platforms section of PEP 11 <11#unsupported-platforms>`,
 porting Python to an unsupported platform is treated as a third-party project.
 For these reports, the PSRT treats them as vulnerability reports for a third-party
-port, but not as Python vulnerabilities.
-If you choose to report such an issue to Python, please follow the requirements
+port, not as Python vulnerabilities.
+If you choose to report such an issue to Python, follow the requirements
 of this guide and include the relevant platform and maintainer context.
 The PSRT forwards these reports to platform maintainers (or other interested
 parties) and they are usually handled under the relevant maintainers' security


### PR DESCRIPTION
CC @python/psrt 

After my experience with such a report today, I think this needs a little straightening out. The role that the PSRT plays in handling these reports is not explicitly clear. In this patch I try to make the distinction that the PSRT "treats them as vulnerability reports for a third-party port, but not as Python vulnerabilities." We should also encourage them to find relevant maintainers, as I had to spend some time digging for one today...

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
