### PR TITLE
docs: add Punjabi translation coordinators

### DIFF
--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -84,7 +84,9 @@ For more details about translations and their progress, see
        `Telegram <https://t.me/pybr_i18n>`__,
        `article <https://rgth.co/blog/python-ptbr-cenario-atual/>`__
    * - Punjabi (pa)
-     - Bhuvansh Kataria (:github-user:`BHUVANSH855`)
+     - | Bhuvansh Kataria (:github-user:`BHUVANSH855`),
+       | Mohit Yadav (:github-user:`mohityadav8`),
+       | Yashraj Jangra (:github-user:`Yashraj-Jangra`)
      - :github:`GitHub <BHUVANSH855/python-docs-pa>`,
        `Transifex <tx_>`_
    * - `Romanian (ro)  <https://docs.python.org/ro/>`__


### PR DESCRIPTION
## Summary

Add the Punjabi translation coordination team to the Devguide by listing the current coordinators.

### Changes

- Add Mohit Yadav (`@mohityadav8`) as a Punjabi translation coordinator.
- Add Yashraj Jangra (`@Yashraj-Jangra`) as a Punjabi translation coordinator.
- Update the coordination team entry to list all current Punjabi coordinators:
  - Bhuvansh Kataria
  - Mohit Yadav
  - Yashraj Jangra

## Notes

This is a documentation-only change and does not modify any functionality.