### PR TITLE
Replace footnotes with direct links

### DIFF
--- a/documentation/translations/translating.rst
+++ b/documentation/translations/translating.rst
@@ -173,16 +173,18 @@ Motivation
 ==========
 
 The Python documentation is written in English, but Python is taught, learned,
-and used around the world, in many languages. English is the native language
-of only about 5% of the world's population, and fewer than a fifth more speak
-it as an additional language [#f1]_. For many people, learning Python also
-means overcoming a language barrier. They must learn not only Python, but also
-enough English to be able to use the language's documentation.
+and used around the world, in many languages. English is the `native language
+of only about 5% of the world's population
+<https://www.ethnologue.com/insights/most-spoken-language/>`__, and fewer than
+a fifth more speak it as an additional language. For many people, learning
+Python also means overcoming a language barrier. They must learn not only
+Python, but also enough English to be able to use the language's documentation.
 
-The United Nations Open Source Principles call on projects both to provide
-documentation and to foster inclusive participation [#f2]_. Providing
-documentation only in English limits who can benefit from it and who can
-participate in the wider Python community.
+The `United Nations Open Source Principles
+<https://opensource.un.org/en/news/united-nations-open-source-principles>`__
+call on projects both to provide documentation and to foster inclusive
+participation. Providing documentation only in English limits who can benefit
+from it and who can participate in the wider Python community.
 
 .. figure:: python-logo-languages.svg
    :align: center
@@ -492,13 +494,6 @@ with the commit hash from before the files were moved):
 
 After running ``pomerge``, review the changes and commit the updated files.
 You may also need to rewrap the lines (see :pypi:`powrap`).
-
-.. rubric:: Footnotes
-
-.. [#f1] Ethnologue, `What is the most spoken language?
-         <https://www.ethnologue.com/insights/most-spoken-language/>`__
-.. [#f2] `United Nations Open Source Principles
-         <https://opensource.un.org/en/news/united-nations-open-source-principles>`__
 
 .. _discourse: https://discuss.python.org/c/documentation/translations/
 .. _tx: https://explore.transifex.com/python-doc/python-newest/


### PR DESCRIPTION
This was suggested by Hugo in https://github.com/python/devguide/pull/1882#discussion_r3790450136. However, I'm not convinced. While I agree it saves a click for those who want to access the reference, I think that it distracts those who don't.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
