### PR TITLE
Reinstate `#updating-news-and-what-s-new-in-python` anchor

### DIFF
--- a/core-team/committing.rst
+++ b/core-team/committing.rst
@@ -68,7 +68,9 @@ to enter the public source tree. Ask yourself the following questions:
    if they haven't. For further questions about the CLA
    process, write to contributors@python.org.
 
-* **Were** ``What's New in Python`` **and** ``Misc/NEWS.d/next`` **updated?**
+* .. _updating-news-and-what-s-new-in-python:
+
+  **Were** ``What's New in Python`` **and** ``Misc/NEWS.d/next`` **updated?**
    If the change is particularly interesting for end users (for example, new features,
    significant improvements, or backwards-incompatible changes), then an
    entry in the ``What's New in Python`` document (in ``Doc/whatsnew/``) should


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->

Similar to https://github.com/python/devguide/pull/1855.

When there's no NEWS, [Bedevere comments](https://github.com/search?q=repo%3Apython%2Fcpython+%22Add+one+using+the+blurb_it%22&type=pullrequests):

> Most changes to Python [require a NEWS entry](https://devguide.python.org/core-developers/committing/#updating-news-and-what-s-new-in-python). Add one using the [blurb_it](https://blurb-it.herokuapp.com) web app or the [blurb](https://pypi.org/project/blurb/) command-line tool.
> 
> If this change has little impact on Python users, wait for a maintainer to apply the `skip news` label instead.

But since https://github.com/python/devguide/pull/1819, there's no content at:

* https://devguide.python.org/core-developers/committing/#updating-news-and-what-s-new-in-python

It's been moved to:

* https://devguide.python.org/getting-started/pull-request-lifecycle/#news-entry

Let's re-add the old anchor on the old page, just above this chunk, with "See also" going to the new page:

<img width="753" height="209" alt="image" src="https://github.com/user-attachments/assets/58be247c-3064-4689-9157-0122dca6aed1" />

