### PR TITLE
Add sepehr-rs as Persian documentation coordinator

### DIFF
--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -74,7 +74,7 @@ For more details about translations and their progress, see
      - | Alireza Shabani (:github-user:`revisto`),
        | Sepehr Rasouli (:github-user:`sepehr-rs`)
      - :github:`GitHub <revisto/python-docs-fa>`,
-       `Telegram <https://t.me/python_docs_farsi>`_
+       `Telegram <https://t.me/python_docs_farsi>`__
    * - `Polish (pl) <https://docs.python.org/pl/>`__
      - | Maciej Olko (:github-user:`m-aciek`),
        | Stan Ulbrych (:github-user:`StanFromIreland`)

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -71,10 +71,10 @@ For more details about translations and their progress, see
      - Albertas Gimbutas (:github-user:`albertas`, `email <mailto:albertasgim@gmail.com>`__)
      - `original announcement <https://mail.python.org/pipermail/doc-sig/2019-July/004138.html>`__
    * - Persian (fa)
-     - | Alireza Shabani (:github-user:`revisto`)
+     - | Alireza Shabani (:github-user:`revisto`),
        | Sepehr Rasouli (:github-user:`sepehr-rs`)
-     - | :github:`GitHub <revisto/python-docs-fa>`
-       | `Telegram <https://t.me/python_docs_farsi>`_
+     - :github:`GitHub <revisto/python-docs-fa>`,
+       `Telegram <https://t.me/python_docs_farsi>`_
    * - `Polish (pl) <https://docs.python.org/pl/>`__
      - | Maciej Olko (:github-user:`m-aciek`),
        | Stan Ulbrych (:github-user:`StanFromIreland`)

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -70,10 +70,11 @@ For more details about translations and their progress, see
    * - Lithuanian (lt)
      - Albertas Gimbutas (:github-user:`albertas`, `email <mailto:albertasgim@gmail.com>`__)
      - `original announcement <https://mail.python.org/pipermail/doc-sig/2019-July/004138.html>`__
-   * - Persian (fa)
-     - | Alireza Shabani (:github-user:`revisto`)
-       | Sepehr Rasouli (:github-user:`sepehr-rs`)
-     - :github:`GitHub <revisto/python-docs-fa>`
+    * - Persian (fa)
+      - | Alireza Shabani (:github-user:`revisto`)
+        | Sepehr Rasouli (:github-user:`sepehr-rs`)
+      - | :github:`GitHub <revisto/python-docs-fa>`
+        | `Telegram <https://t.me/python_docs_farsi>`_
    * - `Polish (pl) <https://docs.python.org/pl/>`__
      - | Maciej Olko (:github-user:`m-aciek`),
        | Stan Ulbrych (:github-user:`StanFromIreland`)

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -71,8 +71,8 @@ For more details about translations and their progress, see
      - Albertas Gimbutas (:github-user:`albertas`, `email <mailto:albertasgim@gmail.com>`__)
      - `original announcement <https://mail.python.org/pipermail/doc-sig/2019-July/004138.html>`__
    * - Persian (fa)
-     - Alireza Shabani (:github-user:`revisto`)
-     - Sepehr Rasouli (:github-user:`sepehr-rs`)
+     - | Alireza Shabani (:github-user:`revisto`)
+       | Sepehr Rasouli (:github-user:`sepehr-rs`)
      - :github:`GitHub <revisto/python-docs-fa>`
    * - `Polish (pl) <https://docs.python.org/pl/>`__
      - | Maciej Olko (:github-user:`m-aciek`),

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -72,6 +72,7 @@ For more details about translations and their progress, see
      - `original announcement <https://mail.python.org/pipermail/doc-sig/2019-July/004138.html>`__
    * - Persian (fa)
      - Alireza Shabani (:github-user:`revisto`)
+     - Sepehr Rasouli (:github-user:`sepehr-rs`)
      - :github:`GitHub <revisto/python-docs-fa>`
    * - `Polish (pl) <https://docs.python.org/pl/>`__
      - | Maciej Olko (:github-user:`m-aciek`),

--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -70,11 +70,11 @@ For more details about translations and their progress, see
    * - Lithuanian (lt)
      - Albertas Gimbutas (:github-user:`albertas`, `email <mailto:albertasgim@gmail.com>`__)
      - `original announcement <https://mail.python.org/pipermail/doc-sig/2019-July/004138.html>`__
-    * - Persian (fa)
-      - | Alireza Shabani (:github-user:`revisto`)
-        | Sepehr Rasouli (:github-user:`sepehr-rs`)
-      - | :github:`GitHub <revisto/python-docs-fa>`
-        | `Telegram <https://t.me/python_docs_farsi>`_
+   * - Persian (fa)
+     - | Alireza Shabani (:github-user:`revisto`)
+       | Sepehr Rasouli (:github-user:`sepehr-rs`)
+     - | :github:`GitHub <revisto/python-docs-fa>`
+       | `Telegram <https://t.me/python_docs_farsi>`_
    * - `Polish (pl) <https://docs.python.org/pl/>`__
      - | Maciej Olko (:github-user:`m-aciek`),
        | Stan Ulbrych (:github-user:`StanFromIreland`)


### PR DESCRIPTION
Adding @sepehr-rs as one of the Persian documentation coordinators.

We've also completed the tutorial and the files required for language switcher inclusion, so we'd like to request a transfer of https://github.com/Revisto/python-docs-fa to the python org as part of the process of adding Farsi to the language switcher.

CC @JulienPalard for approval.