### PR TITLE
Linux build dependencies: use distro names, not package managers

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -765,7 +765,7 @@ some of CPython's modules (for example, ``zlib``).
    For Unix-based systems, we try to use system libraries whenever available.
    This means optional components will only build if the relevant system headers
    are available. The best way to obtain the appropriate headers will vary by
-   distribution, but the appropriate commands for some popular distributions
+   distribution, but the appropriate commands for some popular package managers
    are below.
 
    .. tab:: dnf

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -765,9 +765,9 @@ some of CPython's modules (for example, ``zlib``).
    For Unix-based systems, we try to use system libraries whenever available.
    This means optional components will only build if the relevant system headers
    are available. The best way to obtain these headers varies by distribution,
-   but commands for some popular package managers are given below.
+   but commands for some popular distributions are given below.
 
-   .. tab:: dnf
+   .. tab:: Fedora / RHEL / CentOS
 
       On **Fedora**, **RHEL**, **CentOS** and other ``dnf``-based systems::
 
@@ -784,7 +784,7 @@ some of CPython's modules (for example, ``zlib``).
                xz-devel sqlite sqlite-devel sqlite-libs libuuid-devel gdbm-libs \
                perf expat expat-devel mpdecimal python3-pip
 
-   .. tab:: apt
+   .. tab:: Debian / Ubuntu
 
       On **Debian**, **Ubuntu**, and other ``apt``-based systems, try to get the
       dependencies for the Python you're working on by using the ``apt`` command.

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -764,9 +764,8 @@ some of CPython's modules (for example, ``zlib``).
 
    For Unix-based systems, we try to use system libraries whenever available.
    This means optional components will only build if the relevant system headers
-   are available. The best way to obtain the appropriate headers will vary by
-   distribution, but the appropriate commands for some popular package managers
-   are below.
+   are available. The best way to obtain these headers varies by distribution,
+   but commands for some popular package managers are given below.
 
    .. tab:: dnf
 


### PR DESCRIPTION
Follow-up to PR #1840 to address the review comment from @StanFromIreland about changing 'distributions' to 'package managers' in the Linux tab introduction text.