### PR TITLE
Clarify that performance improvements are not backported

### DIFF
--- a/developer-workflow/development-cycle.rst
+++ b/developer-workflow/development-cycle.rst
@@ -75,18 +75,13 @@ releases; the terms are used interchangeably. These releases have a
 **micro version** number greater than zero.
 
 The only changes allowed to occur in a maintenance branch without debate are
-bug fixes, test improvements, and edits to the documentation.
+bug fixes, test improvements, and edits to the documentation. Performance
+improvements are not among them: an optimization can introduce a regression,
+and a regression in a maintenance release is painful to track down and undo.
 Also, a general rule for maintenance branches is that compatibility
 must not be broken at any point between sibling micro releases (3.12.1, 3.12.2,
 etc.).  For both rules, only rare exceptions are accepted and **must** be
 discussed first.
-
-Performance improvements are not backported. An optimization can introduce a
-regression, and a regression shipped in a maintenance release is painful to
-track down and undo, so optimizations remain on the ``main`` branch. A backport
-is a rare exception, reserved for a clear win that carries no regression risk
-(including for code that subclasses or monkey-patches internals) and matters
-enough to applications to justify it, and it **must** be discussed first.
 
 Backporting changes reduces the risk of future conflicts.
 For documentation, it increases the visibility of improvements,

--- a/developer-workflow/development-cycle.rst
+++ b/developer-workflow/development-cycle.rst
@@ -81,6 +81,13 @@ must not be broken at any point between sibling micro releases (3.12.1, 3.12.2,
 etc.).  For both rules, only rare exceptions are accepted and **must** be
 discussed first.
 
+Performance improvements are not backported. An optimization can introduce a
+regression, and a regression shipped in a maintenance release is painful to
+track down and undo, so optimizations remain on the ``main`` branch. A backport
+is a rare exception, reserved for a clear win that carries no regression risk
+(including for code that subclasses or monkey-patches internals) and matters
+enough to applications to justify it, and it **must** be discussed first.
+
 Backporting changes reduces the risk of future conflicts.
 For documentation, it increases the visibility of improvements,
 since most readers access the `stable documentation <https://docs.python.org/3/>`__

--- a/developer-workflow/development-cycle.rst
+++ b/developer-workflow/development-cycle.rst
@@ -74,14 +74,15 @@ produced from a maintenance branch are called **bugfix** or **maintenance**
 releases; the terms are used interchangeably. These releases have a
 **micro version** number greater than zero.
 
-The only changes allowed to occur in a maintenance branch without debate are
-bug fixes, test improvements, and edits to the documentation. Performance
-improvements are not among them: an optimization can introduce a regression,
-and a regression in a maintenance release is painful to track down and undo.
+Changes backported to a maintenance branch fall into two groups.  *Low-risk*
+changes (bug fixes, test improvements, and documentation edits) may be
+backported without debate.  *Higher-risk* changes (new features, semantic
+changes, and performance improvements) can introduce regressions, so they are
+not backported as a matter of course.
 Also, a general rule for maintenance branches is that compatibility
 must not be broken at any point between sibling micro releases (3.12.1, 3.12.2,
-etc.).  For both rules, only rare exceptions are accepted and **must** be
-discussed first.
+etc.).  For both rules, only rare exceptions are accepted, and each requires a
+strong case agreed upon in discussion beforehand.
 
 Backporting changes reduces the risk of future conflicts.
 For documentation, it increases the visibility of improvements,


### PR DESCRIPTION
A contributor recently proposed backporting a performance improvement to the maintenance branches, and the question surfaced that the devguide does not say whether optimizations should be backported. Core developers confirmed the long-standing practice in the linked discussion: optimizations are not backported, because an optimization can introduce a regression and a regression in a bugfix release is costly to track down and undo.

This adds that rule to the maintenance-branch section of the development cycle, next to the existing "bug fixes, test improvements, and documentation" guidance, and spells out the narrow exception a few core developers noted: a change that is a clear win, carries no regression risk (including for code that subclasses or monkey-patches internals), and matters enough to applications to justify it, discussed first.

Discussion: https://discuss.python.org/t/performance-improvements-and-backports/107625