### PR TITLE
Simplify the landing for new contributors

### DIFF
--- a/_static/devguide_overrides.css
+++ b/_static/devguide_overrides.css
@@ -27,3 +27,9 @@
 table.docutils td {
   vertical-align: top;
 }
+
+/* For the video in index.rst */
+[role="main"] .compact-video {
+  max-width: 500px;
+  margin-inline: auto;
+}

--- a/conf.py
+++ b/conf.py
@@ -11,6 +11,7 @@ extensions = [
     'sphinx_copybutton',
     'sphinx_inline_tabs',
     'sphinx_last_updated_by_git',
+    'sphinxcontrib.youtube',
     'sphinxext.opengraph',
     'sphinxext.rediraffe',
 ]

--- a/index.rst
+++ b/index.rst
@@ -1,4 +1,5 @@
 .. _devguide-main:
+.. _contributing:
 
 ========================
 Python Developer's Guide
@@ -8,23 +9,15 @@ Python Developer's Guide
 
 .. highlight:: bash
 
-This guide is a comprehensive resource for :ref:`contributing <contributing>`
+This guide is a comprehensive resource for contributing
 to Python_ -- for both new and experienced contributors. It is
 :ref:`maintained <devguide>` by the same
 community that maintains Python.  We welcome your contributions!
 
-
-.. _contributing:
-
-Contributing
-------------
-
-We encourage everyone to contribute to Python. To help you, we have put up this
-developer's guide.  If you still have questions after reviewing the material in
+Start with the area that best matches what you want to do.
+If you still have questions after reviewing the material in
 this guide, then the `Core Python Mentorship`_ group is available to help guide new
 contributors through the process.
-
-Guide for contributing to Python:
 
 .. list-table::
    :widths: 10 10 10
@@ -63,14 +56,22 @@ Guide for contributing to Python:
 We **recommend** that sections of this guide be read as needed. You
 can stop where you feel comfortable and begin contributing immediately without
 reading and understanding everything.  If you do choose to skip
-around within the guide, be aware that sections build on each other,
-so you may find it necessary to backtrack to fill in
-missing concepts and terminology.
+around within the guide, be aware that some sections build on each other,
+so you may need to backtrack for missing concepts or terminology.
 
-A number of individuals from the Python community have contributed to a series
+For broader open source contribution advice, a number of individuals from the
+Python community have contributed to a series
 of excellent guides at `Open Source Guides <https://opensource.guide/>`__.
 For example,
 `How to Contribute to Open Source <https://opensource.guide/how-to-contribute/>`__.
+
+.. admonition:: You don't have to be a compiler engineer to work on Python -- Savannah Bailey
+
+   .. container:: compact-video
+
+      .. youtube:: WGXXxGLBVF4
+         :privacy_mode:
+         :width: 100%
 
 
 .. _quick-reference:

--- a/index.rst
+++ b/index.rst
@@ -59,13 +59,13 @@ reading and understanding everything.  If you do choose to skip
 around within the guide, be aware that some sections build on each other,
 so you may need to backtrack for missing concepts or terminology.
 
-For broader open source contribution advice, a number of individuals from the
+For broader open-source contribution advice, a number of individuals from the
 Python community have contributed to a series
 of excellent guides at `Open Source Guides <https://opensource.guide/>`__.
 For example,
 `How to Contribute to Open Source <https://opensource.guide/how-to-contribute/>`__.
 
-.. admonition:: You don't have to be a compiler engineer to work on Python -- Savannah Bailey
+.. admonition:: You don't have to be a compiler engineer to work on Python -- Savannah Ostrowski
 
    .. container:: compact-video
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ sphinx-last-updated-by-git>=0.3.8
 sphinx-lint==1.0.2
 sphinx-notfound-page>=1.1.0
 sphinx_copybutton>=0.5.2
+sphinxcontrib-youtube>=1.5.0
 sphinxext-opengraph>=0.13.0
 sphinxext-rediraffe
 Sphinx>=9.1.0


### PR DESCRIPTION
We essentially had two introductory sections, with the first paragraph linking to one directly below, which also reiterated the first introduction. So, I propose removing the intermediate "Contributing" title and re-flowing the introduction.
Additionally, I also tried to make it more encouraging. The introduction may feel a little overwhelming for new contributors, since we immediately present a large table with lots of links. As such, I think the video helps set a more welcoming tone before readers move on to the great big devguide :-)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
