### PR TITLE
Fix a typo in the 'Comparing changes' section

### DIFF
--- a/getting-started/git-boot-camp.rst
+++ b/getting-started/git-boot-camp.rst
@@ -265,7 +265,7 @@ To re-apply the last stashed change::
 Comparing changes
 -----------------
 
-View all non-commited changes::
+View all non-committed changes::
 
    $ git diff
 


### PR DESCRIPTION
Thanks so much Python team for everything you do!

I noticed a typo here in the devguide and so in the spirit of giving back, I am sending a PR to fix it per your instructions. (This is separate from an upcoming PR for typos I reported for docs.python.org and cannot be combined with those as this devguide is in a separate repo.)

---

On https://devguide.python.org/getting-started/git-boot-camp/ (archived as is at https://web.archive.org/web/20260821110153/https://devguide.python.org/getting-started/git-boot-camp/ )

- In the sentence
  https://github.com/python/devguide/blob/9d5e496abbe69ad47f001034998b5d3b880be668/getting-started/git-boot-camp.rst?plain=1#L268
  > View all non-commited changes:

it seems "non-commited" should be "non-committed".


<img width="1100" height="621" alt="Screenshot_20260822_174021" src="https://github.com/user-attachments/assets/55b8e52f-4d32-446a-bcb0-781cbf8ff411" />
