### PR TITLE
Add Punjabi translation team

### DIFF
--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -86,7 +86,7 @@ For more details about translations and their progress, see
    * - Punjabi (pa)
      - Bhuvansh Kataria (:github-user:`BHUVANSH855`)
      - :github:`GitHub <BHUVANSH855/python-docs-pa>`,
-       `Transifex <https://explore.transifex.com/python-doc/python-newest-tx/>`__
+       `Transifex <tx_>`_
    * - `Romanian (ro)  <https://docs.python.org/ro/>`__
      - Octavian Mustafa (:github-user:`octaG-M`, `email <mailto:octawian@yahoo.com>`__)
      - :github:`GitHub <python/python-docs-ro>`

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -85,7 +85,8 @@ For more details about translations and their progress, see
        `article <https://rgth.co/blog/python-ptbr-cenario-atual/>`__
    * - Punjabi (pa)
      - Bhuvansh Kataria (:github-user:`BHUVANSH855`)
-     - :github:`GitHub <BHUVANSH855/python-docs-pa>`
+     - :github:`GitHub <BHUVANSH855/python-docs-pa>`,
+       `Transifex <https://app.transifex.com/python-doc/python-newest/language/pa/>`__
    * - `Romanian (ro)  <https://docs.python.org/ro/>`__
      - Octavian Mustafa (:github-user:`octaG-M`, `email <mailto:octawian@yahoo.com>`__)
      - :github:`GitHub <python/python-docs-ro>`

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -86,7 +86,7 @@ For more details about translations and their progress, see
    * - Punjabi (pa)
      - Bhuvansh Kataria (:github-user:`BHUVANSH855`)
      - :github:`GitHub <BHUVANSH855/python-docs-pa>`,
-       `Transifex <https://app.transifex.com/python-doc/python-newest/language/pa/>`__
+       `Transifex <https://explore.transifex.com/python-doc/python-newest-tx/>`__
    * - `Romanian (ro)  <https://docs.python.org/ro/>`__
      - Octavian Mustafa (:github-user:`octaG-M`, `email <mailto:octawian@yahoo.com>`__)
      - :github:`GitHub <python/python-docs-ro>`

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -64,9 +64,6 @@ For more details about translations and their progress, see
    * - Marathi (mr)
      - Sanket Garade (:github-user:`sanketgarade`, `email <mailto:garade@pm.me>`__)
      - :github:`GitHub <sanketgarade/python-doc-mr>`
-   * - Punjabi (pa)
-     - Bhuvansh Kataria (:github-user:`BHUVANSH855`)
-     - :github:`GitHub <BHUVANSH855/python-docs-pa>`
    * - Lithuanian (lt)
      - Albertas Gimbutas (:github-user:`albertas`, `email <mailto:albertasgim@gmail.com>`__)
      - `original announcement <https://mail.python.org/pipermail/doc-sig/2019-July/004138.html>`__
@@ -86,6 +83,9 @@ For more details about translations and their progress, see
        `guide <https://python.org.br/traducao/>`__,
        `Telegram <https://t.me/pybr_i18n>`__,
        `article <https://rgth.co/blog/python-ptbr-cenario-atual/>`__
+   * - Punjabi (pa)
+     - Bhuvansh Kataria (:github-user:`BHUVANSH855`)
+     - :github:`GitHub <BHUVANSH855/python-docs-pa>`
    * - `Romanian (ro)  <https://docs.python.org/ro/>`__
      - Octavian Mustafa (:github-user:`octaG-M`, `email <mailto:octawian@yahoo.com>`__)
      - :github:`GitHub <python/python-docs-ro>`

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -64,6 +64,9 @@ For more details about translations and their progress, see
    * - Marathi (mr)
      - Sanket Garade (:github-user:`sanketgarade`, `email <mailto:garade@pm.me>`__)
      - :github:`GitHub <sanketgarade/python-doc-mr>`
+   * - Punjabi (pa)
+     - Bhuvansh Kataria (:github-user:`BHUVANSH855`)
+     - :github:`GitHub <BHUVANSH855/python-docs-pa>`
    * - Lithuanian (lt)
      - Albertas Gimbutas (:github-user:`albertas`, `email <mailto:albertasgim@gmail.com>`__)
      - `original announcement <https://mail.python.org/pipermail/doc-sig/2019-July/004138.html>`__


### PR DESCRIPTION
## Summary

Add Punjabi (`pa`) to the documentation translation coordinators table.

### Coordinator

* Bhuvansh Kataria (@BHUVANSH855)

### Repository

* https://github.com/BHUVANSH855/python-docs-pa

The Punjabi translation project is active, uses Transifex for translation management, and maintains a public GitHub repository for synchronization and collaboration.
