### PR TITLE
Add German translation section to documentation

### DIFF
--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -36,7 +36,7 @@ For more details about translations and their progress, see
        :github:`mirror <python/python-docs-fr>`
    * - German (de)
      - Swen Bachmann (:github-user:`sba72`)
-     - `GitHub <https://github.com/sba72/python-docs-de>`__
+     - :github:`GitHub <sba72/python-docs-de>`
    * - `Greek (el) <https://docs.python.org/el/>`__
      - | Lysandros Nikolaou (:github-user:`lysnikolaou`),
        | Fanis Petkos (:github-user:`thepetk`),

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -34,6 +34,9 @@ For more details about translations and their progress, see
      - Julien Palard (:github-user:`JulienPalard`)
      - `AFPy/python-docs-fr <https://git.afpy.org/AFPy/python-docs-fr/>`__,
        :github:`mirror <python/python-docs-fr>`
+   * - German (de)
+     - Swen Bachmann (:github-user:`sba72`)
+     - `GitHub <https://github.com/sba72/python-docs-de>`__
    * - `Greek (el) <https://docs.python.org/el/>`__
      - | Lysandros Nikolaou (:github-user:`lysnikolaou`),
        | Fanis Petkos (:github-user:`thepetk`),


### PR DESCRIPTION
This PR adds the German (`de`) entry to the translation coordinators table as work on revitalizing the official German documentation translation is starting up (see python/docs-community#200).

cc @python/editorial-board