### PR TITLE
docs: add Windows instructions for pomerge in translating guide

### DIFF
--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -4,6 +4,8 @@
 Translating
 ===========
 
+.. include:: /include/activate-tab.rst
+
 .. highlight::  rest
 
 There are several documentation translations already

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -416,6 +416,7 @@ with the commit hash from before the files were moved):
         git checkout HEAD -- .
 
         # Merge translations from temporary dir back in
+        shopt -s globstar
         pomerge --from /tmp/old-po-files/**/*.po --to **/*.po --clear
 
         # Clean up temporary dir
@@ -436,11 +437,17 @@ with the commit hash from before the files were moved):
         rem Return to the current version
         git checkout HEAD -- .
 
-        rem Merge translations from temporary dir back in
-        pomerge --from "%TEMP%\old-po-files\**\*.po" --to "**\*.po" --clear
+        rem Learn translations from temporary dir
+        for /R "%TEMP%\old-po-files" %F in (*.po) do pomerge --from "%F"
+
+        rem Apply translations to current files
+        for /R . %F in (*.po) do pomerge --to "%F"
+
+        rem Clean up translation memory
+        pomerge --clear
 
         rem Clean up temporary dir
-        rmdir /S /Q %TEMP%\old-po-files
+        rmdir /S /Q "%TEMP%\old-po-files"
 
 After running ``pomerge``, review the changes and commit the updated files.
 You may also need to rewrap the lines (see :pypi:`powrap`).

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -398,8 +398,6 @@ messages, regardless of file paths. To use it, first install the package:
 Then, merge translations from a specific commit (replace :samp:`{COMMIT_HASH}`
 with the commit hash from before the files were moved):
 
-.. TODO: Provide Windows instructions.
-
 .. tab:: Unix
 
     .. code-block:: bash
@@ -420,6 +418,27 @@ with the commit hash from before the files were moved):
 
         # Clean up temporary dir
         rm -rf /tmp/old-po-files
+
+.. tab:: Windows
+
+    .. code-block:: dosbatch
+
+        rem These commands are to be run in the root of the translation repo
+
+        rem Check out a commit before the move
+        git checkout COMMIT_HASH -- .
+
+        rem Copy translations to a temporary dir
+        xcopy . %TEMP%\old-po-files\ /E /I /Q /Y
+
+        rem Return to the current version
+        git checkout HEAD -- .
+
+        rem Merge translations from temporary dir back in
+        pomerge --from "%TEMP%\old-po-files\**\*.po" --to "**\*.po" --clear
+
+        rem Clean up temporary dir
+        rmdir /S /Q %TEMP%\old-po-files
 
 After running ``pomerge``, review the changes and commit the updated files.
 You may also need to rewrap the lines (see :pypi:`powrap`).

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -416,7 +416,7 @@ with the commit hash from before the files were moved):
         git checkout HEAD -- .
 
         # Merge translations from temporary dir back in
-        shopt -s globstar
+        shopt -s globstar  # To find po files recursively, use the globstar option of bash, or your shell equivalent
         pomerge --from /tmp/old-po-files/**/*.po --to **/*.po --clear
 
         # Clean up temporary dir
@@ -424,30 +424,27 @@ with the commit hash from before the files were moved):
 
 .. tab:: Windows
 
-    .. code-block:: dosbatch
+    .. code-block:: powershell
 
-        rem These commands are to be run in the root of the translation repo
+        # These commands are to be run in the root of the translation repo
 
-        rem Check out a commit before the move
+        # Check out a commit before the move
         git checkout COMMIT_HASH -- .
 
-        rem Copy translations to a temporary dir
-        xcopy . %TEMP%\old-po-files\ /E /I /Q /Y
+        # Copy translations to a temporary dir
+        Copy-Item -Path . -Destination $env:TEMP\old-po-files -Recurse -Force
 
-        rem Return to the current version
+        # Return to the current version
         git checkout HEAD -- .
 
-        rem Learn translations from temporary dir
-        for /R "%TEMP%\old-po-files" %F in (*.po) do pomerge --from "%F"
+        # Merge translations from temporary dir back in
+        # We use PowerShell's Get-ChildItem to expand wildcards correctly
+        $old_files = (Get-ChildItem -Path $env:TEMP\old-po-files -Filter *.po -Recurse).FullName
+        $new_files = (Get-ChildItem -Filter *.po -Recurse).FullName
+        pomerge --from $old_files --to $new_files --clear
 
-        rem Apply translations to current files
-        for /R . %F in (*.po) do pomerge --to "%F"
-
-        rem Clean up translation memory
-        pomerge --clear
-
-        rem Clean up temporary dir
-        rmdir /S /Q "%TEMP%\old-po-files"
+        # Clean up temporary dir
+        Remove-Item -Path $env:TEMP\old-po-files -Recurse -Force
 
 After running ``pomerge``, review the changes and commit the updated files.
 You may also need to rewrap the lines (see :pypi:`powrap`).

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -4,6 +4,8 @@
 Translating
 ===========
 
+.. include:: /include/activate-tab.rst
+
 .. highlight::  rest
 
 Several documentation translations are already in production and can be found

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -487,6 +487,7 @@ with the commit hash from before the files were moved):
         git checkout HEAD -- .
 
         # Merge translations from temporary dir back in
+        shopt -s globstar
         pomerge --from /tmp/old-po-files/**/*.po --to **/*.po --clear
 
         # Clean up temporary dir
@@ -507,11 +508,17 @@ with the commit hash from before the files were moved):
         rem Return to the current version
         git checkout HEAD -- .
 
-        rem Merge translations from temporary dir back in
-        pomerge --from "%TEMP%\old-po-files\**\*.po" --to "**\*.po" --clear
+        rem Learn translations from temporary dir
+        for /R "%TEMP%\old-po-files" %F in (*.po) do pomerge --from "%F"
+
+        rem Apply translations to current files
+        for /R . %F in (*.po) do pomerge --to "%F"
+
+        rem Clean up translation memory
+        pomerge --clear
 
         rem Clean up temporary dir
-        rmdir /S /Q %TEMP%\old-po-files
+        rmdir /S /Q "%TEMP%\old-po-files"
 
 After running ``pomerge``, review the changes and commit the updated files.
 You may also need to rewrap the lines (see :pypi:`powrap`).

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -469,8 +469,6 @@ messages, regardless of file paths. To use it, first install the package:
 Then, merge translations from a specific commit (replace :samp:`{COMMIT_HASH}`
 with the commit hash from before the files were moved):
 
-.. TODO: Provide Windows instructions.
-
 .. tab:: Unix
 
     .. code-block:: bash
@@ -491,6 +489,27 @@ with the commit hash from before the files were moved):
 
         # Clean up temporary dir
         rm -rf /tmp/old-po-files
+
+.. tab:: Windows
+
+    .. code-block:: dosbatch
+
+        rem These commands are to be run in the root of the translation repo
+
+        rem Check out a commit before the move
+        git checkout COMMIT_HASH -- .
+
+        rem Copy translations to a temporary dir
+        xcopy . %TEMP%\old-po-files\ /E /I /Q /Y
+
+        rem Return to the current version
+        git checkout HEAD -- .
+
+        rem Merge translations from temporary dir back in
+        pomerge --from "%TEMP%\old-po-files\**\*.po" --to "**\*.po" --clear
+
+        rem Clean up temporary dir
+        rmdir /S /Q %TEMP%\old-po-files
 
 After running ``pomerge``, review the changes and commit the updated files.
 You may also need to rewrap the lines (see :pypi:`powrap`).

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -487,7 +487,7 @@ with the commit hash from before the files were moved):
         git checkout HEAD -- .
 
         # Merge translations from temporary dir back in
-        shopt -s globstar
+        shopt -s globstar  # To find po files recursively, use the globstar option of bash, or your shell equivalent
         pomerge --from /tmp/old-po-files/**/*.po --to **/*.po --clear
 
         # Clean up temporary dir
@@ -495,30 +495,27 @@ with the commit hash from before the files were moved):
 
 .. tab:: Windows
 
-    .. code-block:: dosbatch
+    .. code-block:: powershell
 
-        rem These commands are to be run in the root of the translation repo
+        # These commands are to be run in the root of the translation repo
 
-        rem Check out a commit before the move
+        # Check out a commit before the move
         git checkout COMMIT_HASH -- .
 
-        rem Copy translations to a temporary dir
-        xcopy . %TEMP%\old-po-files\ /E /I /Q /Y
+        # Copy translations to a temporary dir
+        Copy-Item -Path . -Destination $env:TEMP\old-po-files -Recurse -Force
 
-        rem Return to the current version
+        # Return to the current version
         git checkout HEAD -- .
 
-        rem Learn translations from temporary dir
-        for /R "%TEMP%\old-po-files" %F in (*.po) do pomerge --from "%F"
+        # Merge translations from temporary dir back in
+        # We use PowerShell's Get-ChildItem to expand wildcards correctly
+        $old_files = (Get-ChildItem -Path $env:TEMP\old-po-files -Filter *.po -Recurse).FullName
+        $new_files = (Get-ChildItem -Filter *.po -Recurse).FullName
+        pomerge --from $old_files --to $new_files --clear
 
-        rem Apply translations to current files
-        for /R . %F in (*.po) do pomerge --to "%F"
-
-        rem Clean up translation memory
-        pomerge --clear
-
-        rem Clean up temporary dir
-        rmdir /S /Q "%TEMP%\old-po-files"
+        # Clean up temporary dir
+        Remove-Item -Path $env:TEMP\old-po-files -Recurse -Force
 
 After running ``pomerge``, review the changes and commit the updated files.
 You may also need to rewrap the lines (see :pypi:`powrap`).


### PR DESCRIPTION
Fixes #1783

This PR adds the missing Windows commands tab for the `pomerge` translation recovery tool, resolving the `TODO` in `translating.rst`. The commands for Windows use `xcopy` and `rmdir` to achieve the same result as the Unix `cp` and `rm`.