### PR TITLE
Security Policy: Add note on referencing provisional CVE IDs

### DIFF
--- a/security/policy.rst
+++ b/security/policy.rst
@@ -138,6 +138,9 @@ Here's what to expect for how a vulnerability report will be handled:
   may open a public issue.
 * If the PSRT determines the report is a vulnerability, the PSRT will
   accept the report and a CVE ID will be assigned by the PSF CNA.
+
+  Do not publicly reference the assigned CVE ID before its record is published,
+  as the report and ID remain provisional and may still be changed.
 * Once a public pull request containing a fix is merged to CPython,
   the advisory and CVE record will be published with attribution.
 

--- a/security/policy.rst
+++ b/security/policy.rst
@@ -138,7 +138,6 @@ Here's what to expect for how a vulnerability report will be handled:
   may open a public issue.
 * If the PSRT determines the report is a vulnerability, the PSRT will
   accept the report and a CVE ID will be assigned by the PSF CNA.
-
   Do not publicly reference the assigned CVE ID before its record is published,
   as the report and ID remain provisional and may still be changed.
 * Once a public pull request containing a fix is merged to CPython,


### PR DESCRIPTION
This issue has come up a few times now, e.g. in [python/cpython#GHSA-8mmf-429p-8g58](https://github.com/python/cpython/security/advisories/GHSA-8mmf-429p-8g58).
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
