### PR TITLE
Add note on unexpected exceptions to security policy

### DIFF
--- a/security/policy.rst
+++ b/security/policy.rst
@@ -46,7 +46,8 @@ Availability vulnerabilities must also demonstrate an "upward" change in posture
 for the attacker, rather than a "lateral" one.
 Unexpected Python exceptions are not vulnerabilities by themselves unless they
 satisfy the availability criteria above.
-This is to avoid handling performance improvements as security vulnerabilities.
+This is to avoid handling performance and correctness improvements as security
+vulnerabilities.
 
 Vulnerabilities in dependencies of Python (such as zlib, Tcl/Tk, or OpenSSL)
 are not vulnerabilities in Python unless Python's use of the dependency

--- a/security/policy.rst
+++ b/security/policy.rst
@@ -44,10 +44,9 @@ dead-locks, and resource exhaustion) must be
 triggerable with data inputs that are reasonably sized for the use case.
 Availability vulnerabilities must also demonstrate an "upward" change in posture
 for the attacker, rather than a "lateral" one.
-Unexpected Python exceptions are not vulnerabilities by themselves unless they
-satisfy the availability criteria above.
-This is to avoid handling performance and correctness improvements as security
-vulnerabilities.
+This is to avoid handling performance improvements as security vulnerabilities.
+Exceptions are an expected part of control flow when processing inputs,
+therefore crashes resulting from unhandled exceptions are not security vulnerabilities.
 
 Vulnerabilities in dependencies of Python (such as zlib, Tcl/Tk, or OpenSSL)
 are not vulnerabilities in Python unless Python's use of the dependency

--- a/security/policy.rst
+++ b/security/policy.rst
@@ -44,6 +44,8 @@ dead-locks, and resource exhaustion) must be
 triggerable with data inputs that are reasonably sized for the use case.
 Availability vulnerabilities must also demonstrate an "upward" change in posture
 for the attacker, rather than a "lateral" one.
+Unexpected Python exceptions are not vulnerabilities by themselves unless they
+satisfy the availability criteria above.
 This is to avoid handling performance improvements as security vulnerabilities.
 
 Vulnerabilities in dependencies of Python (such as zlib, Tcl/Tk, or OpenSSL)


### PR DESCRIPTION
CC @python/psrt 

This is something we've gotten quite a few times, e.g. [GHSA-2frx-2h99-jv56](https://github.com/python/cpython/security/advisories/GHSA-2frx-2h99-jv56) or [GHSA-32pj-fh79-3c9p](https://github.com/python/cpython/security/advisories/GHSA-32pj-fh79-3c9p). It's only a security issue if the unexpected exception is attacker-triggerable and causes actual availability harm (not merely an unhandled Python exception).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
