### PR TITLE
Document deb822 sources for Ubuntu 24.04 and later

### DIFF
--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -794,7 +794,6 @@ some of CPython's modules (for example, ``zlib``).
 
       On **Ubuntu 24.04 and later**, and on other releases using the deb822
       format, the sources are in ``/etc/apt/sources.list.d/ubuntu.sources``.
-      ``/etc/apt/sources.list`` is left as a stub with nothing to uncomment.
       Add ``deb-src`` to the ``Types`` field of the entries you want sources
       for::
 

--- a/getting-started/setup-building.rst
+++ b/getting-started/setup-building.rst
@@ -790,13 +790,32 @@ some of CPython's modules (for example, ``zlib``).
       dependencies for the Python you're working on by using the ``apt`` command.
 
       First, make sure you have enabled the source packages in the sources list.
-      You can do this by adding the location of the source packages, including
-      URL, distribution name and component name, to ``/etc/apt/sources.list``.
-      Take Ubuntu 22.04 LTS (Jammy Jellyfish) for example::
+      Where those live depends on your release.
+
+      On **Ubuntu 24.04 and later**, and on other releases using the deb822
+      format, the sources are in ``/etc/apt/sources.list.d/ubuntu.sources``.
+      ``/etc/apt/sources.list`` is left as a stub with nothing to uncomment.
+      Add ``deb-src`` to the ``Types`` field of the entries you want sources
+      for::
+
+         $ sudo nano /etc/apt/sources.list.d/ubuntu.sources
+
+      changing::
+
+         Types: deb
+
+      to::
+
+         Types: deb deb-src
+
+      On **Ubuntu 22.04 and other releases using the one-line format**, add the
+      location of the source packages, including URL, distribution name and
+      component name, to ``/etc/apt/sources.list``. Taking Ubuntu 22.04 LTS
+      (Jammy Jellyfish) as the example::
 
          $ deb-src http://archive.ubuntu.com/ubuntu/ jammy main
 
-      Alternatively, uncomment lines with ``deb-src`` using an editor, for
+      Alternatively, uncomment the lines with ``deb-src`` using an editor, for
       example::
 
          $ sudo nano /etc/apt/sources.list


### PR DESCRIPTION
Closes #1530.

## The problem, reproduced

The Debian/Ubuntu tab tells you to enable source packages by editing `/etc/apt/sources.list`, either by adding a `deb-src` line or by uncommenting the ones already there.

On Ubuntu 24.04 that file is a four line stub, and its own comments explain why:

```
# Ubuntu sources have moved to the /etc/apt/sources.list.d/ubuntu.sources
# file, which uses the deb822 format. Use deb822-formatted .sources files
# to manage package sources in the /etc/apt/sources.list.d/ directory.
```

There is nothing to uncomment. A contributor who follows the guide as written reaches the next step and gets:

```
$ sudo apt-get build-dep python3
Reading package lists...
E: You must put some 'deb-src' URIs in your sources.list
```

Which is an unhelpful place to land on your first CPython build.

## Verification

On **Ubuntu 24.04.4 LTS**, tested in both directions:

| | |
|---|---|
| `/etc/apt/sources.list` as shipped | 4 lines, all comments, **zero** `deb-src` lines to uncomment |
| `apt-get build-dep -s python3` before the change | `E: You must put some 'deb-src' URIs in your sources.list` |
| after adding `deb-src` to `Types` in `ubuntu.sources` and `apt-get update` | resolves the full dependency set, through to `python3-sphinx` |
| host restored afterwards | `diff` against the backup is identical, and `build-dep` fails again as before |

Ubuntu's own generated `ubuntu.sources` documents the fix at line 21:

```
## Types: Append deb-src to enable the fetching of source package.
```

## What changed

The 22.04 one-line instructions are **kept, not replaced**, since releases still using that format need them. The section now branches on which format the release uses, and names the file each one actually lives in.

I have not built the docs locally to check the rendering of the nested literal blocks inside the tab, so that is worth a glance in review.
