### PR TITLE
Reinstate `#backport-pr-title` anchor and add explicit backport PR title guidance

### DIFF
--- a/core-team/committing.rst
+++ b/core-team/committing.rst
@@ -149,6 +149,8 @@ bug fixes or security fixes. In almost all cases the fixes should first
 originate on ``main`` and then be ported back to older branches.
 
 
+.. _backport-pr-title:
+
 Backporting changes to an older version
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/getting-started/git-boot-camp.rst
+++ b/getting-started/git-boot-camp.rst
@@ -622,6 +622,9 @@ The format of a correct backport commit message is:
 
     (cherry picked from commit <commit_sha1>)
 
+Here ``gh-XXXXX`` is the GitHub *issue* number, and ``(GH-XXXXX)`` is the
+original *pull request* number.
+
 An example of a bad backport commit message:
 
 .. code-block:: text
@@ -630,6 +633,17 @@ An example of a bad backport commit message:
     gh-XXXXX: Custom title (GH-XXXXX) (#XXXXX)
 
     * Custom message
+
+.. _backport-pr:
+
+The title of the backport PR must follow the same format as the commit title,
+beginning with the ``[<branch>]`` prefix, and referencing the original PR with
+a ``(GH-XXXXX)`` suffix. For example:
+
+.. code-block:: text
+   :class: good
+
+    [3.15] gh-12345: Fix the spam module (GH-24680)
 
 After the backport PR is opened, ``miss-islington`` will link it to the original
 PR and remove the corresponding backport label.

--- a/getting-started/git-boot-camp.rst
+++ b/getting-started/git-boot-camp.rst
@@ -636,9 +636,9 @@ An example of a bad backport commit message:
 
 .. _backport-pr:
 
-The title of the backport PR must follow the same format as the commit title,
-beginning with the ``[<branch>]`` prefix, and referencing the original PR with
-a ``(GH-XXXXX)`` suffix. For example:
+When opening the backport PR, its title PR must follow the same format as the
+commit title, beginning with the ``[<branch>]`` prefix and referencing the
+original PR with a ``(GH-XXXXX)`` suffix. For example:
 
 .. code-block:: text
    :class: good


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->


When Bedevere fails a backport PR because it's missing a `[3.x]` title prefix, it links to the devguide with advice.

The old link:

* https://devguide.python.org/committing/#backport-pr-title

Redirects to:

* https://devguide.python.org/core-team/committing/index.html#backport-pr-title

But since https://github.com/python/devguide/pull/1819, there's:

* no `#backport-pr-title` anchor on that page
* the backporting guide was moved to another page, with a stub also pointing there

For reference, the old devguide pointed to:

* https://web.archive.org/web/20251002203521/https://devguide.python.org/core-team/committing/#backport-pr-title

This PR:

* re-adds `#backport-pr-title` to the original page, at the stub
* adds some explicit backport PR title guidance
