### PR TITLE
Introduce "type names" section to the style guide

### DIFF
--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -58,6 +58,35 @@ of these entities are not assigned any special markup, but the preferred
 spellings are given in :ref:`specific words` to aid authors in maintaining the
 consistency of presentation in the Python documentation.
 
+
+Use simple language
+===================
+
+Avoid esoteric phrasing where possible.  Our audience is world-wide and may not
+be native English speakers.
+
+Don't use Latin abbreviations like "e.g." or "i.e." where English words will do,
+such as "for example" or "that is."
+
+
+Charged terminology to avoid
+============================
+
+Avoid terminology that may be considered insensitive or exclusionary.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Avoid
+     - Instead
+   * - whitelist
+     - allowlist
+   * - blacklist
+     - blocklist, denylist
+   * - master/slave
+     - main, parent/child, server/client, primary/secondary
+
+
 .. _specific words:
 
 Specific words
@@ -135,34 +164,6 @@ name.  For example, "context variables" describes ``contextvars.ContextVar``,
 and "partial function" may be used to describe an application of
 ``functools.partial``.  Use these names only when they serve to clarify the text
 better than the type name itself would, and put them in lowercase.
-
-
-Use simple language
-===================
-
-Avoid esoteric phrasing where possible.  Our audience is world-wide and may not
-be native English speakers.
-
-Don't use Latin abbreviations like "e.g." or "i.e." where English words will do,
-such as "for example" or "that is."
-
-
-Charged terminology to avoid
-============================
-
-Avoid terminology that may be considered insensitive or exclusionary.
-
-.. list-table::
-   :header-rows: 1
-
-   * - Avoid
-     - Instead
-   * - whitelist
-     - allowlist
-   * - blacklist
-     - blocklist, denylist
-   * - master/slave
-     - main, parent/child, server/client, primary/secondary
 
 
 .. index:: diataxis

--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -119,7 +119,7 @@ Unix
 Type names
 ==========
 
-When writing the names of types in prose, prefer to write the name of the type
+When writing the names of types in prose, write the name of the type
 exactly as it appears in source, styled as a class reference or an unlinked
 class.  For example, refer to dict as ``:class:`dict`‌`` or ``:class:`!dict`‌``.
 

--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -116,6 +116,27 @@ Unix
    1970s.
 
 
+Type names
+==========
+
+When writing the names of types in prose, prefer to write the name of the type
+exactly as it appears in source, styled as a class reference or an unlinked
+class.  For example, refer to dict as ``:class:`dict`‌`` or ``:class:`!dict`‌``.
+
+Links should be used according to the :ref:`guidance on links <links>`.
+
+Some type names are commonly understood ideas or nouns outside of Python.
+For example, "tuples" are a general programming concept, as distinct from the
+``tuple`` type.  When referring to general ideas, do not style the relevant word
+as a type.
+
+Many types have descriptive names which do not exactly match their type
+name.  For example, "context variables" describes ``contextvars.ContextVar``,
+and "partial function" may be used to describe an application of
+``functools.partial``.  Use these names only when they serve to clarify the text
+better than the type name itself would, and put them in lowercase.
+
+
 Use simple language
 ===================
 

--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -152,7 +152,7 @@ When writing the names of types in prose, write the name of the type
 exactly as it appears in source, styled as a class reference or an unlinked
 class.  For example, refer to dict as ``:class:`dict`‌`` or ``:class:`!dict`‌``.
 
-Links should be used according to the :ref:`guidance on links <links>`.
+Links should be used according to the :ref:`guidance on links <style-guide-links>`.
 
 Some type names are commonly understood ideas or nouns outside of Python.
 For example, "tuples" are a general programming concept, as distinct from the
@@ -212,7 +212,7 @@ Please consult the `Diátaxis <https://diataxis.fr/>`__ guide for more
 detail.
 
 
-.. _links:
+.. _style-guide-links:
 
 Links
 =====

--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -148,9 +148,10 @@ Unix
 Type names
 ==========
 
-When writing the names of types in prose, write the name of the type
-exactly as it appears in source, styled as a class reference or an unlinked
-class.  For example, refer to dict as ``:class:`dict`‌`` or ``:class:`!dict`‌``.
+When writing the names of types in prose, indicate that the name is a type by
+writing the name of the type exactly as it appears in source, styled as a class
+reference or an unlinked class.  For example, refer to dict as ``:class:`dict`‌``
+or ``:class:`!dict`‌``.
 
 Links should be used according to the :ref:`guidance on links <style-guide-links>`.
 
@@ -159,12 +160,15 @@ For example, "tuples" are a general programming concept, as distinct from the
 ``tuple`` type.  When referring to general ideas, do not style the relevant word
 as a type.
 
-Many types have descriptive names which do not exactly match their type
+Many types have descriptive names which may or may not exactly match their type
 name.  For example, "context variables" describes ``contextvars.ContextVar``,
-and "partial function" may be used to describe an application of
-``functools.partial``.  Use these names only when they serve to clarify the text
-better than the type name itself would, and put them in lowercase.
+and both "dict" and "dictonary" are used to describe ``dict``.  Once it is clear
+that the text refers to a specific type, use the naming which suits the context:
+in the case of ``dict``, any of "dict", "dictionary", or "``:class:`dict```" may
+be best.
 
+Descriptive names should be written as common nouns, meaning they are lowercase
+when not at the start of a sentence or phrase.
 
 .. index:: diataxis
 .. _diataxis:

--- a/documentation/style-guide.rst
+++ b/documentation/style-guide.rst
@@ -212,6 +212,8 @@ Please consult the `Diátaxis <https://diataxis.fr/>`__ guide for more
 detail.
 
 
+.. _links:
+
 Links
 =====
 


### PR DESCRIPTION
Resolves #1821

This enhancement to the style guide was motivated by a desire to resolve some inconsistent phrasing in the docs, which caused some disagreement in a CPython docs PR.

The new section describes guidance for how type names should be documented. Class references or unlinked class styling are preferred, and other styles are described for use only when they are superior to the class name.

---

The issue has no comments, but I introduced the idea in the docs community where it got some positive feedback.
The discussion there helped to shape the issue, which has some basic :+1: s from a couple of core devs.
