### PR TITLE
Fix link to iOS README in setup-building.rst

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -742,7 +742,7 @@ Platforms/Apple --help`` for more details.
 
 You can also run the test suite in Xcode itself. This is required if you want to
 run on a physical device. See the `iOS README
-<https://github.com/python/cpython/blob/main/iOS/README.rst#debugging-test-failures>`__
+<https://github.com/python/cpython/blob/main/Platforms/Apple/iOS/README.md#debugging-test-failures>`__
 for details.
 
 .. c_compile_and_build_end


### PR DESCRIPTION
Updated link to the iOS README for debugging test failures.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
