### PR TITLE
Python Security Policy: Add note on sandboxes

### DIFF
--- a/security/policy.rst
+++ b/security/policy.rst
@@ -33,6 +33,10 @@ and :func:`exec` are documented to execute arbitrary Python code that is
 supplied as data. The :mod:`ctypes` module is documented to enable modifying
 arbitrary locations in memory.
 
+CPython does not support sandboxing untrusted Python code as a security
+boundary, so escapes from such a sandbox are not vulnerabilities in Python
+and should be reported to the sandbox's developers instead.
+
 Vulnerabilities must not depend on malicious control of Python's launch
 conditions, including (but not limited to) command line arguments, environment variables, or
 modifications to files on the target system. We assume that, at the time Python


### PR DESCRIPTION
CC @python/psrt 

Prompted by a recent report (and several similar ones before it), this clarifies that sandboxing untrusted Python code is not a security boundary we support. Escapes from third-party sandboxes should be reported to their developers instead.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
