### PR TITLE
Docs: Clarify GitHub Actions re-run permissions for contributors

### DIFF
--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -667,18 +667,18 @@ list of executed checks. Clicking :guilabel:`Update branch` next to this message
 will merge in the latest changes from the base branch into the PR.
 
 If this still doesn't help with the failure on the PR, you can try
-to re-run that particular failed check. 
+to re-run that particular failed check.
 
-Note that the :guilabel:`Re-run jobs` button on GitHub Actions is only visible 
-to Python core developers and triagers. If you have these permissions, go to 
-the red GitHub Action job, click on the :guilabel:`Re-run jobs` button on the 
-top right, and select :guilabel:`Re-run failed jobs`. The button will only be 
+Note that the :guilabel:`Re-run jobs` button on GitHub Actions is only visible
+to Python core developers and triagers. If you have these permissions, go to
+the red GitHub Action job, click on the :guilabel:`Re-run jobs` button on the
+top right, and select :guilabel:`Re-run failed jobs`. The button will only be
 present when all other jobs finished running.
 
-If you are a regular contributor and cannot see the button, you can ask a 
-reviewer to re-run the failed jobs for you in a PR comment. Alternatively, you 
-can re-trigger the CI by pushing an empty commit to your branch (e.g. 
-``git commit --allow-empty -m "Trigger CI"``), or by closing and re-opening 
+If you are a regular contributor and cannot see the button, you can ask a
+reviewer to re-run the failed jobs for you in a PR comment. Alternatively, you
+can re-trigger the CI by pushing an empty commit to your branch (e.g.
+``git commit --allow-empty -m "Trigger CI"``), or by closing and re-opening
 your pull request.
 
 Re-running failed jobs shouldn't be your first instinct but it is occasionally

--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -667,10 +667,19 @@ list of executed checks. Clicking :guilabel:`Update branch` next to this message
 will merge in the latest changes from the base branch into the PR.
 
 If this still doesn't help with the failure on the PR, you can try
-to re-run that particular failed check. Go to the red GitHub Action job,
-click on the :guilabel:`Re-run jobs` button on the top right, and select
-:guilabel:`Re-run failed jobs`. The button will only be present when all other
-jobs finished running.
+to re-run that particular failed check. 
+
+Note that the :guilabel:`Re-run jobs` button on GitHub Actions is only visible 
+to Python core developers and triagers. If you have these permissions, go to 
+the red GitHub Action job, click on the :guilabel:`Re-run jobs` button on the 
+top right, and select :guilabel:`Re-run failed jobs`. The button will only be 
+present when all other jobs finished running.
+
+If you are a regular contributor and cannot see the button, you can ask a 
+reviewer to re-run the failed jobs for you in a PR comment. Alternatively, you 
+can re-trigger the CI by pushing an empty commit to your branch (e.g. 
+``git commit --allow-empty -m "Trigger CI"``), or by closing and re-opening 
+your pull request.
 
 Re-running failed jobs shouldn't be your first instinct but it is occasionally
 helpful because distributed systems can have intermittent failures, and

--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -667,19 +667,16 @@ list of executed checks. Clicking :guilabel:`Update branch` next to this message
 will merge in the latest changes from the base branch into the PR.
 
 If this still doesn't help with the failure on the PR, you can try
-to re-run that particular failed check.
+to re-run that particular failed check. Note that the :guilabel:`Re-run jobs`
+button is only visible to members of the core and triage team. If you have those
+permissions, go to the failed GitHub Action job, click :guilabel:`Re-run jobs` on
+the top right, and select :guilabel:`Re-run failed jobs`. The button is only
+present once all other jobs have finished.
 
-The :guilabel:`Re-run jobs` button on GitHub Actions is only visible
-to Python core and triage teams. If you have these permissions, go to
-the red GitHub Action job, click on the :guilabel:`Re-run jobs` button on the
-top right, and select :guilabel:`Re-run failed jobs`. The button will only be
-present when all other jobs finished running.
-
-If you are a regular contributor and cannot see the button, you can ask a
-reviewer to re-run the failed jobs for you in a PR comment. Alternatively, you
-can re-trigger the CI by pushing an empty commit to your branch (for example,
-``git commit --allow-empty -m "Trigger CI"``), or by closing and re-opening
-your pull request.
+If don't have access to the button, ask a member of the teams to
+re-run the jobs for you. Alternatively, you can re-trigger CI yourself by
+pushing an empty commit, or by updating your branch with the
+:guilabel:`Update branch` button.
 
 Re-running failed jobs shouldn't be your first instinct but it is occasionally
 helpful because distributed systems can have intermittent failures, and

--- a/getting-started/pull-request-lifecycle.rst
+++ b/getting-started/pull-request-lifecycle.rst
@@ -669,15 +669,15 @@ will merge in the latest changes from the base branch into the PR.
 If this still doesn't help with the failure on the PR, you can try
 to re-run that particular failed check.
 
-Note that the :guilabel:`Re-run jobs` button on GitHub Actions is only visible
-to Python core developers and triagers. If you have these permissions, go to
+The :guilabel:`Re-run jobs` button on GitHub Actions is only visible
+to Python core and triage teams. If you have these permissions, go to
 the red GitHub Action job, click on the :guilabel:`Re-run jobs` button on the
 top right, and select :guilabel:`Re-run failed jobs`. The button will only be
 present when all other jobs finished running.
 
 If you are a regular contributor and cannot see the button, you can ask a
 reviewer to re-run the failed jobs for you in a PR comment. Alternatively, you
-can re-trigger the CI by pushing an empty commit to your branch (e.g.
+can re-trigger the CI by pushing an empty commit to your branch (for example,
 ``git commit --allow-empty -m "Trigger CI"``), or by closing and re-opening
 your pull request.
 


### PR DESCRIPTION
Fixes #1786.

The Developer Guide previously implied that any contributor could click the "Re-run jobs" button to retry a failing CI check. This updates the `pull-request-lifecycle.rst` documentation to explicitly state that the button is only visible to core developers and triagers. It also provides alternative workarounds for regular contributors (e.g. asking a reviewer, pushing an empty commit, or closing/re-opening the PR).