### PR TITLE
Add guidelines for bulk reporting of issues

### DIFF
--- a/security/policy.rst
+++ b/security/policy.rst
@@ -1,3 +1,5 @@
+.. _security-policy:
+
 ===============
 Security policy
 ===============

--- a/triage/issue-tracker.rst
+++ b/triage/issue-tracker.rst
@@ -29,6 +29,8 @@ If you would like to file an issue about this devguide, please do so in the
 :github:`devguide repository <python/devguide>` instead.
 
 
+.. _checking-if-a-bug-already-exists:
+
 Checking if a bug already exists
 --------------------------------
 
@@ -90,6 +92,25 @@ There are a number of additional fields like **Assignees**, **Labels**,
 and **Projects**. Those are filled by triagers and core team members
 and are covered in the :ref:`triaging` page. You don't need
 to worry about those when reporting issues as a Python user.
+
+
+Reporting many issues at once
+-----------------------------
+
+Static analysis, fuzzing, and similar tools can produce a large number of
+findings. If you plan to report them in bulk:
+
+* Run your analysis against the ``main`` branch, so that findings already
+  fixed in development are excluded.
+* Check each finding against existing reports, see
+  :ref:`checking-if-a-bug-already-exists` for more information.
+* Cross-check findings against the :ref:`security-policy`
+  to make sure it is not a security vulnerability. Vulnerabilities must be
+  reported privately, not on the issue tracker.
+* Rather than opening one issue per finding, open a single issue listing
+  them all, and link to the full details (reproducers, tracebacks, logs)
+  as `GitHub gists <https://gist.github.com/>`_. See :gh:`153852` for an
+  example.
 
 
 Working with issues


### PR DESCRIPTION
This came up recently when a user opened a large number of issues (>45) in an hour, as the result of LLM analysis. This wasn't ideal, and we asked them to report as a single issue, in the same style @devdanzin has been doing (and has been working well for us). As such, I propose we document this so that we can link to it if this happens again.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should describe the change to be made.

Most PRs will require an issue number. Trivial changes, like fixing a typo,
do not need an issue.
-->
