### PR TITLE
Clarify that maintainers may close unproductive PRs without explanation

### DIFF
--- a/getting-started/ai-tools.rst
+++ b/getting-started/ai-tools.rst
@@ -53,7 +53,7 @@ Unacceptable uses
 =================
 
 Maintainers may close issues and PRs that are not useful or productive,
-regardless of whether AI tools were used or not.
+without explanation, regardless of whether AI tools were used or not.
 
 If a contributor repeatedly opens unproductive issues or PRs, they may be
 blocked from contributing to the project because it is disruptive and


### PR DESCRIPTION
I discussed this with some people at the language summit this week. Explaining closures exists to teach contributors, and practice varies today, some feel it's the right thing to do and keep doing it, while others already close without comment. Both approaches are fine and this change doesn't discourage explanations, it only makes clear for contributors that they are optional. When a submission is AI-generated, an explanation may only ever be read by an agent, and it's impossible to tell the difference. We want to teach humans, not LLMs. Maintainer time is too limited to owe that effort by default, even though no hostility toward genuine contributors is intended.